### PR TITLE
Initial Applatix integration

### DIFF
--- a/.applatix/axscm_checkout.yaml
+++ b/.applatix/axscm_checkout.yaml
@@ -1,0 +1,22 @@
+---
+type: service_template
+subtype: container
+name: axscm-checkout
+description: Checks out a source repository to /src
+container:
+  resources:
+    mem_mib: 256
+    cpu_cores: 0.1
+  image: get.applatix.io/applatix/axscm:v2.0
+  docker_options: ''
+  command: "axscm clone %%repo%% /src --commit %%commit%%"
+inputs:
+  parameters:
+    commit:
+      default: "%%session.commit%%"
+    repo:
+      default: "%%session.repo%%"
+outputs:
+  artifacts:
+    code:
+      path: "/src"

--- a/.applatix/rocksdb-build.yaml
+++ b/.applatix/rocksdb-build.yaml
@@ -1,0 +1,56 @@
+---
+type: service_template
+subtype: container
+name: rockdb-build-base
+description: This is the base template for building rockdb component.
+container:
+  resources:
+    mem_mib: 4000
+    cpu_cores: 1.5
+  image: get.applatix.io/rockdb-build:v1.1
+  docker_options: "-e CC=%%build_env_cc%% -e CXX=%%build_env_gpp%% -e JOB_NAME=%%build_env_job_name%% -e USE_AWS=%%build_env_use_aws%% -e TRAVIS_BUILD_DIR=%%build_env_travis_build_dir%% %%build_env_tests%%" 
+  command: bash -c 'cd /src/build_tools && ./ax_build.sh'
+inputs:
+  artifacts:
+  - from: "%%checkout_artifact%%"
+    path: "/src"
+  parameters:
+    checkout_artifact:
+    build_env_cc:
+    build_env_gpp:
+    build_env_job_name:
+    build_env_use_aws:
+    build_env_travis_build_dir:
+    build_env_tests:
+outputs:
+
+---
+type: service_template
+subtype: workflow
+name: rockdb-build-standalone
+description: This is the workflow for building/testing all rockdb components.
+inputs:
+  parameters:
+    commit:
+      default: "%%session.commit%%"
+    repo:
+      default: "%%session.repo%%"
+    build_env_cc:
+      default: '/usr/bin/gcc'
+    build_env_gpp:
+      default: '/usr/bin/g++'
+    build_env_job_name:
+      default: 'unittests'
+    build_env_use_aws:
+      default: '1'
+    build_env_travis_build_dir:
+      default: '/src'
+
+steps:
+  - checkout:
+      template: axscm-checkout
+  - rockdb-build:
+      template: rockdb-build-base
+      parameters:
+        checkout_artifact: "%%steps.checkout.code%%"
+        build_env_tests: $$[-e ROCKSDBTESTS_END=db_block_cache_test, -e ROCKSDBTESTS_START=db_block_cache_test -e ROCKSDBTESTS_END=comparator_db_test, -e ROCKSDBTESTS_START=comparator_db_test]$$

--- a/build_tools/ax_build.sh
+++ b/build_tools/ax_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e -x
+
+ulimit -n 8192 || true
+cd ..
+if [[ "${JOB_NAME}" == 'unittests' ]]; then OPT=-DTRAVIS V=1 make -j4 check_some; fi
+if [[ "${JOB_NAME}" == 'java_test' ]]; then OPT=-DTRAVIS V=1 make clean jclean rocksdbjava jtest; fi
+if [[ "${JOB_NAME}" == 'lite_build' ]]; then OPT="-DTRAVIS -DROCKSDB_LITE" V=1 make -j4 static_lib; fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:trusty
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN apt-get install -y software-properties-common 
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get install -y wget
+RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+RUN apt-add-repository -y "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.6 main"
+RUN apt-get update -y
+RUN apt-get install -y clang-3.6 curl g++-6 libbz2-dev libcurl4-openssl-dev libgflags-dev libsnappy-dev zlib1g-dev
+RUN apt-get install -y git
+ENV CXX /usr/bin/g++-6
+ENV CC /usr/bin/gcc-6
+RUN mkdir -p /ax-install/cmake
+RUN mkdir -p /ax-install/aws-install
+WORKDIR /ax-install/cmake
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2.tar.gz && tar xzvf cmake-3.7.2.tar.gz
+WORKDIR /ax-install/cmake/cmake-3.7.2/
+RUN ./bootstrap && make -j 8 && make install
+WORKDIR /ax-install
+RUN git clone https://github.com/aws/aws-sdk-cpp.git
+WORKDIR /ax-install/aws-install
+RUN cmake -DCMAKE_BUILD_TYPE=Release '-DBUILD_ONLY=s3;kinesis' ../aws-sdk-cpp/
+RUN make -j 8 && make install
+RUN ldconfig
+WORKDIR /
+


### PR DESCRIPTION
As discussed with Dhruba, this is to configure automated builds with Applatix (in addition to Travis).

- add docker/Dockerfile to build docker image used in Applatix environment.
- add build_tools/ax_build.sh to be triggered by Applatix workflow rocksdb-build.yaml
   This script is pretty primitive for now.
- add .applatix/rocksdb-build.yaml that specifies the Applatix build/test workflow
   This workflow is just one sample Applatix workflow.
- add .applatix/axscm_checkout.yaml which is a utility yaml used in Applatix build/test workflow to checkout source tree