### PR TITLE
Implement CloudEnvImpl::GetThreadList which redirects the call base_env_

### DIFF
--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -93,6 +93,10 @@ class CloudEnvImpl : public CloudEnv {
   void TEST_InitEmptyCloudManifest();
   void TEST_DisableCloudManifest() { test_disable_cloud_manifest_ = true; }
 
+  Status GetThreadList(std::vector<ThreadStatus>* thread_list) override {
+    return base_env_->GetThreadList(thread_list);
+  }
+
  protected:
   // The type of cloud service e.g. AWS, Azure, Google,  etc.
   const CloudType cloud_type_;


### PR DESCRIPTION
Without it, CloudEnvImpl uses Env::GetThreadList(), which returns Status::NotSupported.