### PR TITLE
Show in the cloud examples how to use bucket other than with prefix "rockset."

### DIFF
--- a/cloud/examples/clone_example.cc
+++ b/cloud/examples/clone_example.cc
@@ -64,9 +64,8 @@ Status CloneDB(const std::string& clone_name, const std::string& src_bucket,
   // No persistent cache
   std::string persistent_cache = "";
 
-  const std::string bucketPrefix = "rockset.";
   // create a bucket name for debugging purposes
-  const std::string bucketName = bucketPrefix + kBucketSuffix;
+  const std::string bucketName = cloud_env->get()->GetSrcBucketName();
 
   // open clone
   DBCloud* db;

--- a/cloud/examples/clone_example.cc
+++ b/cloud/examples/clone_example.cc
@@ -64,8 +64,9 @@ Status CloneDB(const std::string& clone_name, const std::string& src_bucket,
   // No persistent cache
   std::string persistent_cache = "";
 
+  const std::string bucketPrefix = "rockset.";
   // create a bucket name for debugging purposes
-  const std::string bucketName = "rockset." + kBucketSuffix;
+  const std::string bucketName = bucketPrefix + kBucketSuffix;
 
   // open clone
   DBCloud* db;
@@ -102,9 +103,14 @@ int main() {
   char* user = getenv("USER");
   kBucketSuffix.append(user);
 
+  const std::string bucketPrefix = "rockset.";
   // create a bucket name for debugging purposes
-  const std::string bucketName = "rockset." + kBucketSuffix;
+  const std::string bucketName = bucketPrefix + kBucketSuffix;
 
+  // Needed if using bucket prefix other than the default "rockset."
+  cloud_env_options.src_bucket.SetBucketName(kBucketSuffix,bucketPrefix);
+  cloud_env_options.dest_bucket.SetBucketName(kBucketSuffix,bucketPrefix);
+  
   // Create a new AWS cloud env Status
   CloudEnv* cenv;
   Status s =

--- a/cloud/examples/cloud_dump.cc
+++ b/cloud/examples/cloud_dump.cc
@@ -42,8 +42,13 @@ int main() {
   char* user = getenv("USER");
   kBucketSuffix.append(user);
 
+  // "rockset." is the default bucket prefix
+  const std::string bucketPrefix = "rockset.";
+  cloud_env_options.src_bucket.SetBucketName(kBucketSuffix,bucketPrefix);
+  cloud_env_options.dest_bucket.SetBucketName(kBucketSuffix,bucketPrefix);
+  
   // create a bucket name for debugging purposes
-  const std::string bucketName = "rockset." + kBucketSuffix;
+  const std::string bucketName = bucketPrefix + kBucketSuffix;
 
   // Create a new AWS cloud env Status
   CloudEnv* cenv;

--- a/cloud/examples/cloud_durable_example.cc
+++ b/cloud/examples/cloud_durable_example.cc
@@ -45,9 +45,14 @@ int main() {
   char* user = getenv("USER");
   kBucketSuffix.append(user);
 
-  // create a bucket name for debugging purposes
-  const std::string bucketName = "rockset." + kBucketSuffix;
+  // "rockset." is the default bucket prefix
+  const std::string bucketPrefix = "rockset.";
+  cloud_env_options.src_bucket.SetBucketName(kBucketSuffix,bucketPrefix);
+  cloud_env_options.dest_bucket.SetBucketName(kBucketSuffix,bucketPrefix);
 
+  // create a bucket name for debugging purposes
+  const std::string bucketName = bucketPrefix + kBucketSuffix;
+  
   // Create a new AWS cloud env Status
   CloudEnv* cenv;
   Status s =


### PR DESCRIPTION
Hello and thank you for RocksDB-Cloud,
 
These are changes I needed to make to get the cloud examples more easily working with an AWS S3 bucket that did not start with the default bucket prefix "rockset.".

I thought they might be useful for anyone else wanting to try them out on a bucket not starting with "rockset.".