### PR TITLE
Fix assert/data corruption when using persistent cache

### DIFF
--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -156,7 +156,7 @@ size_t S3ReadableFile::GetUniqueId(char* id, size_t max_size) const {
   WalFileType log_type;
   ParseFileName(RemoveEpoch(basename(fname_)), &file_number, &file_type,
                 &log_type);
-  if (max_size < kMaxVarint64Length && file_number > 0) {
+  if (max_size >= kMaxVarint64Length && file_number > 0) {
     char* rid = id;
     rid = EncodeVarint64(rid, file_number);
     return static_cast<size_t>(rid - id);


### PR DESCRIPTION
Fix issue https://github.com/rockset/rocksdb-cloud/issues/73
Code in S3ReadableFile::GetUniqueId() is wrong, instead of
  if (max_size < kMaxVarint64Length && file_number > 0)
it should be
  if (max_size >= kMaxVarint64Length && file_number > 0) {

Tesging done:
Works in my local build - no more asserts in debug build.