### PR TITLE
Separate out the configuration from initialization and construction

### DIFF
--- a/cloud/aws/aws_env.cc
+++ b/cloud/aws/aws_env.cc
@@ -76,7 +76,7 @@ Status AwsCloudAccessCredentials::TEST_Initialize() {
 Status AwsCloudAccessCredentials::CheckCredentials(
     const AwsAccessType& aws_type) const {
 #ifndef USE_AWS
-  (void) aws_type;
+  (void)aws_type;
   return Status::NotSupported("AWS not supported");
 #else
   if (aws_type == AwsAccessType::kSimple) {

--- a/cloud/aws/aws_env.cc
+++ b/cloud/aws/aws_env.cc
@@ -76,6 +76,7 @@ Status AwsCloudAccessCredentials::TEST_Initialize() {
 Status AwsCloudAccessCredentials::CheckCredentials(
     const AwsAccessType& aws_type) const {
 #ifndef USE_AWS
+  (void) aws_type;
   return Status::NotSupported("AWS not supported");
 #else
   if (aws_type == AwsAccessType::kSimple) {
@@ -287,139 +288,7 @@ AwsEnv::AwsEnv(Env* underlying_env, const CloudEnvOptions& _cloud_env_options,
       cloud_env_options.dest_bucket.SetRegion(region);
     }
   }
-
-  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> creds;
-  create_bucket_status_ =
-      cloud_env_options.credentials.GetCredentialsProvider(&creds);
-  if (!create_bucket_status_.ok()) {
-    Log(InfoLogLevel::INFO_LEVEL, info_log,
-        "[aws] NewAwsEnv - Bad AWS credentials");
-  }
-
-  Header(info_log_, "      AwsEnv.src_bucket_name: %s",
-         cloud_env_options.src_bucket.GetBucketName().c_str());
-  Header(info_log_, "      AwsEnv.src_object_path: %s",
-         cloud_env_options.src_bucket.GetObjectPath().c_str());
-  Header(info_log_, "      AwsEnv.src_bucket_region: %s",
-         cloud_env_options.src_bucket.GetRegion().c_str());
-  Header(info_log_, "     AwsEnv.dest_bucket_name: %s",
-         cloud_env_options.dest_bucket.GetBucketName().c_str());
-  Header(info_log_, "     AwsEnv.dest_object_path: %s",
-         cloud_env_options.dest_bucket.GetObjectPath().c_str());
-  Header(info_log_, "     AwsEnv.dest_bucket_region: %s",
-         cloud_env_options.dest_bucket.GetRegion().c_str());
-  Header(info_log_, "            AwsEnv.credentials: %s",
-         creds ? "[given]" : "[not given]");
-
   base_env_ = underlying_env;
-
-  // TODO: support buckets being in different regions
-  if (!SrcMatchesDest() && HasSrcBucket() && HasDestBucket()) {
-    if (cloud_env_options.src_bucket.GetRegion() == cloud_env_options.dest_bucket.GetRegion()) {
-      // alls good
-    } else {
-      create_bucket_status_ =
-          Status::InvalidArgument("Two different regions not supported");
-      Log(InfoLogLevel::ERROR_LEVEL, info_log,
-          "[aws] NewAwsEnv Buckets %s, %s in two different regions %s, %s "
-          "is not supported",
-          cloud_env_options.src_bucket.GetBucketName().c_str(),
-          cloud_env_options.dest_bucket.GetBucketName().c_str(),
-          cloud_env_options.src_bucket.GetRegion().c_str(),
-          cloud_env_options.dest_bucket.GetRegion().c_str());
-      return;
-    }
-  }
-  // create AWS S3 client with appropriate timeouts
-  Aws::Client::ClientConfiguration config;
-  create_bucket_status_ =
-    AwsCloudOptions::GetClientConfiguration(this,
-                                            cloud_env_options.src_bucket.GetRegion(),
-                                            &config);
-  if (create_bucket_status_.ok()) {
-    create_bucket_status_ = CloudStorageProviderImpl::CreateS3Provider(
-        &cloud_env_options.storage_provider);
-    if (create_bucket_status_.ok()) {
-      create_bucket_status_ = cloud_env_options.storage_provider->Prepare(this);
-    }
-  }
-  if (!create_bucket_status_.ok()) {
-    return;
-  }
-
-  Header(info_log_, "AwsEnv connection to endpoint in region: %s",
-         config.region.c_str());
-
-  // create dest bucket if specified
-  if (HasDestBucket()) {
-    if (cloud_env_options.storage_provider->ExistsBucket(GetDestBucketName())
-            .ok()) {
-      Log(InfoLogLevel::INFO_LEVEL, info_log,
-          "[aws] NewAwsEnv Bucket %s already exists",
-          GetDestBucketName().c_str());
-    } else if (cloud_env_options.create_bucket_if_missing) {
-      Log(InfoLogLevel::INFO_LEVEL, info_log,
-          "[aws] NewAwsEnv Going to create bucket %s",
-          GetDestBucketName().c_str());
-      create_bucket_status_ =
-          cloud_env_options.storage_provider->CreateBucket(GetDestBucketName());
-    } else {
-      create_bucket_status_ = Status::NotFound(
-          "[aws] Bucket not found and create_bucket_if_missing is false");
-    }
-  }
-  if (!create_bucket_status_.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, info_log,
-        "[aws] NewAwsEnv Unable to create bucket %s %s",
-        GetDestBucketName().c_str(),
-        create_bucket_status_.ToString().c_str());
-  }
-
-  // create cloud log client for storing/reading logs
-  if (create_bucket_status_.ok() && !cloud_env_options.keep_local_log_files) {
-    if (cloud_env_options.log_type == kLogKinesis) {
-      create_bucket_status_ = CloudLogControllerImpl::CreateKinesisController(
-          this, &cloud_env_options.cloud_log_controller);
-    } else if (cloud_env_options.log_type == kLogKafka) {
-#ifdef USE_KAFKA
-      create_bucket_status_ = CloudLogControllerImpl::CreateKafkaController(
-          this, &cloud_env_options.cloud_log_controller);
-#else
-      create_bucket_status_ = Status::NotSupported(
-          "In order to use Kafka, make sure you're compiling with "
-          "USE_KAFKA=1");
-
-      Log(InfoLogLevel::ERROR_LEVEL, info_log,
-          "[aws] NewAwsEnv Unknown log type %d. %s",
-          cloud_env_options.log_type,
-          create_bucket_status_.ToString().c_str());
-#endif /* USE_KAFKA */
-    } else {
-      create_bucket_status_ =
-          Status::NotSupported("We currently only support Kinesis and Kafka");
-
-      Log(InfoLogLevel::ERROR_LEVEL, info_log,
-          "[aws] NewAwsEnv Unknown log type %d. %s", cloud_env_options.log_type,
-          create_bucket_status_.ToString().c_str());
-    }
-
-    // Create Kinesis stream and wait for it to be ready
-    if (create_bucket_status_.ok()) {
-      create_bucket_status_ =
-          cloud_env_options.cloud_log_controller->StartTailingStream(
-              GetSrcBucketName());
-      if (!create_bucket_status_.ok()) {
-        Log(InfoLogLevel::ERROR_LEVEL, info_log,
-            "[aws] NewAwsEnv Unable to create stream %s",
-            create_bucket_status_.ToString().c_str());
-      }
-    }
-  }
-  if (!create_bucket_status_.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, info_log,
-        "[aws] NewAwsEnv Unable to create environment %s",
-        create_bucket_status_.ToString().c_str());
-  }
 }
 
 AwsEnv::~AwsEnv() {
@@ -866,11 +735,6 @@ void AwsEnv::RemoveFileFromDeletionQueue(const std::string& filename) {
     GetJobExecutor()->CancelJob(itr->second.get());
     files_to_delete_.erase(itr);
   }
-}
-
-Status AwsEnv::TEST_DeletePathInS3(const std::string& bucket,
-                                   const std::string& fname) {
-  return cloud_env_options.storage_provider->DeleteObject(bucket, fname);
 }
 
 Status AwsEnv::DeleteFile(const std::string& logical_fname) {
@@ -1358,10 +1222,35 @@ Status AwsEnv::NewAwsEnv(Env* base_env,
   if (!base_env) {
     base_env = Env::Default();
   }
-  std::unique_ptr<AwsEnv> aenv(new AwsEnv(base_env, cloud_options, info_log));
-  if (!aenv->status().ok()) {
-    status = aenv->status();
-  } else {
+  // These lines of code are likely temporary until the new configuration stuff
+  // comes into play.
+  CloudEnvOptions options = cloud_options;  // Make a copy
+  status =
+      CloudStorageProviderImpl::CreateS3Provider(&options.storage_provider);
+  if (status.ok() && !cloud_options.keep_local_log_files) {
+    if (cloud_options.log_type == kLogKinesis) {
+      status = CloudLogControllerImpl::CreateKinesisController(
+          &options.cloud_log_controller);
+    } else if (cloud_options.log_type == kLogKafka) {
+      status = CloudLogControllerImpl::CreateKafkaController(
+          &options.cloud_log_controller);
+    } else {
+      status =
+          Status::NotSupported("We currently only support Kinesis and Kafka");
+      Log(InfoLogLevel::ERROR_LEVEL, info_log,
+          "[aws] NewAwsEnv Unknown log type %d. %s", cloud_options.log_type,
+          status.ToString().c_str());
+    }
+  }
+  if (!status.ok()) {
+    Log(InfoLogLevel::ERROR_LEVEL, info_log,
+        "[aws] NewAwsEnv Unable to create environment %s",
+        status.ToString().c_str());
+    return status;
+  }
+  std::unique_ptr<AwsEnv> aenv(new AwsEnv(base_env, options, info_log));
+  status = aenv->Prepare();
+  if (status.ok()) {
     *cenv = aenv.release();
   }
   return status;

--- a/cloud/aws/aws_env.h
+++ b/cloud/aws/aws_env.h
@@ -215,9 +215,6 @@ class AwsEnv : public CloudEnvImpl {
     file_deletion_delay_ = delay;
   }
 
-  Status TEST_DeletePathInS3(const std::string& bucket,
-                             const std::string& fname);
-
  private:
   //
   // The AWS credentials are specified to the constructor via

--- a/cloud/aws/aws_kafka.cc
+++ b/cloud/aws/aws_kafka.cc
@@ -203,8 +203,6 @@ class KafkaController : public CloudLogControllerImpl {
   virtual CloudLogWritableFile* CreateWritableFile(const std::string& fname,
                                                    const EnvOptions& options) override;
 
-  Status Verify() const override;
-
  protected:
   Status Initialize(CloudEnv* env) override;
 
@@ -240,12 +238,11 @@ Status KafkaController::Initialize(CloudEnv* env) {
   for (auto const& item : kconf) {
     if (conf->set(item.first, item.second, conf_errstr) !=
         RdKafka::Conf::CONF_OK) {
-      s = Status::InvalidArgument(
-          "Failed adding specified conf to Kafka conf", conf_errstr.c_str());
+      s = Status::InvalidArgument("Failed adding specified conf to Kafka conf",
+                                  conf_errstr.c_str());
 
       Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
-          "[aws] NewAwsEnv Kafka conf set error: %s",
-          s.ToString().c_str());
+          "[aws] NewAwsEnv Kafka conf set error: %s", s.ToString().c_str());
       return s;
     }
   }
@@ -284,24 +281,6 @@ Status KafkaController::Initialize(CloudEnv* env) {
     assert(producer_topic_ != nullptr);
     assert(consumer_topic_ != nullptr);
     assert(consuming_queue_ != nullptr);
-  }
-  return s;
-}
-
-Status KafkaController::Verify() const {
-  Status s = CloudLogControllerImpl::Verify();
-  if (s.ok()) {
-    if (!producer_) {
-      s = Status::InvalidArgument("Failed creating Kafka producer");
-    } else if (!consumer_) {
-      s = Status::InvalidArgument("Failed creating Kafka consumer");
-    } else if (producer_topic_ == nullptr) {
-      s = Status::InvalidArgument("Failed to initialize Kafa Producer Topic");
-    } else if (consumer_topic_ == nullptr) {
-      s = Status::InvalidArgument("Failed to initialize Kafa Consumer Topic");
-    } else if (consuming_queue_ == nullptr) {
-      s = Status::InvalidArgument("Failed to initialize Kafa Consuming Queue");
-    }
   }
   return s;
 }

--- a/cloud/aws/aws_kafka.cc
+++ b/cloud/aws/aws_kafka.cc
@@ -175,37 +175,6 @@ Status KafkaWritableFile::LogDelete() {
 //
 class KafkaController : public CloudLogControllerImpl {
  public:
-  KafkaController(CloudEnv* env, std::unique_ptr<RdKafka::Producer> producer,
-                  std::unique_ptr<RdKafka::Consumer> consumer)
-      : CloudLogControllerImpl(env),
-        producer_(std::move(producer)),
-        consumer_(std::move(consumer)) {
-    const std::string topic_name = env_->GetSrcBucketName();
-    
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
-        "[%s] KafkaController opening stream %s using cachedir '%s'",
-        Name(), topic_name.c_str(), cache_dir_.c_str());
-    
-    std::string pt_errstr, ct_errstr;
-    
-    // Initialize stream name.
-    RdKafka::Topic* producer_topic =
-      RdKafka::Topic::create(producer_.get(), topic_name, NULL, pt_errstr);
-    
-    RdKafka::Topic* consumer_topic =
-      RdKafka::Topic::create(consumer_.get(), topic_name, NULL, ct_errstr);
-    
-    RdKafka::Queue* consuming_queue = RdKafka::Queue::create(consumer_.get());
-    
-    assert(producer_topic != nullptr);
-    assert(consumer_topic != nullptr);
-    assert(consuming_queue != nullptr);
-    
-    consuming_queue_.reset(consuming_queue);
-    
-    producer_topic_.reset(producer_topic);
-    consumer_topic_.reset(consumer_topic);
-  }
 
   ~KafkaController() {
     for (size_t i = 0; i < partitions_.size(); i++) {
@@ -234,6 +203,11 @@ class KafkaController : public CloudLogControllerImpl {
   virtual CloudLogWritableFile* CreateWritableFile(const std::string& fname,
                                                    const EnvOptions& options) override;
 
+  Status Verify() const override;
+
+ protected:
+  Status Initialize(CloudEnv* env) override;
+
  private:
   Status InitializePartitions();
 
@@ -247,6 +221,90 @@ class KafkaController : public CloudLogControllerImpl {
 
   std::vector<std::shared_ptr<RdKafka::TopicPartition>> partitions_;
 };
+
+Status KafkaController::Initialize(CloudEnv* env) {
+  Status s = CloudLogControllerImpl::Initialize(env);
+  if (!s.ok()) {
+    return s;
+  }
+  std::string conf_errstr, producer_errstr, consumer_errstr;
+  const auto& kconf =
+      env->GetCloudEnvOptions().kafka_log_options.client_config_params;
+  if (kconf.empty()) {
+    return Status::InvalidArgument("No configs specified to kafka client");
+  }
+
+  std::unique_ptr<RdKafka::Conf> conf(
+      RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
+
+  for (auto const& item : kconf) {
+    if (conf->set(item.first, item.second, conf_errstr) !=
+        RdKafka::Conf::CONF_OK) {
+      s = Status::InvalidArgument(
+          "Failed adding specified conf to Kafka conf", conf_errstr.c_str());
+
+      Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
+          "[aws] NewAwsEnv Kafka conf set error: %s",
+          s.ToString().c_str());
+      return s;
+    }
+  }
+
+  producer_.reset(RdKafka::Producer::create(conf.get(), producer_errstr));
+  consumer_.reset(RdKafka::Consumer::create(conf.get(), consumer_errstr));
+
+  if (!producer_) {
+    s = Status::InvalidArgument("Failed creating Kafka producer",
+                                producer_errstr.c_str());
+
+    Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
+        "[%s] Kafka producer error: %s", Name(), s.ToString().c_str());
+  } else if (!consumer_) {
+    s = Status::InvalidArgument("Failed creating Kafka consumer",
+                                consumer_errstr.c_str());
+
+    Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
+        "[%s] Kafka consumer error: %s", Name(), s.ToString().c_str());
+  } else {
+    const std::string topic_name = env->GetSrcBucketName();
+
+    Log(InfoLogLevel::DEBUG_LEVEL, env->info_log_,
+        "[%s] KafkaController opening stream %s using cachedir '%s'", Name(),
+        topic_name.c_str(), cache_dir_.c_str());
+
+    std::string pt_errstr, ct_errstr;
+
+    // Initialize stream name.
+    consuming_queue_.reset(RdKafka::Queue::create(consumer_.get()));
+    producer_topic_.reset(
+        RdKafka::Topic::create(producer_.get(), topic_name, NULL, pt_errstr));
+    consumer_topic_.reset(
+        RdKafka::Topic::create(consumer_.get(), topic_name, NULL, ct_errstr));
+
+    assert(producer_topic_ != nullptr);
+    assert(consumer_topic_ != nullptr);
+    assert(consuming_queue_ != nullptr);
+  }
+  return s;
+}
+
+Status KafkaController::Verify() const {
+  Status s = CloudLogControllerImpl::Verify();
+  if (s.ok()) {
+    if (!producer_) {
+      s = Status::InvalidArgument("Failed creating Kafka producer");
+    } else if (!consumer_) {
+      s = Status::InvalidArgument("Failed creating Kafka consumer");
+    } else if (producer_topic_ == nullptr) {
+      s = Status::InvalidArgument("Failed to initialize Kafa Producer Topic");
+    } else if (consumer_topic_ == nullptr) {
+      s = Status::InvalidArgument("Failed to initialize Kafa Consumer Topic");
+    } else if (consuming_queue_ == nullptr) {
+      s = Status::InvalidArgument("Failed to initialize Kafa Consuming Queue");
+    }
+  }
+  return s;
+}
 
 Status KafkaController::TailStream() {
   InitializePartitions();
@@ -391,71 +449,15 @@ CloudLogWritableFile* KafkaController::CreateWritableFile(
 #endif /* USE_KAFKA */
 
 namespace rocksdb {
-#ifndef USE_KAFKA
 Status CloudLogControllerImpl::CreateKafkaController(
-    CloudEnv*, std::shared_ptr<CloudLogController>*) {
+    std::shared_ptr<CloudLogController>* output) {
+#ifndef USE_KAFKA
+  output->reset();
   return Status::NotSupported("In order to use Kafka, make sure you're compiling with "
                               "USE_KAFKA=1");
-}
 #else
-Status CloudLogControllerImpl::CreateKafkaController(
-    CloudEnv* env, std::shared_ptr<CloudLogController>* output) {
-  Status st = Status::OK();
-  std::string conf_errstr, producer_errstr, consumer_errstr;
-  const auto& kconf = env->GetCloudEnvOptions().kafka_log_options.client_config_params;
-
-  std::unique_ptr<RdKafka::Conf> conf(
-      RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
-
-  if (kconf.empty()) {
-    st = Status::InvalidArgument("No configs specified to kafka client");
-
-    return st;
-  }
-
-  for (auto const& item : kconf) {
-    if (conf->set(item.first,
-                  item.second,
-                  conf_errstr) != RdKafka::Conf::CONF_OK) {
-      st = Status::InvalidArgument("Failed adding specified conf to Kafka conf",
-                                   conf_errstr.c_str());
-
-      Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
-          "[aws] NewAwsEnv Kafka conf set error: %s", st.ToString().c_str());
-      return st;
-    }
-  }
-
-  {
-    std::unique_ptr<RdKafka::Producer> producer(
-        RdKafka::Producer::create(conf.get(), producer_errstr));
-    std::unique_ptr<RdKafka::Consumer> consumer(
-        RdKafka::Consumer::create(conf.get(), consumer_errstr));
-
-    if (!producer) {
-      st = Status::InvalidArgument("Failed creating Kafka producer",
-                                   producer_errstr.c_str());
-
-      Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
-          "[aws] NewAwsEnv Kafka producer error: %s", st.ToString().c_str());
-    } else if (!consumer) {
-      st = Status::InvalidArgument("Failed creating Kafka consumer",
-                                   consumer_errstr.c_str());
-
-      Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
-          "[aws] NewAwsEnv Kafka consumer error: %s", st.ToString().c_str());
-    } else {
-      output->reset(new rocksdb::cloud::kafka::KafkaController(env, 
-                                                               std::move(producer),
-                                                               std::move(consumer)));
-      
-      if (output->get() == nullptr) {
-        st = Status::IOError("Error in creating Kafka controller");
-      }
-    }
-  }
-  return st;
-}
+  output->reset(new rocksdb::cloud::kafka::KafkaController());
+  return Status::OK();
 #endif // USE_KAFKA
+}
 }  // namespace rocksdb
-

--- a/cloud/aws/aws_kinesis.cc
+++ b/cloud/aws/aws_kinesis.cc
@@ -176,23 +176,6 @@ Status KinesisWritableFile::LogDelete() {
 //
 class KinesisController : public CloudLogControllerImpl {
  public:
-  KinesisController(
-      CloudEnv* env,
-      const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& provider,
-      const Aws::Client::ClientConfiguration& config)
-      : CloudLogControllerImpl(env) {
-    kinesis_client_.reset(provider
-                          ? new Aws::Kinesis::KinesisClient(provider, config)
-                          : new Aws::Kinesis::KinesisClient(config));
-    // Initialize stream name.
-    std::string bucket = env_->GetSrcBucketName();
-    topic_ = Aws::String(bucket.c_str(), bucket.size());
-    
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
-        "[%s] KinesisController opening stream %s using cachedir '%s'",
-        Name(), topic_.c_str(), cache_dir_.c_str());
-  }
-
   virtual ~KinesisController() {
       Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
       "[%s] KinesisController closed", Name());
@@ -206,6 +189,11 @@ class KinesisController : public CloudLogControllerImpl {
 
   CloudLogWritableFile* CreateWritableFile(const std::string& fname,
                                            const EnvOptions& options) override;
+  Status Verify() const override;
+
+ protected:
+  Status Initialize(CloudEnv* env) override;
+
  private:
   std::shared_ptr<Aws::Kinesis::KinesisClient> kinesis_client_;
   
@@ -222,6 +210,43 @@ class KinesisController : public CloudLogControllerImpl {
   // shards_position_.
   void SeekShards();
 };
+
+Status KinesisController::Initialize(CloudEnv* env) {
+  Status status = CloudLogControllerImpl::Initialize(env);
+  if (status.ok()) {
+    Aws::Client::ClientConfiguration config;
+    const auto& options = env->GetCloudEnvOptions();
+    std::shared_ptr<Aws::Auth::AWSCredentialsProvider> provider;
+    status = options.credentials.GetCredentialsProvider(&provider);
+    if (status.ok()) {
+      status = AwsCloudOptions::GetClientConfiguration(
+          env, options.src_bucket.GetRegion(), &config);
+    }
+    if (status.ok()) {
+      kinesis_client_.reset(
+          provider ? new Aws::Kinesis::KinesisClient(provider, config)
+                   : new Aws::Kinesis::KinesisClient(config));
+      // Initialize stream name.
+      std::string bucket = env->GetSrcBucketName();
+      topic_ = Aws::String(bucket.c_str(), bucket.size());
+
+      Log(InfoLogLevel::DEBUG_LEVEL, env->info_log_,
+          "[%s] KinesisController opening stream %s using cachedir '%s'",
+          Name(), topic_.c_str(), cache_dir_.c_str());
+    }
+  }
+  return status;
+}
+
+Status KinesisController::Verify() const {
+  Status s = CloudLogControllerImpl::Verify();
+  if (s.ok()) {
+    if (!kinesis_client_) {
+      s = Status::InvalidArgument("Failed to initialize kinesis client");
+    }
+  }
+  return s;
+}
 
 Status KinesisController::TailStream() {
   status_ = InitializeShards();
@@ -453,27 +478,15 @@ CloudLogWritableFile* KinesisController::CreateWritableFile(
 #endif /* USE_AWS */
 
 namespace rocksdb {
-#ifndef USE_AWS
 Status CloudLogControllerImpl::CreateKinesisController(
-    CloudEnv*, std::shared_ptr<CloudLogController>*) {
+    std::shared_ptr<CloudLogController>* output) {
+#ifndef USE_AWS
+  output->reset();
   return Status::NotSupported("In order to use Kinesis, make sure you're compiling with "
                               "USE_AWS=1");
-}
 #else
-Status CloudLogControllerImpl::CreateKinesisController(
-    CloudEnv *env, std::shared_ptr<CloudLogController> *output) {
-  Aws::Client::ClientConfiguration config;
-  const auto & options = env->GetCloudEnvOptions();
-  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> provider;
-  Status st = options.credentials.GetCredentialsProvider(&provider);
-  if (st.ok()) {
-    st = AwsCloudOptions::GetClientConfiguration(env,
-                                                 options.src_bucket.GetRegion(), &config);
-  }
-  if (st.ok()) {
-    output->reset(new rocksdb::cloud::kinesis::KinesisController(env, provider, config));
-  }
-  return st;
-}
+  output->reset(new rocksdb::cloud::kinesis::KinesisController());
+  return Status::OK();
 #endif /* USE_AWS */
+}
 } // namespace rocksdb

--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -33,6 +33,7 @@
 #include <aws/s3/model/PutObjectResult.h>
 #include <aws/s3/model/ServerSideEncryption.h>
 #include <aws/transfer/TransferManager.h>
+#endif // USE_AWS
 
 #include <cassert>
 #include <cinttypes>
@@ -51,6 +52,7 @@
 #include "util/string_util.h"
 
 namespace rocksdb {
+#ifdef USE_AWS
 class CloudRequestCallbackGuard {
  public:
   CloudRequestCallbackGuard(CloudRequestCallback* callback,
@@ -870,11 +872,9 @@ Status S3StorageProvider::DoPutObject(const std::string& local_file,
       object_path.c_str(), file_size);
   return Status::OK();
 }
-}  // namespace
 
 #endif /* USE_AWS */
 
-namespace rocksdb {
 Status CloudStorageProviderImpl::CreateS3Provider(
     std::shared_ptr<CloudStorageProvider>* provider) {
 #ifndef USE_AWS

--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -33,7 +33,7 @@
 #include <aws/s3/model/PutObjectResult.h>
 #include <aws/s3/model/ServerSideEncryption.h>
 #include <aws/transfer/TransferManager.h>
-#endif // USE_AWS
+#endif  // USE_AWS
 
 #include <cassert>
 #include <cinttypes>
@@ -389,8 +389,6 @@ class S3StorageProvider : public CloudStorageProviderImpl {
                               const std::string& object_path,
                               std::unique_ptr<CloudStorageWritableFile>* result,
                               const EnvOptions& options) override;
-  Status Verify() const override;
-
  protected:
   Status Initialize(CloudEnv* env) override;
   Status DoGetObject(const std::string& bucket_name,
@@ -449,16 +447,6 @@ Status S3StorageProvider::Initialize(CloudEnv* env) {
     }
   }
   return status;
-}
-
-Status S3StorageProvider::Verify() const {
-  Status s = CloudStorageProviderImpl::Verify();
-  if (s.ok()) {
-    if (!s3client_) {
-      s = Status::InvalidArgument("S3Client Failed to initialize");
-    }
-  }
-  return s;
 }
 
 //

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -999,24 +999,6 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
   return Status::OK();
 }
 
-Status CloudEnvImpl::Verify() const {
-  Status s;
-  if (!cloud_env_options.storage_provider) {
-    s = Status::InvalidArgument(
-        "Cloud environment requires a storage provider");
-  } else {
-    s = cloud_env_options.storage_provider->Verify();
-  }
-  if (s.ok()) {
-    if (cloud_env_options.cloud_log_controller) {
-      s = cloud_env_options.cloud_log_controller->Verify();
-    } else if (!cloud_env_options.keep_local_log_files) {
-      s = Status::InvalidArgument(
-          "Log controller required for remote log files");
-    }
-  }
-  return s;
-}
 Status CloudEnvImpl::Prepare() {
   Header(info_log_, "     %s.src_bucket_name: %s", Name(),
          cloud_env_options.src_bucket.GetBucketName().c_str());

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -106,7 +106,6 @@ class CloudEnvImpl : public CloudEnv {
 
  protected:
   virtual Status Prepare();
-  virtual Status Verify() const;
 
   // Does the dir need to be re-initialized?
   Status NeedsReinitialization(const std::string& clone_dir, bool* do_reinit);

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -105,6 +105,9 @@ class CloudEnvImpl : public CloudEnv {
   }
 
  protected:
+  virtual Status Prepare();
+  virtual Status Verify() const;
+
   // Does the dir need to be re-initialized?
   Status NeedsReinitialization(const std::string& clone_dir, bool* do_reinit);
 

--- a/cloud/cloud_log_controller.cc
+++ b/cloud/cloud_log_controller.cc
@@ -76,15 +76,6 @@ Status CloudLogControllerImpl::Prepare(CloudEnv* env) {
   return status_;
 }
 
-Status CloudLogControllerImpl::Verify() const {
-  if (!status_.ok()) {
-    return status_;
-  } else if (!env_) {
-    return Status::InvalidArgument("Log Controller not initialized: ", Name());
-  }
-  return status_;
-}
-
 std::string CloudLogControllerImpl::GetCachePath(
     const Slice& original_pathname) const {
   const std::string & cache_dir = GetCacheDir();

--- a/cloud/cloud_log_controller.cc
+++ b/cloud/cloud_log_controller.cc
@@ -54,14 +54,14 @@ Status CloudLogControllerImpl::Initialize(CloudEnv* env) {
   cache_dir_ = bucket_dir + pathsep + uid;
 
   // Create temporary directories.
-  Status status = env_->GetBaseEnv()->CreateDirIfMissing(kCacheDir);
-  if (status.ok()) {
-    status = env_->GetBaseEnv()->CreateDirIfMissing(bucket_dir);
+  Status st = env_->GetBaseEnv()->CreateDirIfMissing(kCacheDir);
+  if (st.ok()) {
+    st = env_->GetBaseEnv()->CreateDirIfMissing(bucket_dir);
   }
-  if (status.ok()) {
-    status = env_->GetBaseEnv()->CreateDirIfMissing(cache_dir_);
+  if (st.ok()) {
+    st = env_->GetBaseEnv()->CreateDirIfMissing(cache_dir_);
   }
-  return status;
+  return st;
 }
 
 Status CloudLogControllerImpl::Prepare(CloudEnv* env) {

--- a/cloud/cloud_log_controller_impl.h
+++ b/cloud/cloud_log_controller_impl.h
@@ -16,12 +16,16 @@ class CloudLogControllerImpl : public CloudLogController {
   static constexpr const char* kCacheDir = "/tmp/ROCKSET";
   // Delay in Cloud Log stream: writes to read visibility
   static const std::chrono::microseconds kRetryPeriod;
+  static Status CreateKinesisController(
+      std::shared_ptr<CloudLogController>* result);
+  static Status CreateKafkaController(
+      std::shared_ptr<CloudLogController>* result);
 
   static const uint32_t kAppend = 0x1;  // add a new record to a logfile
   static const uint32_t kDelete = 0x2;  // delete a log file
   static const uint32_t kClosed = 0x4;  // closing a file
 
-  CloudLogControllerImpl(CloudEnv* env);
+  CloudLogControllerImpl();
   virtual ~CloudLogControllerImpl();
   static Status CreateKinesisController(
       CloudEnv* env, std::shared_ptr<CloudLogController>* result);
@@ -50,8 +54,11 @@ class CloudLogControllerImpl : public CloudLogController {
                              const EnvOptions& options) override;
   Status FileExists(const std::string& fname) override;
   Status GetFileSize(const std::string& logical_fname, uint64_t* size) override;
+  virtual Status Prepare(CloudEnv* env) override;
+  virtual Status Verify() const override;
 
  protected:
+  virtual Status Initialize(CloudEnv* env);
   // Converts an original pathname to a pathname in the cache.
   std::string GetCachePath(const Slice& original_pathname) const;
 

--- a/cloud/cloud_log_controller_impl.h
+++ b/cloud/cloud_log_controller_impl.h
@@ -55,8 +55,6 @@ class CloudLogControllerImpl : public CloudLogController {
   Status FileExists(const std::string& fname) override;
   Status GetFileSize(const std::string& logical_fname, uint64_t* size) override;
   virtual Status Prepare(CloudEnv* env) override;
-  virtual Status Verify() const override;
-
  protected:
   virtual Status Initialize(CloudEnv* env);
   // Converts an original pathname to a pathname in the cache.

--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -286,17 +286,6 @@ CloudStorageProviderImpl::CloudStorageProviderImpl() : rng_(time(nullptr)) {}
 
 CloudStorageProviderImpl::~CloudStorageProviderImpl() {}
 
-Status CloudStorageProviderImpl::Verify() const {
-  if (!status_.ok()) {
-    return status_;
-  } else if (!env_) {
-    return Status::InvalidArgument("Storage Provider not initialized: ",
-                                   Name());
-  } else {
-    return Status::OK();
-  }
-}
-
 Status CloudStorageProviderImpl::Prepare(CloudEnv* env) {
   status_ = Initialize(env);
   if (status_.ok()) {

--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -256,7 +256,7 @@ Status CloudStorageWritableFileImpl::Sync() {
 CloudStorageProvider::~CloudStorageProvider() {}
 
 Status CloudStorageProvider::Prepare(CloudEnv* env) {
-  Status status;
+  Status st;
   if (env->HasDestBucket()) {
     // create dest bucket if specified
     if (ExistsBucket(env->GetDestBucketName()).ok()) {
@@ -267,19 +267,19 @@ Status CloudStorageProvider::Prepare(CloudEnv* env) {
       Log(InfoLogLevel::INFO_LEVEL, env->info_log_,
           "[%s] Going to create bucket %s", Name(),
           env->GetDestBucketName().c_str());
-      status = CreateBucket(env->GetDestBucketName());
+      st = CreateBucket(env->GetDestBucketName());
     } else {
-      status = Status::NotFound(
+      st = Status::NotFound(
           "Bucket not found and create_bucket_if_missing is false");
     }
-    if (!status.ok()) {
+    if (!st.ok()) {
       Log(InfoLogLevel::ERROR_LEVEL, env->info_log_,
           "[%s] Unable to create bucket %s %s", Name(),
-          env->GetDestBucketName().c_str(), status.ToString().c_str());
-      return status;
+          env->GetDestBucketName().c_str(), st.ToString().c_str());
+      return st;
     }
   }
-  return status;
+  return st;
 }
 
 CloudStorageProviderImpl::CloudStorageProviderImpl() : rng_(time(nullptr)) {}

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -117,8 +117,6 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
                               std::unique_ptr<CloudStorageReadableFile>* result,
                               const EnvOptions& options) override;
   virtual Status Prepare(CloudEnv* env) override;
-  virtual Status Verify() const override;
-
  protected:
   Random64 rng_;
   virtual Status Initialize(CloudEnv* env);

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -1247,7 +1247,7 @@ TEST_F(CloudTest, EphemeralOnCorruptedDB) {
   // MANIFEST is not yet uploaded from the durable shard.
   auto aws_env = dynamic_cast<AwsEnv*>(aenv_.get());
   ASSERT_TRUE(aws_env != nullptr);
-  aws_env->TEST_DeletePathInS3(
+  aws_env->GetCloudEnvOptions().storage_provider->DeleteObject(
       aws_env->GetSrcBucketName(),
       aws_env->GetSrcObjectPath() + "/" + manifest_file_name);
 

--- a/include/rocksdb/cloud/cloud_log_controller.h
+++ b/include/rocksdb/cloud/cloud_log_controller.h
@@ -85,8 +85,8 @@ class CloudLogController {
   virtual Status FileExists(const std::string& fname) = 0;
   virtual Status GetFileSize(const std::string& logical_fname,
                              uint64_t* size) = 0;
+  // Prepares/Initializes the log controller for the input cloud environment
   virtual Status Prepare(CloudEnv* env) = 0;
-  virtual Status Verify() const = 0;
 };
 
 }  // namespace rocksdb

--- a/include/rocksdb/cloud/cloud_log_controller.h
+++ b/include/rocksdb/cloud/cloud_log_controller.h
@@ -85,6 +85,8 @@ class CloudLogController {
   virtual Status FileExists(const std::string& fname) = 0;
   virtual Status GetFileSize(const std::string& logical_fname,
                              uint64_t* size) = 0;
+  virtual Status Prepare(CloudEnv* env) = 0;
+  virtual Status Verify() const = 0;
 };
 
 }  // namespace rocksdb

--- a/include/rocksdb/cloud/cloud_storage_provider.h
+++ b/include/rocksdb/cloud/cloud_storage_provider.h
@@ -112,8 +112,5 @@ class CloudStorageProvider {
 
   // Prepares/Initializes the storage provider for the input cloud environment
   virtual Status Prepare(CloudEnv* env);
-
-  // Verifies the storage provider is correctly initialized and ready to use.
-  virtual Status Verify() const = 0;
 };
 }  // namespace rocksdb


### PR DESCRIPTION
Make the construction of the Cloud objects (LogController, CloudEnv, and StorageProvider) be a separate step from the configuration of the objects and the initialization.  This will later allow the objects to be configured and initialized via properties files.