### PR TITLE
Rename the XXObject methods to XXCloudObject

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -114,7 +114,7 @@ Status CloudEnvImpl::DeleteInvisibleFiles(const std::string& dbname) {
   Status s;
   if (HasDestBucket()) {
     std::vector<std::string> pathnames;
-    s = cloud_env_options.storage_provider->ListObjects(
+    s = cloud_env_options.storage_provider->ListCloudObjects(
         GetDestBucketName(), GetDestObjectPath(), &pathnames);
     if (!s.ok()) {
       return s;
@@ -542,7 +542,7 @@ Status CloudEnvImpl::GetCloudDbid(const std::string& local_dir,
 
   // Read dbid from src bucket if it exists
   if (HasSrcBucket()) {
-    Status st = cloud_env_options.storage_provider->GetObject(
+    Status st = cloud_env_options.storage_provider->GetCloudObject(
         GetSrcBucketName(), GetSrcObjectPath() + "/IDENTITY", tmpfile);
     if (!st.ok() && !st.IsNotFound()) {
       return st;
@@ -565,7 +565,7 @@ Status CloudEnvImpl::GetCloudDbid(const std::string& local_dir,
 
   // Read dbid from dest bucket if it exists
   if (HasDestBucket()) {
-    Status st = cloud_env_options.storage_provider->GetObject(
+    Status st = cloud_env_options.storage_provider->GetCloudObject(
         GetDestBucketName(), GetDestObjectPath() + "/IDENTITY", tmpfile);
     if (!st.ok() && !st.IsNotFound()) {
       return st;
@@ -790,7 +790,7 @@ Status CloudEnvImpl::SanitizeDirectory(const DBOptions& options,
   // Download IDENTITY, first try destination, then source
   if (HasDestBucket()) {
     // download IDENTITY from dest
-    st = cloud_env_options.storage_provider->GetObject(
+    st = cloud_env_options.storage_provider->GetCloudObject(
         GetDestBucketName(), IdentityFileName(GetDestObjectPath()),
         IdentityFileName(local_name));
     if (!st.ok() && !st.IsNotFound()) {
@@ -801,7 +801,7 @@ Status CloudEnvImpl::SanitizeDirectory(const DBOptions& options,
   }
   if (!got_identity_from_dest && HasSrcBucket() && !SrcMatchesDest()) {
     // download IDENTITY from src
-    st = cloud_env_options.storage_provider->GetObject(
+    st = cloud_env_options.storage_provider->GetCloudObject(
         GetSrcBucketName(), IdentityFileName(GetSrcObjectPath()),
         IdentityFileName(local_name));
     if (!st.ok() && !st.IsNotFound()) {
@@ -883,7 +883,7 @@ Status CloudEnvImpl::FetchCloudManifest(const std::string& local_dbname,
   }
   // first try to get cloudmanifest from dest
   if (HasDestBucket()) {
-    Status st = cloud_env_options.storage_provider->GetObject(
+    Status st = cloud_env_options.storage_provider->GetCloudObject(
         GetDestBucketName(), CloudManifestFile(GetDestObjectPath()),
         cloudmanifest);
     if (!st.ok() && !st.IsNotFound()) {
@@ -905,7 +905,7 @@ Status CloudEnvImpl::FetchCloudManifest(const std::string& local_dbname,
   }
   // we couldn't get cloud manifest from dest, need to try from src?
   if (HasSrcBucket() && !SrcMatchesDest()) {
-    Status st = cloud_env_options.storage_provider->GetObject(
+    Status st = cloud_env_options.storage_provider->GetCloudObject(
         GetSrcBucketName(), CloudManifestFile(GetSrcObjectPath()),
         cloudmanifest);
     if (!st.ok() && !st.IsNotFound()) {
@@ -981,7 +981,7 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
     // upload new manifest, only if we have it (i.e. this is not a new
     // database, indicated by maxFileNumber)
     if (maxFileNumber > 0) {
-      st = cloud_env_options.storage_provider->PutObject(
+      st = cloud_env_options.storage_provider->PutCloudObject(
           ManifestFileWithEpoch(local_dbname, newEpoch), GetDestBucketName(),
           ManifestFileWithEpoch(GetDestObjectPath(), newEpoch));
       if (!st.ok()) {
@@ -989,7 +989,7 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
       }
     }
     // upload new cloud manifest
-    st = cloud_env_options.storage_provider->PutObject(
+    st = cloud_env_options.storage_provider->PutCloudObject(
         CloudManifestFile(local_dbname), GetDestBucketName(),
         CloudManifestFile(GetDestObjectPath()));
     if (!st.ok()) {

--- a/cloud/cloud_env_wrapper.h
+++ b/cloud/cloud_env_wrapper.h
@@ -28,41 +28,41 @@ class MockStorageProvider : public CloudStorageProvider {
                              const std::string& /*path_prefix*/) override {
     return notsup_;
   }
-  Status ListObjects(const std::string& /*bucket_name*/,
-                     const std::string& /*object_path*/,
-                     std::vector<std::string>* /*result*/) override {
+  Status ListCloudObjects(const std::string& /*bucket_name*/,
+                          const std::string& /*object_path*/,
+                          std::vector<std::string>* /*result*/) override {
     return notsup_;
   }
-  Status DeleteObject(const std::string& /*bucket_name*/,
-                      const std::string& /*object_path*/) override {
+  Status DeleteCloudObject(const std::string& /*bucket_name*/,
+                           const std::string& /*object_path*/) override {
     return notsup_;
   }
-  Status ExistsObject(const std::string& /*bucket_name*/,
-                      const std::string& /*object_path*/) override {
+  Status ExistsCloudObject(const std::string& /*bucket_name*/,
+                           const std::string& /*object_path*/) override {
     return notsup_;
   }
-  Status GetObjectSize(const std::string& /*bucket_name*/,
-                       const std::string& /*object_path*/,
-                       uint64_t* /*size*/) override {
+  Status GetCloudObjectSize(const std::string& /*bucket_name*/,
+                            const std::string& /*object_path*/,
+                            uint64_t* /*size*/) override {
     return notsup_;
   }
-  Status GetObjectModificationTime(const std::string& /*bucket_name*/,
-                                   const std::string& /*object_path*/,
-                                   uint64_t* /*time*/) override {
+  Status GetCloudObjectModificationTime(const std::string& /*bucket_name*/,
+                                        const std::string& /*object_path*/,
+                                        uint64_t* /*time*/) override {
     return notsup_;
   }
-  Status GetObjectMetadata(
+  Status GetCloudObjectMetadata(
       const std::string& /*bucket_name*/, const std::string& /*object_path*/,
       std::unordered_map<std::string, std::string>* /*metadata*/) override {
     return notsup_;
   }
-  Status CopyObject(const std::string& /*bucket_name_src*/,
-                    const std::string& /*object_path_src*/,
-                    const std::string& /*bucket_name_dest*/,
-                    const std::string& /*object_path_dest*/) override {
+  Status CopyCloudObject(const std::string& /*bucket_name_src*/,
+                         const std::string& /*object_path_src*/,
+                         const std::string& /*bucket_name_dest*/,
+                         const std::string& /*object_path_dest*/) override {
     return notsup_;
   }
-  Status PutObjectMetadata(
+  Status PutCloudObjectMetadata(
       const std::string& /*bucket_name*/, const std::string& /*object_path*/,
       const std::unordered_map<std::string, std::string>& /*metadata*/)
       override {
@@ -83,15 +83,15 @@ class MockStorageProvider : public CloudStorageProvider {
     return notsup_;
   }
 
-  Status GetObject(const std::string& /*bucket_name*/,
-                   const std::string& /*object_path*/,
-                   const std::string& /*local_path*/) override {
+  Status GetCloudObject(const std::string& /*bucket_name*/,
+                        const std::string& /*object_path*/,
+                        const std::string& /*local_path*/) override {
     return notsup_;
   }
 
-  Status PutObject(const std::string& /*local_path*/,
-                   const std::string& /*bucket_name*/,
-                   const std::string& /*object_path*/) override {
+  Status PutCloudObject(const std::string& /*local_path*/,
+                        const std::string& /*bucket_name*/,
+                        const std::string& /*object_path*/) override {
     return notsup_;
   }
 

--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -309,14 +309,14 @@ Status CloudStorageProviderImpl::NewCloudReadableFile(
   // First, check if the file exists and also find its size. We use size in
   // CloudReadableFile to make sure we always read the valid ranges of the file
   uint64_t size;
-  Status st = GetObjectSize(bucket, fname, &size);
+  Status st = GetCloudObjectSize(bucket, fname, &size);
   if (!st.ok()) {
     return st;
   }
   return DoNewCloudReadableFile(bucket, fname, size, result, options);
 }
 
-Status CloudStorageProviderImpl::GetObject(
+Status CloudStorageProviderImpl::GetCloudObject(
     const std::string& bucket_name, const std::string& object_path,
     const std::string& local_destination) {
   Env* localenv = env_->GetBaseEnv();
@@ -325,7 +325,7 @@ Status CloudStorageProviderImpl::GetObject(
 
   uint64_t remote_size;
   Status s =
-      DoGetObject(bucket_name, object_path, tmp_destination, &remote_size);
+      DoGetCloudObject(bucket_name, object_path, tmp_destination, &remote_size);
   if (!s.ok()) {
     localenv->DeleteFile(tmp_destination);
     return s;
@@ -341,7 +341,7 @@ Status CloudStorageProviderImpl::GetObject(
     localenv->DeleteFile(tmp_destination);
     s = Status::IOError("Partial download of a file " + local_destination);
     Log(InfoLogLevel::ERROR_LEVEL, env_->info_log_,
-        "[%s] GetObject %s/%s local size %" PRIu64
+        "[%s] GetCloudObject %s/%s local size %" PRIu64
         " != cloud size "
         "%" PRIu64 ". %s",
         Name(), bucket_name.c_str(), object_path.c_str(), local_size,
@@ -352,31 +352,31 @@ Status CloudStorageProviderImpl::GetObject(
     s = localenv->RenameFile(tmp_destination, local_destination);
   }
   Log(InfoLogLevel::INFO_LEVEL, env_->info_log_,
-      "[%s] GetObject %s/%s size %" PRIu64 ". %s", bucket_name.c_str(), Name(),
-      object_path.c_str(), local_size, s.ToString().c_str());
+      "[%s] GetCloudObject %s/%s size %" PRIu64 ". %s", bucket_name.c_str(),
+      Name(), object_path.c_str(), local_size, s.ToString().c_str());
   return s;
 }
 
-Status CloudStorageProviderImpl::PutObject(const std::string& local_file,
-                                           const std::string& bucket_name,
-                                           const std::string& object_path) {
+Status CloudStorageProviderImpl::PutCloudObject(
+    const std::string& local_file, const std::string& bucket_name,
+    const std::string& object_path) {
   uint64_t fsize = 0;
   // debugging paranoia. Files uploaded to Cloud can never be zero size.
   auto st = env_->GetBaseEnv()->GetFileSize(local_file, &fsize);
   if (!st.ok()) {
     Log(InfoLogLevel::ERROR_LEVEL, env_->info_log_,
-        "[%s] PutObject localpath %s error getting size %s", Name(),
+        "[%s] PutCloudObject localpath %s error getting size %s", Name(),
         local_file.c_str(), st.ToString().c_str());
     return st;
   }
   if (fsize == 0) {
     Log(InfoLogLevel::ERROR_LEVEL, env_->info_log_,
-        "[%s] PutObject localpath %s error zero size", Name(),
+        "[%s] PutCloudObject localpath %s error zero size", Name(),
         local_file.c_str());
     return Status::IOError(local_file + " Zero size.");
   }
 
-  return DoPutObject(local_file, bucket_name, object_path, fsize);
+  return DoPutCloudObject(local_file, bucket_name, object_path, fsize);
 }
 
 }  // namespace rocksdb

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -106,12 +106,12 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
 
   CloudStorageProviderImpl();
   virtual ~CloudStorageProviderImpl();
-  Status GetObject(const std::string& bucket_name,
-                   const std::string& object_path,
-                   const std::string& local_destination) override;
-  Status PutObject(const std::string& local_file,
-                   const std::string& bucket_name,
-                   const std::string& object_path) override;
+  Status GetCloudObject(const std::string& bucket_name,
+                        const std::string& object_path,
+                        const std::string& local_destination) override;
+  Status PutCloudObject(const std::string& local_file,
+                        const std::string& bucket_name,
+                        const std::string& object_path) override;
   Status NewCloudReadableFile(const std::string& bucket,
                               const std::string& fname,
                               std::unique_ptr<CloudStorageReadableFile>* result,
@@ -127,14 +127,14 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
       const EnvOptions& options) = 0;
 
   // Downloads object from the cloud into a local directory
-  virtual Status DoGetObject(const std::string& bucket_name,
-                             const std::string& object_path,
-                             const std::string& local_path,
-                             uint64_t* remote_size) = 0;
-  virtual Status DoPutObject(const std::string& local_file,
-                             const std::string& object_path,
-                             const std::string& bucket_name,
-                             uint64_t file_size) = 0;
+  virtual Status DoGetCloudObject(const std::string& bucket_name,
+                                  const std::string& object_path,
+                                  const std::string& local_path,
+                                  uint64_t* remote_size) = 0;
+  virtual Status DoPutCloudObject(const std::string& local_file,
+                                  const std::string& object_path,
+                                  const std::string& bucket_name,
+                                  uint64_t file_size) = 0;
 
   CloudEnv* env_;
   Status status_;

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -221,7 +221,8 @@ Status DBCloudImpl::Savepoint() {
   for (auto onefile : live_files) {
     auto remapped_fname = cenv->RemapFilename(onefile.name);
     std::string destpath = cenv->GetDestObjectPath() + "/" + remapped_fname;
-    if (!provider->ExistsObject(cenv->GetDestBucketName(), destpath).ok()) {
+    if (!provider->ExistsCloudObject(cenv->GetDestBucketName(), destpath)
+             .ok()) {
       to_copy.push_back(remapped_fname);
     }
   }
@@ -237,7 +238,7 @@ Status DBCloudImpl::Savepoint() {
         break;
       }
       auto& onefile = to_copy[idx];
-      Status s = provider->CopyObject(
+      Status s = provider->CopyCloudObject(
           cenv->GetSrcBucketName(), cenv->GetSrcObjectPath() + "/" + onefile,
           cenv->GetDestBucketName(), cenv->GetDestObjectPath() + "/" + onefile);
       if (!s.ok()) {
@@ -344,7 +345,7 @@ Status DBCloudImpl::DoCheckpointToCloud(
       }
 
       auto& f = files_to_copy[idx];
-      auto copy_st = provider->PutObject(
+      auto copy_st = provider->PutCloudObject(
           GetName() + "/" + f.first, destination.GetBucketName(),
           destination.GetObjectPath() + "/" + f.second);
       if (!copy_st.ok()) {

--- a/cloud/purge.cc
+++ b/cloud/purge.cc
@@ -57,7 +57,7 @@ void CloudEnvImpl::Purger() {
     // delete obsolete paths
     for (const auto& p : to_be_deleted_paths) {
       // TODO more unit tests before we delete data
-      // st = DeleteObject(GetDestBucketName(), p);
+      // st = DeleteCloudObject(GetDestBucketName(), p);
       Log(InfoLogLevel::WARN_LEVEL, info_log_,
           "[pg] bucket prefix %s obsolete dbpath %s deleted. %s",
           GetDestBucketName().c_str(), p.c_str(), st.ToString().c_str());
@@ -133,8 +133,8 @@ Status CloudEnvImpl::FindObsoleteFiles(const std::string& bucket_name_prefix,
     std::string mpath = iter->second;
 
     std::vector<std::string> objects;
-    st = cloud_env_options.storage_provider->ListObjects(bucket_name_prefix,
-                                                         mpath, &objects);
+    st = cloud_env_options.storage_provider->ListCloudObjects(
+        bucket_name_prefix, mpath, &objects);
     if (!st.ok()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
           "[pg] Unable to list objects in bucketprefix %s path_prefix %s. %s",
@@ -171,7 +171,7 @@ Status CloudEnvImpl::FindObsoleteDbid(
     for (auto iter = dbid_list.begin(); iter != dbid_list.end(); ++iter) {
       std::unique_ptr<SequentialFile> result;
       std::string path = CloudManifestFile(iter->second);
-      st = GetCloudEnvOptions().storage_provider->ExistsObject(
+      st = GetCloudEnvOptions().storage_provider->ExistsCloudObject(
           GetDestBucketName(), path);
       // this dbid can be cleaned up
       if (st.IsNotFound()) {
@@ -204,8 +204,8 @@ Status CloudEnvImpl::extractParents(const std::string& bucket_name_prefix,
     // download IDENTITY
     std::string cloudfile = iter->second + "/IDENTITY";
     std::string localfile = scratch + "/.rockset_IDENTITY." + random;
-    st = GetCloudEnvOptions().storage_provider->GetObject(bucket_name_prefix,
-                                                          cloudfile, localfile);
+    st = GetCloudEnvOptions().storage_provider->GetCloudObject(
+        bucket_name_prefix, cloudfile, localfile);
     if (!st.ok() && !st.IsNotFound()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
           "[pg] Unable to download IDENTITY file from "

--- a/include/rocksdb/cloud/cloud_storage_provider.h
+++ b/include/rocksdb/cloud/cloud_storage_provider.h
@@ -45,54 +45,54 @@ class CloudStorageProvider {
   virtual Status EmptyBucket(const std::string& bucket_name,
                              const std::string& object_path) = 0;
   // Delete the specified object from the specified cloud bucket
-  virtual Status DeleteObject(const std::string& bucket_name,
-                              const std::string& object_path) = 0;
+  virtual Status DeleteCloudObject(const std::string& bucket_name,
+                                   const std::string& object_path) = 0;
 
   // Does the specified object exist in the cloud storage
   // returns all the objects that have the specified path prefix and
   // are stored in a cloud bucket
-  virtual Status ListObjects(const std::string& bucket_name,
-                             const std::string& object_path,
-                             std::vector<std::string>* path_names) = 0;
+  virtual Status ListCloudObjects(const std::string& bucket_name,
+                                  const std::string& object_path,
+                                  std::vector<std::string>* path_names) = 0;
 
   // Does the specified object exist in the cloud storage
-  virtual Status ExistsObject(const std::string& bucket_name,
-                              const std::string& object_path) = 0;
+  virtual Status ExistsCloudObject(const std::string& bucket_name,
+                                   const std::string& object_path) = 0;
 
   // Get the size of the object in cloud storage
-  virtual Status GetObjectSize(const std::string& bucket_name,
-                               const std::string& object_path,
-                               uint64_t* filesize) = 0;
+  virtual Status GetCloudObjectSize(const std::string& bucket_name,
+                                    const std::string& object_path,
+                                    uint64_t* filesize) = 0;
 
   // Get the modification time of the object in cloud storage
-  virtual Status GetObjectModificationTime(const std::string& bucket_name,
-                                           const std::string& object_path,
-                                           uint64_t* time) = 0;
+  virtual Status GetCloudObjectModificationTime(const std::string& bucket_name,
+                                                const std::string& object_path,
+                                                uint64_t* time) = 0;
 
   // Get the metadata of the object in cloud storage
-  virtual Status GetObjectMetadata(
+  virtual Status GetCloudObjectMetadata(
       const std::string& bucket_name, const std::string& object_path,
       std::unordered_map<std::string, std::string>* metadata) = 0;
 
   // Copy the specified cloud object from one location in the cloud
   // storage to another location in cloud storage
-  virtual Status CopyObject(const std::string& src_bucket_name,
-                            const std::string& src_object_path,
-                            const std::string& dest_bucket_name,
-                            const std::string& dest_object_path) = 0;
+  virtual Status CopyCloudObject(const std::string& src_bucket_name,
+                                 const std::string& src_object_path,
+                                 const std::string& dest_bucket_name,
+                                 const std::string& dest_object_path) = 0;
 
   // Downloads object from the cloud into a local directory
-  virtual Status GetObject(const std::string& bucket_name,
-                           const std::string& object_path,
-                           const std::string& local_path) = 0;
+  virtual Status GetCloudObject(const std::string& bucket_name,
+                                const std::string& object_path,
+                                const std::string& local_path) = 0;
 
   // Uploads object to the cloud
-  virtual Status PutObject(const std::string& local_path,
-                           const std::string& bucket_name,
-                           const std::string& object_path) = 0;
+  virtual Status PutCloudObject(const std::string& local_path,
+                                const std::string& bucket_name,
+                                const std::string& object_path) = 0;
 
   // Updates/Sets the metadata of the object in cloud storage
-  virtual Status PutObjectMetadata(
+  virtual Status PutCloudObjectMetadata(
       const std::string& bucket_name, const std::string& object_path,
       const std::unordered_map<std::string, std::string>& metadata) = 0;
 


### PR DESCRIPTION
This rename is to minimize the conflicts on some platforms (like Windows) with built-in names (like GetObject).