### PR TITLE
Move common code from AwsEnv to CloudEnvImpl

### DIFF
--- a/cloud/aws/aws_env.cc
+++ b/cloud/aws/aws_env.cc
@@ -239,17 +239,17 @@ void JobExecutor::DoWork() {
   while (true) {
     std::unique_lock<std::mutex> lk(mutex_);
     if (shutting_down_) {
-        break;
+      break;
     }
     if (scheduled_jobs_.empty()) {
-        jobs_changed_cv_.wait(lk);
-        continue;
+      jobs_changed_cv_.wait(lk);
+      continue;
     }
     auto earliest_job = scheduled_jobs_.begin();
     auto earliest_job_time = earliest_job->first;
     if (earliest_job_time >= std::chrono::steady_clock::now()) {
-        jobs_changed_cv_.wait_until(lk, earliest_job_time);
-        continue;
+      jobs_changed_cv_.wait_until(lk, earliest_job_time);
+      continue;
     }
     // invoke the function
     lk.unlock();
@@ -278,7 +278,8 @@ AwsEnv::AwsEnv(Env* underlying_env, const CloudEnvOptions& _cloud_env_options,
   if (cloud_env_options.src_bucket.GetRegion().empty() ||
       cloud_env_options.dest_bucket.GetRegion().empty()) {
     std::string region;
-    if (! CloudEnvOptions::GetNameFromEnvironment("AWS_DEFAULT_REGION", "aws_default_region", &region)) {
+    if (!CloudEnvOptions::GetNameFromEnvironment(
+            "AWS_DEFAULT_REGION", "aws_default_region", &region)) {
       region = default_region;
     }
     if (cloud_env_options.src_bucket.GetRegion().empty()) {
@@ -305,429 +306,6 @@ AwsEnv::~AwsEnv() {
 }
 
 void AwsEnv::Shutdown() { Aws::ShutdownAPI(Aws::SDKOptions()); }
-Status AwsEnv::status() { return create_bucket_status_; }
-
-//
-// Check if options are compatible with the S3 storage system
-//
-Status AwsEnv::CheckOption(const EnvOptions& options) {
-  // Cannot mmap files that reside on AWS S3, unless the file is also local
-  if (options.use_mmap_reads && !cloud_env_options.keep_local_sst_files) {
-    std::string msg = "Mmap only if keep_local_sst_files is set";
-    return Status::InvalidArgument(msg);
-  }
-  return Status::OK();
-}
-
-// Ability to read a file directly from cloud storage
-Status AwsEnv::NewSequentialFileCloud(const std::string& bucket,
-                                      const std::string& fname,
-                                      std::unique_ptr<SequentialFile>* result,
-                                      const EnvOptions& options) {
-  assert(status().ok());
-  std::unique_ptr<CloudStorageReadableFile> file;
-  Status st = cloud_env_options.storage_provider->NewCloudReadableFile(
-      bucket, fname, &file, options);
-  if (!st.ok()) {
-    return st;
-  }
-
-  result->reset(dynamic_cast<SequentialFile*>(file.release()));
-  return st;
-}
-
-// open a file for sequential reading
-Status AwsEnv::NewSequentialFile(const std::string& logical_fname,
-                                 std::unique_ptr<SequentialFile>* result,
-                                 const EnvOptions& options) {
-  assert(status().ok());
-  result->reset();
-
-  auto fname = RemapFilename(logical_fname);
-  auto file_type = GetFileType(fname);
-  bool sstfile = (file_type == RocksDBFileType::kSstFile),
-       manifest = (file_type == RocksDBFileType::kManifestFile),
-       identity = (file_type == RocksDBFileType::kIdentityFile),
-       logfile = (file_type == RocksDBFileType::kLogFile);
-
-  auto st = CheckOption(options);
-  if (!st.ok()) {
-    return st;
-  }
-
-  if (sstfile || manifest || identity) {
-    // We read first from local storage and then from cloud storage.
-    st = base_env_->NewSequentialFile(fname, result, options);
-
-    if (!st.ok()) {
-      if (cloud_env_options.keep_local_sst_files || !sstfile) {
-        // copy the file to the local storage if keep_local_sst_files is true
-        if (HasDestBucket()) {
-          st = cloud_env_options.storage_provider->GetCloudObject(
-              GetDestBucketName(), destname(fname), fname);
-        }
-        if (!st.ok() && HasSrcBucket() && !SrcMatchesDest()) {
-          st = cloud_env_options.storage_provider->GetCloudObject(
-              GetSrcBucketName(), srcname(fname), fname);
-        }
-        if (st.ok()) {
-          // we successfully copied the file, try opening it locally now
-          st = base_env_->NewSequentialFile(fname, result, options);
-        }
-      } else {
-        std::unique_ptr<CloudStorageReadableFile> file;
-        if (!st.ok() && HasDestBucket()) {  // read from destination S3
-          st = cloud_env_options.storage_provider->NewCloudReadableFile(
-              GetDestBucketName(), destname(fname), &file, options);
-        }
-        if (!st.ok() && HasSrcBucket()) {  // read from src bucket
-          st = cloud_env_options.storage_provider->NewCloudReadableFile(
-              GetSrcBucketName(), srcname(fname), &file, options);
-        }
-        if (st.ok()) {
-          result->reset(dynamic_cast<SequentialFile*>(file.release()));
-        }
-      }
-    }
-    Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-        "[aws] NewSequentialFile file %s %s", fname.c_str(),
-        st.ToString().c_str());
-    return st;
-
-  } else if (logfile && !cloud_env_options.keep_local_log_files) {
-    return cloud_env_options.cloud_log_controller->NewSequentialFile(
-        fname, result, options);
-  }
-
-  // This is neither a sst file or a log file. Read from default env.
-  return base_env_->NewSequentialFile(fname, result, options);
-}
-
-// open a file for random reading
-Status AwsEnv::NewRandomAccessFile(const std::string& logical_fname,
-                                   std::unique_ptr<RandomAccessFile>* result,
-                                   const EnvOptions& options) {
-  assert(status().ok());
-  result->reset();
-
-  auto fname = RemapFilename(logical_fname);
-  auto file_type = GetFileType(fname);
-  bool sstfile = (file_type == RocksDBFileType::kSstFile),
-       manifest = (file_type == RocksDBFileType::kManifestFile),
-       identity = (file_type == RocksDBFileType::kIdentityFile),
-       logfile = (file_type == RocksDBFileType::kLogFile);
-
-  // Validate options
-  auto st = CheckOption(options);
-  if (!st.ok()) {
-    return st;
-  }
-
-  if (sstfile || manifest || identity) {
-    // Read from local storage and then from cloud storage.
-    st = base_env_->NewRandomAccessFile(fname, result, options);
-
-    if (!st.ok() && !base_env_->FileExists(fname).IsNotFound()) {
-      // if status is not OK, but file does exist locally, something is wrong
-      return st;
-    }
-
-    if (cloud_env_options.keep_local_sst_files || !sstfile) {
-      if (!st.ok()) {
-        // copy the file to the local storage if keep_local_sst_files is true
-        if (HasDestBucket()) {
-          st = cloud_env_options.storage_provider->GetCloudObject(
-              GetDestBucketName(), destname(fname), fname);
-        }
-        if (!st.ok() && HasSrcBucket() && !SrcMatchesDest()) {
-          st = cloud_env_options.storage_provider->GetCloudObject(
-              GetSrcBucketName(), srcname(fname), fname);
-        }
-        if (st.ok()) {
-          // we successfully copied the file, try opening it locally now
-          st = base_env_->NewRandomAccessFile(fname, result, options);
-        }
-      }
-      // If we are being paranoic, then we validate that our file size is
-      // the same as in cloud storage.
-      if (st.ok() && sstfile && cloud_env_options.validate_filesize) {
-        uint64_t remote_size = 0;
-        uint64_t local_size = 0;
-        Status stax = base_env_->GetFileSize(fname, &local_size);
-        if (!stax.ok()) {
-          return stax;
-        }
-        stax = Status::NotFound();
-        if (HasDestBucket()) {
-          stax = cloud_env_options.storage_provider->GetCloudObjectSize(
-              GetDestBucketName(), destname(fname), &remote_size);
-        }
-        if (stax.IsNotFound() && HasSrcBucket()) {
-          stax = cloud_env_options.storage_provider->GetCloudObjectSize(
-              GetSrcBucketName(), srcname(fname), &remote_size);
-        }
-        if (stax.IsNotFound() && !HasDestBucket()) {
-          // It is legal for file to not be present in S3 if destination bucket
-          // is not set.
-        } else if (!stax.ok() || remote_size != local_size) {
-          std::string msg = "[aws] HeadObject src " + fname + " local size " +
-                            std::to_string(local_size) + " cloud size " +
-                            std::to_string(remote_size) + " " + stax.ToString();
-          Log(InfoLogLevel::ERROR_LEVEL, info_log_, "%s", msg.c_str());
-          return Status::IOError(msg);
-        }
-      }
-    } else if (!st.ok()) {
-      // Only execute this code path if keep_local_sst_files == false. If it's
-      // true, we will never use CloudReadableFile to read; we copy the file
-      // locally and read using base_env.
-      std::unique_ptr<CloudStorageReadableFile> file;
-      if (!st.ok() && HasDestBucket()) {
-        st = cloud_env_options.storage_provider->NewCloudReadableFile(
-            GetDestBucketName(), destname(fname), &file, options);
-      }
-      if (!st.ok() && HasSrcBucket()) {
-        st = cloud_env_options.storage_provider->NewCloudReadableFile(
-            GetSrcBucketName(), srcname(fname), &file, options);
-      }
-      if (st.ok()) {
-        result->reset(dynamic_cast<RandomAccessFile*>(file.release()));
-      }
-    }
-    Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-        "[%s] NewRandomAccessFile file %s %s", Name(), fname.c_str(),
-        st.ToString().c_str());
-    return st;
-
-  } else if (logfile && !cloud_env_options.keep_local_log_files) {
-    // read from Kinesis
-    st = cloud_env_options.cloud_log_controller->NewRandomAccessFile(
-        fname, result, options);
-    return st;
-  }
-
-  // This is neither a sst file or a log file. Read from default env.
-  return base_env_->NewRandomAccessFile(fname, result, options);
-}
-
-// create a new file for writing
-Status AwsEnv::NewWritableFile(const std::string& logical_fname,
-                               std::unique_ptr<WritableFile>* result,
-                               const EnvOptions& options) {
-  assert(status().ok());
-  result->reset();
-
-  auto fname = RemapFilename(logical_fname);
-  auto file_type = GetFileType(fname);
-  bool sstfile = (file_type == RocksDBFileType::kSstFile),
-       manifest = (file_type == RocksDBFileType::kManifestFile),
-       identity = (file_type == RocksDBFileType::kIdentityFile),
-       logfile = (file_type == RocksDBFileType::kLogFile);
-
-  Status s;
-
-  if (HasDestBucket() && (sstfile || identity || manifest)) {
-    std::unique_ptr<CloudStorageWritableFile> f;
-    cloud_env_options.storage_provider->NewCloudWritableFile(
-        fname, GetDestBucketName(), destname(fname), &f, options);
-    s = f->status();
-    if (!s.ok()) {
-      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-          "[aws] NewWritableFile src %s %s", fname.c_str(),
-          s.ToString().c_str());
-      return s;
-    }
-    result->reset(dynamic_cast<WritableFile*>(f.release()));
-  } else if (logfile && !cloud_env_options.keep_local_log_files) {
-    std::unique_ptr<CloudLogWritableFile> f(
-        cloud_env_options.cloud_log_controller->CreateWritableFile(fname,
-                                                                   options));
-    if (!f || !f->status().ok()) {
-      s = Status::IOError("[aws] NewWritableFile", fname.c_str());
-      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-          "[kinesis] NewWritableFile src %s %s", fname.c_str(),
-          s.ToString().c_str());
-      return s;
-    }
-    result->reset(dynamic_cast<WritableFile*>(f.release()));
-  } else {
-    s = base_env_->NewWritableFile(fname, result, options);
-  }
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[aws] NewWritableFile src %s %s",
-      fname.c_str(), s.ToString().c_str());
-  return s;
-}
-
-Status AwsEnv::ReopenWritableFile(const std::string& fname,
-                                  std::unique_ptr<WritableFile>* result,
-                                  const EnvOptions& options) {
-  // This is not accurately correct because there is no wasy way to open
-  // an S3 file in append mode. We still need to support this because
-  // rocksdb's ExternalSstFileIngestionJob invokes this api to reopen
-  // a pre-created file to flush/sync it.
-  return base_env_->ReopenWritableFile(fname, result, options);
-}
-
-class S3Directory : public Directory {
- public:
-  explicit S3Directory(AwsEnv* env, const std::string name)
-      : env_(env), name_(name) {
-    status_ = env_->GetBaseEnv()->NewDirectory(name, &posixDir);
-  }
-
-  ~S3Directory() {}
-
-  virtual Status Fsync() {
-    if (!status_.ok()) {
-      return status_;
-    }
-    return posixDir->Fsync();
-  }
-
-  virtual Status status() { return status_; }
-
- private:
-  AwsEnv* env_;
-  std::string name_;
-  Status status_;
-  std::unique_ptr<Directory> posixDir;
-};
-
-//
-//  Returns success only if the directory-bucket exists in the
-//  AWS S3 service and the posixEnv local directory exists as well.
-//
-Status AwsEnv::NewDirectory(const std::string& name,
-                            std::unique_ptr<Directory>* result) {
-  assert(status().ok());
-  result->reset(nullptr);
-
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[aws] NewDirectory name '%s'",
-      name.c_str());
-
-  // create new object.
-  std::unique_ptr<S3Directory> d(new S3Directory(this, name));
-
-  // Check if the path exists in local dir
-  if (!d->status().ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-        "[aws] NewDirectory name %s unable to create local dir", name.c_str());
-    return d->status();
-  }
-  result->reset(d.release());
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[aws] NewDirectory name %s ok",
-      name.c_str());
-  return Status::OK();
-}
-
-//
-// Check if the specified filename exists.
-//
-Status AwsEnv::FileExists(const std::string& logical_fname) {
-  assert(status().ok());
-  Status st;
-
-  auto fname = RemapFilename(logical_fname);
-  auto file_type = GetFileType(fname);
-  bool sstfile = (file_type == RocksDBFileType::kSstFile),
-       manifest = (file_type == RocksDBFileType::kManifestFile),
-       identity = (file_type == RocksDBFileType::kIdentityFile),
-       logfile = (file_type == RocksDBFileType::kLogFile);
-
-  if (sstfile || manifest || identity) {
-    // We read first from local storage and then from cloud storage.
-    st = base_env_->FileExists(fname);
-    if (st.IsNotFound() && HasDestBucket()) {
-      st = cloud_env_options.storage_provider->ExistsCloudObject(
-          GetDestBucketName(), destname(fname));
-    }
-    if (!st.ok() && HasSrcBucket()) {
-      st = cloud_env_options.storage_provider->ExistsCloudObject(
-          GetSrcBucketName(), srcname(fname));
-    }
-  } else if (logfile && !cloud_env_options.keep_local_log_files) {
-    // read from Kinesis
-    st = cloud_env_options.cloud_log_controller->FileExists(fname);
-  } else {
-    st = base_env_->FileExists(fname);
-  }
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[aws] FileExists path '%s' %s",
-      fname.c_str(), st.ToString().c_str());
-  return st;
-}
-
-Status AwsEnv::GetChildren(const std::string& path,
-                           std::vector<std::string>* result) {
-  assert(status().ok());
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[s3] GetChildren path '%s' ",
-      path.c_str());
-  result->clear();
-
-  // Fetch the list of children from both buckets in S3
-  Status st;
-  if (HasSrcBucket() && !cloud_env_options.skip_cloud_files_in_getchildren) {
-    st = cloud_env_options.storage_provider->ListCloudObjects(
-        GetSrcBucketName(), GetSrcObjectPath(), result);
-    if (!st.ok()) {
-      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-          "[aws] GetChildren src bucket %s %s error from S3 %s",
-          GetSrcBucketName().c_str(), path.c_str(), st.ToString().c_str());
-      return st;
-    }
-  }
-  if (HasDestBucket() && !SrcMatchesDest() &&
-      !cloud_env_options.skip_cloud_files_in_getchildren) {
-    st = cloud_env_options.storage_provider->ListCloudObjects(
-        GetDestBucketName(), GetDestObjectPath(), result);
-    if (!st.ok()) {
-      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-          "[aws] GetChildren dest bucket %s %s error from S3 %s",
-          GetDestBucketName().c_str(), path.c_str(), st.ToString().c_str());
-      return st;
-    }
-  }
-
-  // fetch all files that exist in the local posix directory
-  std::vector<std::string> local_files;
-  st = base_env_->GetChildren(path, &local_files);
-  if (!st.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-        "[aws] GetChildren %s error on local dir", path.c_str());
-    return st;
-  }
-
-  for (auto const& value : local_files) {
-    result->push_back(value);
-  }
-
-  // Remove all results that are not supposed to be visible.
-  result->erase(
-      std::remove_if(result->begin(), result->end(),
-                     [&](const std::string& f) {
-                       auto noepoch = RemoveEpoch(f);
-                       if (!IsSstFile(noepoch) && !IsManifestFile(noepoch)) {
-                         return false;
-                       }
-                       return RemapFilename(noepoch) != f;
-                     }),
-      result->end());
-  // Remove the epoch, remap into RocksDB's domain
-  for (size_t i = 0; i < result->size(); ++i) {
-    auto noepoch = RemoveEpoch(result->at(i));
-    if (IsSstFile(noepoch) || IsManifestFile(noepoch)) {
-      // remap sst and manifest files
-      result->at(i) = noepoch;
-    }
-  }
-  // remove duplicates
-  std::sort(result->begin(), result->end());
-  result->erase(std::unique(result->begin(), result->end()), result->end());
-
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-      "[s3] GetChildren %s successfully returned %" ROCKSDB_PRIszt " files",
-      path.c_str(), result->size());
-  return Status::OK();
-}
 
 void AwsEnv::RemoveFileFromDeletionQueue(const std::string& filename) {
   std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
@@ -739,8 +317,6 @@ void AwsEnv::RemoveFileFromDeletionQueue(const std::string& filename) {
 }
 
 Status AwsEnv::DeleteFile(const std::string& logical_fname) {
-  assert(status().ok());
-
   auto fname = RemapFilename(logical_fname);
   auto file_type = GetFileType(fname);
   bool sstfile = (file_type == RocksDBFileType::kSstFile),
@@ -854,224 +430,12 @@ Status AwsEnv::DeleteCloudFileFromDest(const std::string& fname) {
   return Status::OK();
 }
 
-// S3 has no concepts of directories, so we just have to forward the request to
-// base_env_
-Status AwsEnv::CreateDir(const std::string& dirname) {
-  assert(status().ok());
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[s3] CreateDir dir '%s'",
-      dirname.c_str());
-  Status st;
-
-  // create local dir
-  st = base_env_->CreateDir(dirname);
-
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[s3] CreateDir dir %s %s",
-      dirname.c_str(), st.ToString().c_str());
-  return st;
-};
-
-// S3 has no concepts of directories, so we just have to forward the request to
-// base_env_
-Status AwsEnv::CreateDirIfMissing(const std::string& dirname) {
-  assert(status().ok());
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[s3] CreateDirIfMissing dir '%s'",
-      dirname.c_str());
-  Status st;
-
-  // create directory in base_env_
-  st = base_env_->CreateDirIfMissing(dirname);
-
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-      "[s3] CreateDirIfMissing created dir %s %s", dirname.c_str(),
-      st.ToString().c_str());
-  return st;
-};
-
-// S3 has no concepts of directories, so we just have to forward the request to
-// base_env_
-Status AwsEnv::DeleteDir(const std::string& dirname) {
-  assert(status().ok());
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[s3] DeleteDir src '%s'",
-      dirname.c_str());
-  Status st = base_env_->DeleteDir(dirname);
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[s3] DeleteDir dir %s %s",
-      dirname.c_str(), st.ToString().c_str());
-  return st;
-};
-
-Status AwsEnv::GetFileSize(const std::string& logical_fname, uint64_t* size) {
-  assert(status().ok());
-  *size = 0L;
-
-  auto fname = RemapFilename(logical_fname);
-  auto file_type = GetFileType(fname);
-  bool sstfile = (file_type == RocksDBFileType::kSstFile),
-       logfile = (file_type == RocksDBFileType::kLogFile);
-
-  Status st;
-  if (sstfile) {
-    if (base_env_->FileExists(fname).ok()) {
-      st = base_env_->GetFileSize(fname, size);
-    } else {
-      st = Status::NotFound();
-      // Get file length from S3
-      if (HasDestBucket()) {
-        st = cloud_env_options.storage_provider->GetCloudObjectSize(
-            GetDestBucketName(), destname(fname), size);
-      }
-      if (st.IsNotFound() && HasSrcBucket()) {
-        st = cloud_env_options.storage_provider->GetCloudObjectSize(
-            GetSrcBucketName(), srcname(fname), size);
-      }
-    }
-  } else if (logfile && !cloud_env_options.keep_local_log_files) {
-    st = cloud_env_options.cloud_log_controller->GetFileSize(fname, size);
-  } else {
-    st = base_env_->GetFileSize(fname, size);
-  }
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-      "[aws] GetFileSize src '%s' %s %" PRIu64, fname.c_str(),
-      st.ToString().c_str(), *size);
-  return st;
-}
-
-Status AwsEnv::GetFileModificationTime(const std::string& logical_fname,
-                                       uint64_t* time) {
-  assert(status().ok());
-  *time = 0;
-
-  auto fname = RemapFilename(logical_fname);
-  auto file_type = GetFileType(fname);
-  bool sstfile = (file_type == RocksDBFileType::kSstFile),
-       logfile = (file_type == RocksDBFileType::kLogFile);
-
-  Status st;
-  if (sstfile) {
-    if (base_env_->FileExists(fname).ok()) {
-      st = base_env_->GetFileModificationTime(fname, time);
-    } else {
-      st = Status::NotFound();
-      if (HasDestBucket()) {
-        st = cloud_env_options.storage_provider->GetCloudObjectModificationTime(
-            GetDestBucketName(), destname(fname), time);
-      }
-      if (st.IsNotFound() && HasSrcBucket()) {
-        st = cloud_env_options.storage_provider->GetCloudObjectModificationTime(
-            GetSrcBucketName(), srcname(fname), time);
-      }
-    }
-  } else if (logfile && !cloud_env_options.keep_local_log_files) {
-    st = cloud_env_options.cloud_log_controller->GetFileModificationTime(fname,
-                                                                         time);
-  } else {
-    st = base_env_->GetFileModificationTime(fname, time);
-  }
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-      "[aws] GetFileModificationTime src '%s' %s", fname.c_str(),
-      st.ToString().c_str());
-  return st;
-}
-
-// The rename is not atomic. S3 does not support renaming natively.
-// Copy file to a new object in S3 and then delete original object.
-Status AwsEnv::RenameFile(const std::string& logical_src,
-                          const std::string& logical_target) {
-  assert(status().ok());
-
-  auto src = RemapFilename(logical_src);
-  auto target = RemapFilename(logical_target);
-  // Get file type of target
-  auto file_type = GetFileType(target);
-  bool sstfile = (file_type == RocksDBFileType::kSstFile),
-       manifest = (file_type == RocksDBFileType::kManifestFile),
-       identity = (file_type == RocksDBFileType::kIdentityFile),
-       logfile = (file_type == RocksDBFileType::kLogFile);
-
-  // Rename should never be called on sst files.
-  if (sstfile) {
-    Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-        "[aws] RenameFile source sstfile %s %s is not supported", src.c_str(),
-        target.c_str());
-    assert(0);
-    return Status::NotSupported(Slice(src), Slice(target));
-  } else if (logfile) {
-    // Rename should never be called on log files as well
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-        "[aws] RenameFile source logfile %s %s is not supported", src.c_str(),
-        target.c_str());
-    assert(0);
-    return Status::NotSupported(Slice(src), Slice(target));
-  } else if (manifest) {
-    // Rename should never be called on manifest files as well
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-        "[aws] RenameFile source manifest %s %s is not supported", src.c_str(),
-        target.c_str());
-    assert(0);
-    return Status::NotSupported(Slice(src), Slice(target));
-
-  } else if (!identity || !HasDestBucket()) {
-    return base_env_->RenameFile(src, target);
-  }
-  // Only ID file should come here
-  assert(identity);
-  assert(HasDestBucket());
-  assert(basename(target) == "IDENTITY");
-
-  // Save Identity to S3
-  Status st = SaveIdentitytoS3(src, destname(target));
-
-  // Do the rename on local filesystem too
-  if (st.ok()) {
-    st = base_env_->RenameFile(src, target);
-  }
-  Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-      "[s3] RenameFile src %s target %s: %s", src.c_str(), target.c_str(),
-      st.ToString().c_str());
-  return st;
-}
-
-Status AwsEnv::LinkFile(const std::string& src, const std::string& target) {
-  // We only know how to link file if both src and dest buckets are empty
-  if (HasDestBucket() || HasSrcBucket()) {
-    return Status::NotSupported();
-  }
-  auto src_remapped = RemapFilename(src);
-  auto target_remapped = RemapFilename(target);
-  return base_env_->LinkFile(src_remapped, target_remapped);
-}
-
-//
-// Copy my IDENTITY file to cloud storage. Update dbid registry.
-//
-Status AwsEnv::SaveIdentitytoS3(const std::string& localfile,
-                                const std::string& idfile) {
-  assert(basename(idfile) == "IDENTITY");
-
-  // Read id into string
-  std::string dbid;
-  Status st = ReadFileToString(base_env_, localfile, &dbid);
-  dbid = trim(dbid);
-
-  // Upload ID file to  S3
-  if (st.ok()) {
-    st = cloud_env_options.storage_provider->PutCloudObject(
-        localfile, GetDestBucketName(), idfile);
-  }
-
-  // Save mapping from ID to cloud pathname
-  if (st.ok() && !GetDestObjectPath().empty()) {
-    st = SaveDbid(GetDestBucketName(), dbid, GetDestObjectPath());
-  }
-  return st;
-}
-
 //
 // All db in a bucket are stored in path /.rockset/dbid/<dbid>
 // The value of the object is the pathname where the db resides.
 //
 Status AwsEnv::SaveDbid(const std::string& bucket_name, const std::string& dbid,
                         const std::string& dirname) {
-  assert(status().ok());
   Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[s3] SaveDbid dbid %s dir '%s'",
       dbid.c_str(), dirname.c_str());
 
@@ -1103,8 +467,7 @@ Status AwsEnv::GetPathForDbid(const std::string& bucket,
   std::string dbidkey = dbid_registry_ + dbid;
 
   Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
-      "[s3] Bucket %s GetPathForDbid dbid %s", bucket.c_str(),
-      dbid.c_str());
+      "[s3] Bucket %s GetPathForDbid dbid %s", bucket.c_str(), dbid.c_str());
 
   std::unordered_map<std::string, std::string> metadata;
   Status st = cloud_env_options.storage_provider->GetCloudObjectMetadata(
@@ -1139,7 +502,6 @@ Status AwsEnv::GetPathForDbid(const std::string& bucket,
 // Retrieves the list of all registered dbids and their paths
 //
 Status AwsEnv::GetDbidList(const std::string& bucket, DbidList* dblist) {
-
   // fetch the list all all dbids
   std::vector<std::string> dbid_list;
   Status st = cloud_env_options.storage_provider->ListCloudObjects(
@@ -1169,9 +531,7 @@ Status AwsEnv::GetDbidList(const std::string& bucket, DbidList* dblist) {
 //
 // Deletes the specified dbid from the registry
 //
-Status AwsEnv::DeleteDbid(const std::string& bucket,
-                          const std::string& dbid) {
-
+Status AwsEnv::DeleteDbid(const std::string& bucket, const std::string& dbid) {
   // fetch the list all all dbids
   std::string dbidkey = dbid_registry_ + dbid;
   Status st =
@@ -1180,24 +540,6 @@ Status AwsEnv::DeleteDbid(const std::string& bucket,
       "[aws] %s DeleteDbid DeleteDbid(%s) %s", bucket.c_str(), dbid.c_str(),
       st.ToString().c_str());
   return st;
-}
-
-
-
-//
-// prepends the configured src object path name
-//
-std::string AwsEnv::srcname(const std::string& localname) {
-  assert(cloud_env_options.src_bucket.IsValid());
-  return cloud_env_options.src_bucket.GetObjectPath() + "/" + basename(localname);
-}
-
-//
-// prepends the configured dest object path name
-//
-std::string AwsEnv::destname(const std::string& localname) {
-  assert(cloud_env_options.dest_bucket.IsValid());
-  return cloud_env_options.dest_bucket.GetObjectPath() + "/" + basename(localname);
 }
 
 Status AwsEnv::LockFile(const std::string& /*fname*/, FileLock** lock) {
@@ -1209,15 +551,10 @@ Status AwsEnv::LockFile(const std::string& /*fname*/, FileLock** lock) {
 
 Status AwsEnv::UnlockFile(FileLock* /*lock*/) { return Status::OK(); }
 
-Status AwsEnv::NewLogger(const std::string& fname,
-                         std::shared_ptr<Logger>* result) {
-  return base_env_->NewLogger(fname, result);
-}
-
 // The factory method for creating an S3 Env
-Status AwsEnv::NewAwsEnv(Env* base_env,
-                         const CloudEnvOptions& cloud_options,
-                         const std::shared_ptr<Logger> & info_log, CloudEnv** cenv) {
+Status AwsEnv::NewAwsEnv(Env* base_env, const CloudEnvOptions& cloud_options,
+                         const std::shared_ptr<Logger>& info_log,
+                         CloudEnv** cenv) {
   Status status;
   *cenv = nullptr;
   // If underlying env is not defined, then use PosixEnv

--- a/cloud/aws/aws_env.h
+++ b/cloud/aws/aws_env.h
@@ -22,7 +22,6 @@ namespace rocksdb {
 
 class S3ReadableFile;
 
-
 namespace detail {
 struct JobHandle;
 }  // namespace detail
@@ -53,9 +52,9 @@ struct JobHandle;
 class AwsEnv : public CloudEnvImpl {
  public:
   // A factory method for creating S3 envs
-  static Status NewAwsEnv(Env* env,
-                          const CloudEnvOptions& env_options,
-                          const std::shared_ptr<Logger> & info_log, CloudEnv** cenv);
+  static Status NewAwsEnv(Env* env, const CloudEnvOptions& env_options,
+                          const std::shared_ptr<Logger>& info_log,
+                          CloudEnv** cenv);
 
   virtual ~AwsEnv();
 
@@ -72,136 +71,20 @@ class AwsEnv : public CloudEnvImpl {
   // explicitly make the default region be us-west-2.
   static constexpr const char* default_region = "us-west-2";
 
-  virtual Status NewSequentialFile(const std::string& fname,
-                                   std::unique_ptr<SequentialFile>* result,
-                                   const EnvOptions& options) override;
-
-  virtual Status NewSequentialFileCloud(const std::string& bucket,
-                                        const std::string& fname,
-                                        std::unique_ptr<SequentialFile>* result,
-                                        const EnvOptions& options) override;
-
-  virtual Status NewRandomAccessFile(const std::string& fname,
-                                     std::unique_ptr<RandomAccessFile>* result,
-                                     const EnvOptions& options) override;
-
-  virtual Status NewWritableFile(const std::string& fname,
-                                 std::unique_ptr<WritableFile>* result,
-                                 const EnvOptions& options) override;
-
-  virtual Status ReopenWritableFile(const std::string& /*fname*/,
-                                    std::unique_ptr<WritableFile>* /*result*/,
-                                    const EnvOptions& /*options*/) override;
-
-  virtual Status NewDirectory(const std::string& name,
-                              std::unique_ptr<Directory>* result) override;
-
-  virtual Status FileExists(const std::string& fname) override;
-
-  virtual Status GetChildren(const std::string& path,
-                             std::vector<std::string>* result) override;
-
   virtual Status DeleteFile(const std::string& fname) override;
-
-  virtual Status CreateDir(const std::string& name) override;
-
-  virtual Status CreateDirIfMissing(const std::string& name) override;
-
-  virtual Status DeleteDir(const std::string& name) override;
-
-  virtual Status GetFileSize(const std::string& fname, uint64_t* size) override;
-
-  virtual Status GetFileModificationTime(const std::string& fname,
-                                         uint64_t* file_mtime) override;
-
-  virtual Status RenameFile(const std::string& src,
-                            const std::string& target) override;
-
-  virtual Status LinkFile(const std::string& src,
-                          const std::string& target) override;
 
   virtual Status LockFile(const std::string& fname, FileLock** lock) override;
 
   virtual Status UnlockFile(FileLock* lock) override;
-
-  virtual Status NewLogger(const std::string& fname,
-                           std::shared_ptr<Logger>* result) override;
-
-  virtual void Schedule(void (*function)(void* arg), void* arg,
-                        Priority pri = LOW, void* tag = nullptr,
-                        void (*unschedFunction)(void* arg) = 0) override {
-    base_env_->Schedule(function, arg, pri, tag, unschedFunction);
-  }
-
-  virtual int UnSchedule(void* tag, Priority pri) override {
-    return base_env_->UnSchedule(tag, pri);
-  }
-
-  virtual void StartThread(void (*function)(void* arg), void* arg) override {
-    base_env_->StartThread(function, arg);
-  }
-
-  virtual void WaitForJoin() override { base_env_->WaitForJoin(); }
-
-  virtual unsigned int GetThreadPoolQueueLen(
-      Priority pri = LOW) const override {
-    return base_env_->GetThreadPoolQueueLen(pri);
-  }
-
-  virtual Status GetTestDirectory(std::string* path) override {
-    return base_env_->GetTestDirectory(path);
-  }
-
-  virtual uint64_t NowMicros() override { return base_env_->NowMicros(); }
-
-  virtual void SleepForMicroseconds(int micros) override {
-    base_env_->SleepForMicroseconds(micros);
-  }
-
-  virtual Status GetHostName(char* name, uint64_t len) override {
-    return base_env_->GetHostName(name, len);
-  }
-
-  virtual Status GetCurrentTime(int64_t* unix_time) override {
-    return base_env_->GetCurrentTime(unix_time);
-  }
-
-  virtual Status GetAbsolutePath(const std::string& db_path,
-                                 std::string* output_path) override {
-    return base_env_->GetAbsolutePath(db_path, output_path);
-  }
-
-  virtual void SetBackgroundThreads(int number, Priority pri = LOW) override {
-    base_env_->SetBackgroundThreads(number, pri);
-  }
-  int GetBackgroundThreads(Priority pri) override {
-    return base_env_->GetBackgroundThreads(pri);
-  }
-
-  virtual void IncBackgroundThreadsIfNeeded(int number, Priority pri) override {
-    base_env_->IncBackgroundThreadsIfNeeded(number, pri);
-  }
-
-  virtual std::string TimeToString(uint64_t number) override {
-    return base_env_->TimeToString(number);
-  }
-
-  static uint64_t gettid() {
-    assert(sizeof(pthread_t) <= sizeof(uint64_t));
-    return (uint64_t)pthread_self();
-  }
-
-  virtual uint64_t GetThreadID() const override { return AwsEnv::gettid(); }
 
   std::string GetWALCacheDir();
 
   // Saves and retrieves the dbid->dirname mapping in S3
   Status SaveDbid(const std::string& bucket_name, const std::string& dbid,
                   const std::string& dirname) override;
-  Status GetPathForDbid(const std::string& bucket,
-                        const std::string& dbid, std::string* dirname) override;
-  Status GetDbidList(const std::string& bucket,
-                     DbidList* dblist) override;
+  Status GetPathForDbid(const std::string& bucket, const std::string& dbid,
+                        std::string* dirname) override;
+  Status GetDbidList(const std::string& bucket, DbidList* dblist) override;
   Status DeleteDbid(const std::string& bucket,
                     const std::string& dbid) override;
   Status DeleteCloudFileFromDest(const std::string& fname) override;
@@ -220,41 +103,17 @@ class AwsEnv : public CloudEnvImpl {
   // The AWS credentials are specified to the constructor via
   // access_key_id and secret_key.
   //
-  explicit AwsEnv(Env* underlying_env,
-                  const CloudEnvOptions& cloud_options,
-                  const std::shared_ptr<Logger> & info_log = nullptr);
-
-
+  explicit AwsEnv(Env* underlying_env, const CloudEnvOptions& cloud_options,
+                  const std::shared_ptr<Logger>& info_log = nullptr);
 
   // The pathname that contains a list of all db's inside a bucket.
   static constexpr const char* dbid_registry_ = "/.rockset/dbid/";
-
-  Status create_bucket_status_;
 
   std::mutex files_to_delete_mutex_;
   std::chrono::seconds file_deletion_delay_ = std::chrono::hours(1);
   std::unordered_map<std::string, std::shared_ptr<detail::JobHandle>>
       files_to_delete_;
   Random64 rng_;
-
-  Status status();
-
-  // Validate options
-  Status CheckOption(const EnvOptions& options);
-
-
-  Status NewS3ReadableFile(const std::string& bucket, const std::string& fname,
-                           std::unique_ptr<S3ReadableFile>* result);
-
-  // Save IDENTITY file to S3. Update dbid registry.
-  Status SaveIdentitytoS3(const std::string& localfile,
-                          const std::string& target_idfile);
-
-  // Converts a local pathname to an object name in the src bucket
-  std::string srcname(const std::string& localname);
-
-  // Converts a local pathname to an object name in the dest bucket
-  std::string destname(const std::string& localname);
 };
 
 }  // namespace rocksdb

--- a/cloud/aws/aws_file.h
+++ b/cloud/aws/aws_file.h
@@ -10,6 +10,6 @@ inline Aws::String ToAwsString(const std::string& s) {
   return Aws::String(s.data(), s.size());
 }
 
-}  // namepace rocksdb
+}  // namespace rocksdb
 
 #endif /* USE_AWS */

--- a/cloud/aws/aws_retry.cc
+++ b/cloud/aws/aws_retry.cc
@@ -11,7 +11,7 @@
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/core/client/RetryStrategy.h>
-#endif // USE_AWS
+#endif  // USE_AWS
 
 namespace rocksdb {
 #ifdef USE_AWS
@@ -20,28 +20,28 @@ namespace rocksdb {
 //
 class AwsRetryStrategy : public Aws::Client::RetryStrategy {
  public:
-  AwsRetryStrategy(CloudEnv *env) : env_(env) {
+  AwsRetryStrategy(CloudEnv* env) : env_(env) {
     default_strategy_ = std::make_shared<Aws::Client::DefaultRetryStrategy>();
     Log(InfoLogLevel::INFO_LEVEL, env_->info_log_,
         "[aws] Configured custom retry policy");
   }
-  
-  ~AwsRetryStrategy() override { }
-   
+
+  ~AwsRetryStrategy() override {}
 
   // Returns true if the error can be retried given the error and the number of
   // times already tried.
   bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
                    long attemptedRetries) const override;
-  
+
   // Calculates the time in milliseconds the client should sleep before
   // attempting another request based on the error and attemptedRetries count.
-  long CalculateDelayBeforeNextRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
-                                     long attemptedRetries) const override;
+  long CalculateDelayBeforeNextRetry(
+      const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
+      long attemptedRetries) const override;
 
  private:
   // rocksdb retries, etc
-  CloudEnv *env_;
+  CloudEnv* env_;
 
   // The default strategy implemented by AWS client
   std::shared_ptr<Aws::Client::RetryStrategy> default_strategy_;
@@ -54,8 +54,9 @@ class AwsRetryStrategy : public Aws::Client::RetryStrategy {
 // Returns true if the error can be retried given the error and the number of
 // times already tried.
 //
-bool AwsRetryStrategy::ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
-                                   long attemptedRetries) const {
+bool AwsRetryStrategy::ShouldRetry(
+    const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
+    long attemptedRetries) const {
   auto ce = error.GetErrorType();
   const Aws::String errmsg = error.GetMessage();
   const Aws::String exceptionMsg = error.GetExceptionName();
@@ -99,18 +100,19 @@ bool AwsRetryStrategy::ShouldRetry(const Aws::Client::AWSError<Aws::Client::Core
 // attempting another request based on the error and attemptedRetries count.
 //
 long AwsRetryStrategy::CalculateDelayBeforeNextRetry(
-                                                     const Aws::Client::AWSError<Aws::Client::CoreErrors>& error, long attemptedRetries) const {
+    const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
+    long attemptedRetries) const {
   return default_strategy_->CalculateDelayBeforeNextRetry(error,
                                                           attemptedRetries);
 }
 
-Status AwsCloudOptions::GetClientConfiguration(CloudEnv *env,
-                                               const std::string& region,
-                                               Aws::Client::ClientConfiguration* config) {
+Status AwsCloudOptions::GetClientConfiguration(
+    CloudEnv* env, const std::string& region,
+    Aws::Client::ClientConfiguration* config) {
   config->connectTimeoutMs = 30000;
   config->requestTimeoutMs = 600000;
-  
-  const auto & cloud_env_options = env->GetCloudEnvOptions();
+
+  const auto& cloud_env_options = env->GetCloudEnvOptions();
   // Setup how retries need to be done
   config->retryStrategy = std::make_shared<AwsRetryStrategy>(env);
   if (cloud_env_options.request_timeout_ms != 0) {
@@ -121,12 +123,10 @@ Status AwsCloudOptions::GetClientConfiguration(CloudEnv *env,
   return Status::OK();
 }
 #else
-Status AwsCloudOptions::GetClientConfiguration(CloudEnv *,
-                                               const std::string& ,
-                                               Aws::Client::ClientConfiguration*) {
+Status AwsCloudOptions::GetClientConfiguration(
+    CloudEnv*, const std::string&, Aws::Client::ClientConfiguration*) {
   return Status::NotSupported("Not configured for AWS support");
 }
 #endif /* USE_AWS */
- 
-}  // namespace
 
+}  // namespace rocksdb

--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -390,6 +390,7 @@ class S3StorageProvider : public CloudStorageProviderImpl {
                               const std::string& object_path,
                               std::unique_ptr<CloudStorageWritableFile>* result,
                               const EnvOptions& options) override;
+
  protected:
   Status Initialize(CloudEnv* env) override;
   Status DoGetCloudObject(const std::string& bucket_name,

--- a/cloud/cloud_env.cc
+++ b/cloud/cloud_env.cc
@@ -17,17 +17,18 @@
 
 namespace rocksdb {
 
-bool CloudEnvOptions::GetNameFromEnvironment(const char *name, const char *alt, std::string * result) {
-
-  char *value = getenv(name);               // See if name is set in the environment
-  if (value == nullptr && alt != nullptr) { // Not set.  Do we have an alt name?
-    value = getenv(alt);                    // See if alt is in the environment
+bool CloudEnvOptions::GetNameFromEnvironment(const char* name, const char* alt,
+                                             std::string* result) {
+  char* value = getenv(name);  // See if name is set in the environment
+  if (value == nullptr &&
+      alt != nullptr) {   // Not set.  Do we have an alt name?
+    value = getenv(alt);  // See if alt is in the environment
   }
-  if (value != nullptr) {                   // Did we find the either name/alt in the env?
-    result->assign(value);                  // Yes, update result
-    return true;                            // And return success
+  if (value != nullptr) {   // Did we find the either name/alt in the env?
+    result->assign(value);  // Yes, update result
+    return true;            // And return success
   } else {
-    return false;                           // No, return not found
+    return false;  // No, return not found
   }
 }
 void CloudEnvOptions::TEST_Initialize(const std::string& bucket,
@@ -38,9 +39,7 @@ void CloudEnvOptions::TEST_Initialize(const std::string& bucket,
   credentials.TEST_Initialize();
 }
 
-BucketOptions::BucketOptions() {
-    prefix_ = "rockset.";
-}
+BucketOptions::BucketOptions() { prefix_ = "rockset."; }
 
 void BucketOptions::SetBucketName(const std::string& bucket,
                                   const std::string& prefix) {
@@ -86,12 +85,10 @@ void BucketOptions::TEST_Initialize(const std::string& bucket,
   }
 }
 
-CloudEnv::CloudEnv(const CloudEnvOptions& options, Env *base, const std::shared_ptr<Logger>& logger)
-  : cloud_env_options(options),
-    base_env_(base),
-    info_log_(logger) {
-}
-  
+CloudEnv::CloudEnv(const CloudEnvOptions& options, Env* base,
+                   const std::shared_ptr<Logger>& logger)
+    : cloud_env_options(options), base_env_(base), info_log_(logger) {}
+
 CloudEnv::~CloudEnv() {}
 
 Status CloudEnv::NewAwsEnv(
@@ -101,12 +98,17 @@ Status CloudEnv::NewAwsEnv(
     const std::string& dest_cloud_region, const CloudEnvOptions& cloud_options,
     const std::shared_ptr<Logger>& logger, CloudEnv** cenv) {
   CloudEnvOptions options = cloud_options;
-  if (!src_cloud_bucket.empty()) options.src_bucket.SetBucketName(src_cloud_bucket);
-  if (!src_cloud_object.empty()) options.src_bucket.SetObjectPath(src_cloud_object);
+  if (!src_cloud_bucket.empty())
+    options.src_bucket.SetBucketName(src_cloud_bucket);
+  if (!src_cloud_object.empty())
+    options.src_bucket.SetObjectPath(src_cloud_object);
   if (!src_cloud_region.empty()) options.src_bucket.SetRegion(src_cloud_region);
-  if (!dest_cloud_bucket.empty()) options.dest_bucket.SetBucketName(dest_cloud_bucket);
-  if (!dest_cloud_object.empty()) options.dest_bucket.SetObjectPath(dest_cloud_object);
-  if (!dest_cloud_region.empty()) options.dest_bucket.SetRegion(dest_cloud_region);
+  if (!dest_cloud_bucket.empty())
+    options.dest_bucket.SetBucketName(dest_cloud_bucket);
+  if (!dest_cloud_object.empty())
+    options.dest_bucket.SetObjectPath(dest_cloud_object);
+  if (!dest_cloud_region.empty())
+    options.dest_bucket.SetRegion(dest_cloud_region);
   return NewAwsEnv(base_env, options, logger, cenv);
 }
 
@@ -118,9 +120,9 @@ Status CloudEnv::NewAwsEnv(Env* /*base_env*/,
   return Status::NotSupported("RocksDB Cloud not compiled with AWS support");
 }
 #else
-Status CloudEnv::NewAwsEnv(Env* base_env,
-                           const CloudEnvOptions& options,
-                           const std::shared_ptr<Logger> & logger, CloudEnv** cenv) {
+Status CloudEnv::NewAwsEnv(Env* base_env, const CloudEnvOptions& options,
+                           const std::shared_ptr<Logger>& logger,
+                           CloudEnv** cenv) {
   // Dump out cloud env options
   options.Dump(logger.get());
 

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+
 #include "cloud/cloud_manifest.h"
 #include "rocksdb/cloud/cloud_env_options.h"
 #include "rocksdb/env.h"
@@ -20,11 +21,123 @@ class CloudEnvImpl : public CloudEnv {
 
  public:
   // Constructor
-  CloudEnvImpl(const CloudEnvOptions & options, Env* base_env, const std::shared_ptr<Logger>& logger);
+  CloudEnvImpl(const CloudEnvOptions& options, Env* base_env,
+               const std::shared_ptr<Logger>& logger);
 
   virtual ~CloudEnvImpl();
 
   const CloudType& GetCloudType() const { return cloud_env_options.cloud_type; }
+
+  Status NewSequentialFile(const std::string& fname,
+                           std::unique_ptr<SequentialFile>* result,
+                           const EnvOptions& options) override;
+  Status NewSequentialFileCloud(const std::string& bucket,
+                                const std::string& fname,
+                                std::unique_ptr<SequentialFile>* result,
+                                const EnvOptions& options) override;
+
+  Status NewRandomAccessFile(const std::string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             const EnvOptions& options) override;
+
+  Status NewWritableFile(const std::string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         const EnvOptions& options) override;
+
+  Status ReopenWritableFile(const std::string& /*fname*/,
+                            std::unique_ptr<WritableFile>* /*result*/,
+                            const EnvOptions& /*options*/) override;
+
+  Status RenameFile(const std::string& src, const std::string& target) override;
+
+  Status LinkFile(const std::string& src, const std::string& target) override;
+
+  Status FileExists(const std::string& fname) override;
+
+  Status GetChildren(const std::string& path,
+                     std::vector<std::string>* result) override;
+
+  Status GetFileSize(const std::string& fname, uint64_t* size) override;
+
+  Status GetFileModificationTime(const std::string& fname,
+                                 uint64_t* file_mtime) override;
+
+  Status NewDirectory(const std::string& name,
+                      std::unique_ptr<Directory>* result) override;
+
+  Status CreateDir(const std::string& name) override;
+
+  Status CreateDirIfMissing(const std::string& name) override;
+
+  Status DeleteDir(const std::string& name) override;
+
+  Status NewLogger(const std::string& fname,
+                   std::shared_ptr<Logger>* result) override {
+    return base_env_->NewLogger(fname, result);
+  }
+
+  virtual void Schedule(void (*function)(void* arg), void* arg,
+                        Priority pri = LOW, void* tag = nullptr,
+                        void (*unschedFunction)(void* arg) = 0) override {
+    base_env_->Schedule(function, arg, pri, tag, unschedFunction);
+  }
+
+  virtual int UnSchedule(void* tag, Priority pri) override {
+    return base_env_->UnSchedule(tag, pri);
+  }
+
+  virtual void StartThread(void (*function)(void* arg), void* arg) override {
+    base_env_->StartThread(function, arg);
+  }
+
+  virtual void WaitForJoin() override { base_env_->WaitForJoin(); }
+
+  virtual unsigned int GetThreadPoolQueueLen(
+      Priority pri = LOW) const override {
+    return base_env_->GetThreadPoolQueueLen(pri);
+  }
+
+  virtual Status GetTestDirectory(std::string* path) override {
+    return base_env_->GetTestDirectory(path);
+  }
+
+  virtual uint64_t NowMicros() override { return base_env_->NowMicros(); }
+
+  virtual void SleepForMicroseconds(int micros) override {
+    base_env_->SleepForMicroseconds(micros);
+  }
+
+  virtual Status GetHostName(char* name, uint64_t len) override {
+    return base_env_->GetHostName(name, len);
+  }
+
+  virtual Status GetCurrentTime(int64_t* unix_time) override {
+    return base_env_->GetCurrentTime(unix_time);
+  }
+
+  virtual Status GetAbsolutePath(const std::string& db_path,
+                                 std::string* output_path) override {
+    return base_env_->GetAbsolutePath(db_path, output_path);
+  }
+
+  virtual void SetBackgroundThreads(int number, Priority pri = LOW) override {
+    base_env_->SetBackgroundThreads(number, pri);
+  }
+  int GetBackgroundThreads(Priority pri) override {
+    return base_env_->GetBackgroundThreads(pri);
+  }
+
+  virtual void IncBackgroundThreadsIfNeeded(int number, Priority pri) override {
+    base_env_->IncBackgroundThreadsIfNeeded(number, pri);
+  }
+
+  virtual std::string TimeToString(uint64_t number) override {
+    return base_env_->TimeToString(number);
+  }
+
+  virtual uint64_t GetThreadID() const override {
+    return base_env_->GetThreadID();
+  }
 
   Status SanitizeDirectory(const DBOptions& options,
                            const std::string& clone_name, bool read_only);
@@ -105,7 +218,19 @@ class CloudEnvImpl : public CloudEnv {
   }
 
  protected:
+  // Copy IDENTITY file to cloud storage. Update dbid registry.
+  Status SaveIdentityToCloud(const std::string& localfile,
+                             const std::string& idfile);
+
+  // Check if options are compatible with the storage system
+  virtual Status CheckOption(const EnvOptions& options);
+
   virtual Status Prepare();
+  // Converts a local pathname to an object name in the src bucket
+  std::string srcname(const std::string& localname);
+
+  // Converts a local pathname to an object name in the dest bucket
+  std::string destname(const std::string& localname);
 
   // Does the dir need to be re-initialized?
   Status NeedsReinitialization(const std::string& clone_dir, bool* do_reinit);

--- a/cloud/cloud_env_options.cc
+++ b/cloud/cloud_env_options.cc
@@ -2,6 +2,7 @@
 #ifndef ROCKSDB_LITE
 
 #include <cinttypes>
+
 #include "cloud/cloud_env_impl.h"
 #include "cloud/cloud_env_wrapper.h"
 #include "cloud/db_cloud_impl.h"

--- a/cloud/cloud_log_controller.cc
+++ b/cloud/cloud_log_controller.cc
@@ -19,9 +19,10 @@
 #include "util/string_util.h"
 
 namespace rocksdb {
-CloudLogWritableFile::CloudLogWritableFile(
-    CloudEnv* env, const std::string& fname, const EnvOptions& /*options*/)
-  : env_(env), fname_(fname) {}
+CloudLogWritableFile::CloudLogWritableFile(CloudEnv* env,
+                                           const std::string& fname,
+                                           const EnvOptions& /*options*/)
+    : env_(env), fname_(fname) {}
 
 CloudLogWritableFile::~CloudLogWritableFile() {}
 
@@ -78,7 +79,7 @@ Status CloudLogControllerImpl::Prepare(CloudEnv* env) {
 
 std::string CloudLogControllerImpl::GetCachePath(
     const Slice& original_pathname) const {
-  const std::string & cache_dir = GetCacheDir();
+  const std::string& cache_dir = GetCacheDir();
   return cache_dir + pathsep + basename(original_pathname.ToString());
 }
 
@@ -146,27 +147,26 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
     // If this file is not yet open, open it and store it in cache.
     if (iter == cache_fds_.end()) {
       std::unique_ptr<RandomRWFile> result;
-      st = env_->GetBaseEnv()->NewRandomRWFile(
-          pathname, &result, EnvOptions());
+      st = env_->GetBaseEnv()->NewRandomRWFile(pathname, &result, EnvOptions());
 
       if (!st.ok()) {
-          // create the file
-          std::unique_ptr<WritableFile> tmp_writable_file;
-          env_->GetBaseEnv()->NewWritableFile(pathname, &tmp_writable_file,
-                                               EnvOptions());
-          tmp_writable_file.reset();
-          // Try again.
-          st = env_->GetBaseEnv()->NewRandomRWFile(
-                  pathname, &result, EnvOptions());
+        // create the file
+        std::unique_ptr<WritableFile> tmp_writable_file;
+        env_->GetBaseEnv()->NewWritableFile(pathname, &tmp_writable_file,
+                                            EnvOptions());
+        tmp_writable_file.reset();
+        // Try again.
+        st = env_->GetBaseEnv()->NewRandomRWFile(pathname, &result,
+                                                 EnvOptions());
       }
 
       if (st.ok()) {
         cache_fds_[pathname] = std::move(result);
         Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
-            "[%s] Tailer: Successfully opened file %s and cached",
-            Name(), pathname.c_str());
+            "[%s] Tailer: Successfully opened file %s and cached", Name(),
+            pathname.c_str());
       } else {
-          return st;
+        return st;
       }
     }
 
@@ -183,7 +183,8 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
     if (iter != cache_fds_.end()) {
       Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
           "[%s] Tailer: Delete file %s, but it is still open."
-          " Closing it now..", Name(), pathname.c_str());
+          " Closing it now..",
+          Name(), pathname.c_str());
       RandomRWFile* fd = iter->second.get();
       fd->Close();
       cache_fds_.erase(iter);
@@ -191,8 +192,8 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
 
     st = env_->GetBaseEnv()->DeleteFile(pathname);
     Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
-        "[%s] Tailer: Deleted file: %s %s",
-        Name(), pathname.c_str(), st.ToString().c_str());
+        "[%s] Tailer: Deleted file: %s %s", Name(), pathname.c_str(),
+        st.ToString().c_str());
 
     if (st.IsNotFound()) {
       st = Status::OK();
@@ -205,14 +206,13 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
       cache_fds_.erase(iter);
     }
     Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
-        "[%s] Tailer: Closed file %s %s",
-        Name(), pathname.c_str(), st.ToString().c_str());
+        "[%s] Tailer: Closed file %s %s", Name(), pathname.c_str(),
+        st.ToString().c_str());
   } else {
     st = Status::IOError("Unknown operation");
     Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
-        "[%s] Tailer: Unknown operation '%x': File %s %s",
-        Name(), operation, pathname.c_str(),
-        st.ToString().c_str());
+        "[%s] Tailer: Unknown operation '%x': File %s %s", Name(), operation,
+        pathname.c_str(), st.ToString().c_str());
   }
 
   return st;
@@ -285,7 +285,7 @@ void CloudLogControllerImpl::StopTailingStream() {
 Status CloudLogControllerImpl::Retry(RetryType func) {
   Status stat;
   std::chrono::microseconds start(env_->NowMicros());
-  
+
   while (true) {
     // If command is successful, return immediately
     stat = func();

--- a/cloud/cloud_log_controller_impl.h
+++ b/cloud/cloud_log_controller_impl.h
@@ -55,6 +55,7 @@ class CloudLogControllerImpl : public CloudLogController {
   Status FileExists(const std::string& fname) override;
   Status GetFileSize(const std::string& logical_fname, uint64_t* size) override;
   virtual Status Prepare(CloudEnv* env) override;
+
  protected:
   virtual Status Initialize(CloudEnv* env);
   // Converts an original pathname to a pathname in the cache.

--- a/cloud/cloud_manifest.cc
+++ b/cloud/cloud_manifest.cc
@@ -1,9 +1,12 @@
 //  Copyright (c) 2016-present, Rockset, Inc.  All rights reserved.
 
 #include "cloud/cloud_manifest.h"
+
 #include <rocksdb/status.h>
+
 #include <algorithm>
 #include <vector>
+
 #include "db/log_reader.h"
 #include "db/log_writer.h"
 #include "file/writable_file_writer.h"

--- a/cloud/cloud_manifest.h
+++ b/cloud/cloud_manifest.h
@@ -2,7 +2,9 @@
 
 #pragma once
 #include <rocksdb/status.h>
+
 #include <vector>
+
 #include "db/log_reader.h"
 #include "db/log_writer.h"
 

--- a/cloud/cloud_manifest_test.cc
+++ b/cloud/cloud_manifest_test.cc
@@ -1,6 +1,7 @@
 // Copyright (c) 2017 Rockset
 
 #include "cloud/cloud_manifest.h"
+
 #include "env/composite_env_wrapper.h"
 #include "file/writable_file_writer.h"
 #include "rocksdb/env.h"
@@ -51,9 +52,10 @@ TEST_F(CloudManifestTest, BasicTest) {
       {
         std::unique_ptr<WritableFile> file;
         ASSERT_OK(env_->NewWritableFile(tmpfile, &file, EnvOptions()));
-        ASSERT_OK(manifest->WriteToLog(std::unique_ptr<WritableFileWriter>(
-            new WritableFileWriter(NewLegacyWritableFileWrapper(std::move(file)),
-                                   tmpfile, EnvOptions()))));        
+        ASSERT_OK(manifest->WriteToLog(
+            std::unique_ptr<WritableFileWriter>(new WritableFileWriter(
+                NewLegacyWritableFileWrapper(std::move(file)), tmpfile,
+                EnvOptions()))));
       }
 
       manifest.reset();
@@ -61,8 +63,8 @@ TEST_F(CloudManifestTest, BasicTest) {
         std::unique_ptr<SequentialFile> file;
         ASSERT_OK(env_->NewSequentialFile(tmpfile, &file, EnvOptions()));
         CloudManifest::LoadFromLog(
-            std::unique_ptr<SequentialFileReader>(
-                new SequentialFileReader(NewLegacySequentialFileWrapper(file), tmpfile)),
+            std::unique_ptr<SequentialFileReader>(new SequentialFileReader(
+                NewLegacySequentialFileWrapper(file), tmpfile)),
             &manifest);
       }
     }

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -117,6 +117,7 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
                               std::unique_ptr<CloudStorageReadableFile>* result,
                               const EnvOptions& options) override;
   virtual Status Prepare(CloudEnv* env) override;
+
  protected:
   Random64 rng_;
   virtual Status Initialize(CloudEnv* env);

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -38,9 +38,9 @@ class ConstantSizeSstFileManager : public SstFileManagerImpl {
                              int64_t rate_bytes_per_sec,
                              double max_trash_db_ratio,
                              uint64_t bytes_max_delete_chunk)
-    : SstFileManagerImpl(env, std::make_shared<LegacyFileSystemWrapper>(env),
-                         std::move(logger), rate_bytes_per_sec,
-                         max_trash_db_ratio, bytes_max_delete_chunk),
+      : SstFileManagerImpl(env, std::make_shared<LegacyFileSystemWrapper>(env),
+                           std::move(logger), rate_bytes_per_sec,
+                           max_trash_db_ratio, bytes_max_delete_chunk),
         constant_file_size_(constant_file_size) {
     assert(constant_file_size_ >= 0);
   }
@@ -322,9 +322,10 @@ Status DBCloudImpl::DoCheckpointToCloud(
   auto current_epoch = cenv->GetCloudManifest()->GetCurrentEpoch().ToString();
   auto manifest_fname = ManifestFileWithEpoch("", current_epoch);
   auto tmp_manifest_fname = manifest_fname + ".tmp";
-  LegacyFileSystemWrapper fs(base_env);    
-  st = CopyFile(&fs, GetName() + "/" + manifest_fname,
-                GetName() + "/" + tmp_manifest_fname, manifest_file_size, false);
+  LegacyFileSystemWrapper fs(base_env);
+  st =
+      CopyFile(&fs, GetName() + "/" + manifest_fname,
+               GetName() + "/" + tmp_manifest_fname, manifest_file_size, false);
   if (!st.ok()) {
     return st;
   }
@@ -377,7 +378,7 @@ Status DBCloudImpl::DoCheckpointToCloud(
   }
 
   if (!st.ok()) {
-      return st;
+    return st;
   }
 
   // Ignore errors
@@ -389,22 +390,21 @@ Status DBCloudImpl::DoCheckpointToCloud(
 }
 
 Status DBCloudImpl::ExecuteRemoteCompactionRequest(
-      const PluggableCompactionParam& inputParams,
-      PluggableCompactionResult* result ,
-      bool doSanitize) {
+    const PluggableCompactionParam& inputParams,
+    PluggableCompactionResult* result, bool doSanitize) {
   auto cenv = static_cast<CloudEnvImpl*>(GetEnv());
 
   // run the compaction request on the underlying local database
-  Status status = GetBaseDB()->ExecuteRemoteCompactionRequest(inputParams,
-		  result, doSanitize);
+  Status status = GetBaseDB()->ExecuteRemoteCompactionRequest(
+      inputParams, result, doSanitize);
   if (!status.ok()) {
     return status;
   }
 
   // convert the local pathnames to the cloud pathnames
   for (unsigned int i = 0; i < result->output_files.size(); i++) {
-      OutputFile* outfile = &result->output_files[i];
-      outfile->pathname = cenv->RemapFilename(outfile->pathname);
+    OutputFile* outfile = &result->output_files[i];
+    outfile->pathname = cenv->RemapFilename(outfile->pathname);
   }
   return Status::OK();
 }

--- a/cloud/db_cloud_impl.h
+++ b/cloud/db_cloud_impl.h
@@ -29,8 +29,7 @@ class DBCloudImpl : public DBCloud {
 
   Status ExecuteRemoteCompactionRequest(
       const PluggableCompactionParam& inputParams,
-      PluggableCompactionResult* result,
-      bool sanitize) override;
+      PluggableCompactionResult* result, bool sanitize) override;
 
  protected:
   // The CloudEnv used by this open instance.
@@ -45,5 +44,5 @@ class DBCloudImpl : public DBCloud {
 
   explicit DBCloudImpl(DB* db);
 };
-}
+}  // namespace rocksdb
 #endif  // ROCKSDB_LITE

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -30,7 +30,6 @@
 
 namespace rocksdb {
 
-
 class CloudTest : public testing::Test {
  public:
   CloudTest() {
@@ -65,8 +64,8 @@ class CloudTest : public testing::Test {
 
     CloudEnv* aenv;
     // create a dummy aws env
-    CloudEnv::NewAwsEnv(base_env_, cloud_env_options_,
-                                    options_.info_log, &aenv);
+    CloudEnv::NewAwsEnv(base_env_, cloud_env_options_, options_.info_log,
+                        &aenv);
     aenv_.reset(aenv);
     // delete all pre-existing contents from the bucket
     Status st = aenv_->GetCloudEnvOptions().storage_provider->EmptyBucket(
@@ -101,7 +100,7 @@ class CloudTest : public testing::Test {
     ASSERT_EQ(rc, 0);
   }
 
-  virtual ~CloudTest() { 
+  virtual ~CloudTest() {
     // Cleanup the cloud bucket
     if (!cloud_env_options_.src_bucket.GetBucketName().empty()) {
       CloudEnv* aenv;
@@ -114,7 +113,7 @@ class CloudTest : public testing::Test {
       }
     }
 
-    CloseDB(); 
+    CloseDB();
   }
 
   void CreateAwsEnv() {
@@ -234,18 +233,17 @@ class CloudTest : public testing::Test {
   }
 
   Status GetCloudLiveFilesSrc(std::set<uint64_t>* list) {
-    std::unique_ptr<ManifestReader>
-      manifest(new ManifestReader(options_.info_log, aenv_.get(), aenv_->GetSrcBucketName()));
+    std::unique_ptr<ManifestReader> manifest(new ManifestReader(
+        options_.info_log, aenv_.get(), aenv_->GetSrcBucketName()));
     return manifest->GetLiveFiles(aenv_->GetSrcObjectPath(), list);
   }
 
   // Verify that local files are the same as cloud files in src bucket path
   void ValidateCloudLiveFilesSrcSize() {
-
     // Loop though all the files in the cloud manifest
     std::set<uint64_t> cloud_files;
     ASSERT_OK(GetCloudLiveFilesSrc(&cloud_files));
-    for (uint64_t num: cloud_files) {
+    for (uint64_t num : cloud_files) {
       std::string pathname = MakeTableFileName(dbname_, num);
       Log(options_.info_log, "cloud file list  %s\n", pathname.c_str());
     }
@@ -255,7 +253,7 @@ class CloudTest : public testing::Test {
     uint64_t localSize = 0;
 
     // loop through all the local files and validate
-    for (std::string path: localFiles) {
+    for (std::string path : localFiles) {
       std::string cpath = aenv_->GetSrcObjectPath() + "/" + path;
       ASSERT_OK(
           aenv_->GetCloudEnvOptions().storage_provider->GetCloudObjectSize(
@@ -265,8 +263,10 @@ class CloudTest : public testing::Test {
       std::string lpath = dbname_ + "/" + path;
       ASSERT_OK(aenv_->GetBaseEnv()->GetFileSize(lpath, &localSize));
       ASSERT_TRUE(localSize == cloudSize);
-      Log(options_.info_log, "local file %s size %" PRIu64 "\n", lpath.c_str(), localSize);
-      Log(options_.info_log, "cloud file %s size %" PRIu64 "\n", cpath.c_str(), cloudSize);
+      Log(options_.info_log, "local file %s size %" PRIu64 "\n", lpath.c_str(),
+          localSize);
+      Log(options_.info_log, "cloud file %s size %" PRIu64 "\n", cpath.c_str(),
+          cloudSize);
       printf("local file %s size %" PRIu64 "\n", lpath.c_str(), localSize);
       printf("cloud file %s size %" PRIu64 "\n", cpath.c_str(), cloudSize);
     }
@@ -357,8 +357,7 @@ TEST_F(CloudTest, Newdb) {
     // Create and Open a new ephemeral instance
     std::unique_ptr<CloudEnv> cloud_env;
     std::unique_ptr<DBCloud> cloud_db;
-    CloneDB("newdb1", "", "", &cloud_db,
-            &cloud_env);
+    CloneDB("newdb1", "", "", &cloud_db, &cloud_env);
 
     // Retrieve the id of the first reopen
     ASSERT_OK(cloud_db->GetDbIdentity(newdb1_dbid));
@@ -393,12 +392,12 @@ TEST_F(CloudTest, Newdb) {
     ASSERT_TRUE(cloud_db->Get(ReadOptions(), "Dhruba", &value).IsNotFound());
   }
   {
-    // Create another ephemeral instance using a different local dir but the same two
-    // buckets as newdb1. This should be identical in contents with newdb1.
+    // Create another ephemeral instance using a different local dir but the
+    // same two buckets as newdb1. This should be identical in contents with
+    // newdb1.
     std::unique_ptr<CloudEnv> cloud_env;
     std::unique_ptr<DBCloud> cloud_db;
-    CloneDB("newdb2", "", "", &cloud_db,
-            &cloud_env);
+    CloneDB("newdb2", "", "", &cloud_db, &cloud_env);
 
     // Retrieve the id of the second clone db
     ASSERT_OK(cloud_db->GetDbIdentity(newdb2_dbid));
@@ -502,8 +501,8 @@ TEST_F(CloudTest, TrueClone) {
     std::unique_ptr<CloudEnv> cloud_env;
     std::unique_ptr<DBCloud> cloud_db;
     CloneDB("localpath3",  // xxx try with localpath2
-            cloud_env_options_.src_bucket.GetBucketName(),
-            clone_path2, &cloud_db, &cloud_env);
+            cloud_env_options_.src_bucket.GetBucketName(), clone_path2,
+            &cloud_db, &cloud_env);
 
     // Retrieve the id of the clone db
     ASSERT_OK(cloud_db->GetDbIdentity(newdb3_dbid));
@@ -582,7 +581,6 @@ TEST_F(CloudTest, KeepLocalFiles) {
   CloseDB();
   ValidateCloudLiveFilesSrcSize();
 }
-
 
 TEST_F(CloudTest, CopyToFromS3) {
   std::string fname = dbname_ + "/100000.sst";
@@ -687,7 +685,8 @@ TEST_F(CloudTest, Savepoint) {
     // This is true clone and should have all the contents of the masterdb
     std::unique_ptr<CloudEnv> cloud_env;
     std::unique_ptr<DBCloud> cloud_db;
-    CloneDB("localpath1", cloud_env_options_.src_bucket.GetBucketName(), dest_path, &cloud_db, &cloud_env);
+    CloneDB("localpath1", cloud_env_options_.src_bucket.GetBucketName(),
+            dest_path, &cloud_db, &cloud_env);
 
     // check that the original kv appears in the clone
     value.clear();
@@ -800,8 +799,8 @@ TEST_F(CloudTest, DirectReads) {
 TEST_F(CloudTest, KeepLocalLogKafka) {
   cloud_env_options_.keep_local_log_files = false;
   cloud_env_options_.log_type = LogType::kLogKafka;
-  cloud_env_options_.kafka_log_options.client_config_params["metadata.broker.list"]
-      = "localhost:9092";
+  cloud_env_options_.kafka_log_options
+      .client_config_params["metadata.broker.list"] = "localhost:9092";
 
   OpenDB();
 
@@ -881,7 +880,7 @@ TEST_F(CloudTest, TwoDBsOneBucket) {
 
   OpenDB();
   auto firstManifestFile =
-    aenv_->GetDestObjectPath() + "/" +
+      aenv_->GetDestObjectPath() + "/" +
       ((CloudEnvImpl*)aenv_.get())->RemapFilename("MANIFEST-1");
   EXPECT_OK(aenv_->GetCloudEnvOptions().storage_provider->ExistsCloudObject(
       aenv_->GetDestBucketName(), firstManifestFile));
@@ -1130,7 +1129,7 @@ TEST_F(CloudTest, PreloadCloudManifest) {
 //
 TEST_F(CloudTest, Ephemeral) {
   cloud_env_options_.keep_local_sst_files = true;
-  options_.level0_file_num_compaction_trigger = 100; // never compact
+  options_.level0_file_num_compaction_trigger = 100;  // never compact
 
   // Create a primary DB with two files
   OpenDB();
@@ -1150,8 +1149,7 @@ TEST_F(CloudTest, Ephemeral) {
   {
     std::unique_ptr<CloudEnv> cloud_env;
     std::unique_ptr<DBCloud> cloud_db;
-    CloneDB("db_ephemeral", "", "", &cloud_db,
-            &cloud_env);
+    CloneDB("db_ephemeral", "", "", &cloud_db, &cloud_env);
 
     // Retrieve the id of the first reopen
     ASSERT_OK(cloud_db->GetDbIdentity(newdb1_dbid));
@@ -1200,10 +1198,10 @@ TEST_F(CloudTest, Ephemeral) {
     std::unique_ptr<DBCloud> cloud_db;
     std::string dbid;
     options_.info_log = nullptr;
-    CreateLoggerFromOptions(clone_dir_ + "/db_ephemeral", options_, &options_.info_log);
+    CreateLoggerFromOptions(clone_dir_ + "/db_ephemeral", options_,
+                            &options_.info_log);
 
-    CloneDB("db_ephemeral", "", "", &cloud_db,
-            &cloud_env);
+    CloneDB("db_ephemeral", "", "", &cloud_db, &cloud_env);
 
     // Retrieve the id of this clone. It should be same as before
     ASSERT_OK(cloud_db->GetDbIdentity(dbid));
@@ -1284,7 +1282,7 @@ TEST_F(CloudTest, EphemeralOnCorruptedDB) {
 TEST_F(CloudTest, EphemeralResync) {
   cloud_env_options_.keep_local_sst_files = true;
   cloud_env_options_.ephemeral_resync_on_open = true;
-  options_.level0_file_num_compaction_trigger = 100; // never compact
+  options_.level0_file_num_compaction_trigger = 100;  // never compact
 
   // Create a primary DB with two files
   OpenDB();
@@ -1304,8 +1302,7 @@ TEST_F(CloudTest, EphemeralResync) {
   {
     std::unique_ptr<CloudEnv> cloud_env;
     std::unique_ptr<DBCloud> cloud_db;
-    CloneDB("db_ephemeral", "", "", &cloud_db,
-            &cloud_env);
+    CloneDB("db_ephemeral", "", "", &cloud_db, &cloud_env);
 
     // Retrieve the id of the first reopen
     ASSERT_OK(cloud_db->GetDbIdentity(newdb1_dbid));
@@ -1356,10 +1353,10 @@ TEST_F(CloudTest, EphemeralResync) {
     std::unique_ptr<DBCloud> cloud_db;
     std::string dbid;
     options_.info_log = nullptr;
-    CreateLoggerFromOptions(clone_dir_ + "/db_ephemeral", options_, &options_.info_log);
+    CreateLoggerFromOptions(clone_dir_ + "/db_ephemeral", options_,
+                            &options_.info_log);
 
-    CloneDB("db_ephemeral", "", "", &cloud_db,
-            &cloud_env);
+    CloneDB("db_ephemeral", "", "", &cloud_db, &cloud_env);
 
     // Retrieve the id of this clone. It should be same as before
     ASSERT_OK(cloud_db->GetDbIdentity(dbid));
@@ -1379,7 +1376,7 @@ TEST_F(CloudTest, EphemeralResync) {
 
 TEST_F(CloudTest, CheckpointToCloud) {
   cloud_env_options_.keep_local_sst_files = true;
-  options_.level0_file_num_compaction_trigger = 100; // never compact
+  options_.level0_file_num_compaction_trigger = 100;  // never compact
 
   // Pre-create the bucket.
   CreateAwsEnv();

--- a/cloud/filename.h
+++ b/cloud/filename.h
@@ -49,10 +49,10 @@ inline std::string dirname(std::string const& pathname) {
 // If s doesn't end with '/', it appends it.
 // Special case: if s is empty, we don't append '/'
 inline std::string ensure_ends_with_pathsep(std::string s) {
-    if (!s.empty() && s.back() != '/') {
-        s += '/';
-    }
-    return s;
+  if (!s.empty() && s.back() != '/') {
+    s += '/';
+  }
+  return s;
 }
 
 // If the last char of the string is the specified character, then return a

--- a/cloud/manifest_reader.cc
+++ b/cloud/manifest_reader.cc
@@ -2,6 +2,7 @@
 #ifndef ROCKSDB_LITE
 
 #include "cloud/manifest_reader.h"
+
 #include "cloud/aws/aws_env.h"
 #include "cloud/cloud_manifest.h"
 #include "cloud/db_cloud_impl.h"
@@ -31,14 +32,14 @@ Status ManifestReader::GetLiveFiles(const std::string bucket_path,
   {
     std::unique_ptr<SequentialFile> file;
     auto cloudManifestFile = CloudManifestFile(bucket_path);
-    s = cenv_->NewSequentialFileCloud(
-        bucket_prefix_, cloudManifestFile, &file, EnvOptions());
+    s = cenv_->NewSequentialFileCloud(bucket_prefix_, cloudManifestFile, &file,
+                                      EnvOptions());
     if (!s.ok()) {
       return s;
     }
     s = CloudManifest::LoadFromLog(
-        std::unique_ptr<SequentialFileReader>(
-            new SequentialFileReader(NewLegacySequentialFileWrapper(file), cloudManifestFile)),
+        std::unique_ptr<SequentialFileReader>(new SequentialFileReader(
+            NewLegacySequentialFileWrapper(file), cloudManifestFile)),
         &cloud_manifest);
     if (!s.ok()) {
       return s;
@@ -54,7 +55,8 @@ Status ManifestReader::GetLiveFiles(const std::string bucket_path,
     if (!s.ok()) {
       return s;
     }
-    file_reader.reset(new SequentialFileReader(NewLegacySequentialFileWrapper(file), manifestFile));
+    file_reader.reset(new SequentialFileReader(
+        NewLegacySequentialFileWrapper(file), manifestFile));
   }
 
   // create a callback that gets invoked whil looping through the log records
@@ -113,10 +115,11 @@ Status ManifestReader::GetMaxFileNumberFromManifest(Env* env,
 
   VersionSet::LogReporter reporter;
   reporter.status = &s;
-  log::Reader reader(NULL,
-                     std::unique_ptr<SequentialFileReader>(
-                         new SequentialFileReader(NewLegacySequentialFileWrapper(file), fname)),
-                     &reporter, true /*checksum*/, 0);
+  log::Reader reader(
+      NULL,
+      std::unique_ptr<SequentialFileReader>(new SequentialFileReader(
+          NewLegacySequentialFileWrapper(file), fname)),
+      &reporter, true /*checksum*/, 0);
 
   Slice record;
   std::string scratch;
@@ -136,5 +139,5 @@ Status ManifestReader::GetMaxFileNumberFromManifest(Env* env,
   }
   return s;
 }
-}
+}  // namespace rocksdb
 #endif /* ROCKSDB_LITE */

--- a/cloud/purge.h
+++ b/cloud/purge.h
@@ -33,5 +33,5 @@ class Purge {
   CloudEnvImpl* cenv_;
   std::shared_ptr<Logger> info_log_;
 };
-}
+}  // namespace rocksdb
 #endif  // ROCKSDB_LITE

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -88,7 +88,7 @@ DBTestBase::DBTestBase(const std::string path)
   
   env_->NewLogger(test::TmpDir(env_) + "/rocksdb-cloud.log", &info_log_);
   info_log_->SetInfoLogLevel(InfoLogLevel::DEBUG_LEVEL);
-  s3_env_ = CreateNewAwsEnv(mypath);
+  s3_env_ = CreateNewAwsEnv(mypath, env_);
 #endif
   env_->SetBackgroundThreads(1, Env::LOW);
   env_->SetBackgroundThreads(1, Env::HIGH);
@@ -643,7 +643,7 @@ Options DBTestBase::GetOptions(
 }
 
 #ifdef USE_AWS
-Env* DBTestBase::CreateNewAwsEnv(const std::string& prefix) {
+  Env* DBTestBase::CreateNewAwsEnv(const std::string& prefix, Env *parent) {
   if (!prefix.empty()) {
     fprintf(stderr, "Creating new AWS env with prefix %s\n", prefix.c_str());
   }
@@ -653,7 +653,7 @@ Env* DBTestBase::CreateNewAwsEnv(const std::string& prefix) {
   CloudEnv* cenv = nullptr;
   std::string region;
   coptions.TEST_Initialize("dbtest.", prefix, region);
-  Status st = AwsEnv::NewAwsEnv(Env::Default(), coptions, info_log_, &cenv);
+  Status st = AwsEnv::NewAwsEnv(parent, coptions, info_log_, &cenv);
   ((CloudEnvImpl*)cenv)->TEST_DisableCloudManifest();
   ((AwsEnv*)cenv)->TEST_SetFileDeletionDelay(std::chrono::seconds(0));
   ROCKS_LOG_INFO(info_log_, "Created new aws env with path %s", prefix.c_str());

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -736,7 +736,7 @@ class DBTestBase : public testing::Test {
   };
 
 #ifdef USE_AWS
-  Env* CreateNewAwsEnv(const std::string& pathPrefix);
+  Env* CreateNewAwsEnv(const std::string& pathPrefix, Env *env);
   std::shared_ptr<Logger> info_log_;
 #endif
 

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -1,12 +1,12 @@
 //  Copyright (c) 2016-present, Rockset, Inc.  All rights reserved.
 //
 #pragma once
-#include "rocksdb/env.h"
-#include "rocksdb/status.h"
-
 #include <functional>
 #include <memory>
 #include <unordered_map>
+
+#include "rocksdb/env.h"
+#include "rocksdb/status.h"
 
 namespace Aws {
 namespace Auth {
@@ -43,7 +43,7 @@ enum LogType : unsigned char {
 
 // Type of AWS access credentials
 enum class AwsAccessType {
-  kUndefined, // Use AWS SDK's default credential chain
+  kUndefined,  // Use AWS SDK's default credential chain
   kSimple,
   kInstance,
   kTaskRole,
@@ -107,23 +107,24 @@ using CloudRequestCallback =
     std::function<void(CloudRequestOpType, uint64_t, uint64_t, bool)>;
 
 class BucketOptions {
-private:
-  std::string bucket_; // The suffix for the bucket name
-  std::string prefix_; // The prefix for the bucket name.  Defaults to "rockset."
-  std::string object_; // The object path for the bucket
-  std::string region_; // The region for the bucket
-  std::string name_;   // The name of the bucket (prefix_ + bucket_)
-public:
+ private:
+  std::string bucket_;  // The suffix for the bucket name
+  std::string
+      prefix_;  // The prefix for the bucket name.  Defaults to "rockset."
+  std::string object_;  // The object path for the bucket
+  std::string region_;  // The region for the bucket
+  std::string name_;    // The name of the bucket (prefix_ + bucket_)
+ public:
   BucketOptions();
   // Sets the name of the bucket to be the new bucket name.
   // If prefix is specified, the new bucket name will be [prefix][bucket]
   // If no prefix is specified, the bucket name will use the existing prefix
   void SetBucketName(const std::string& bucket, const std::string& prefix = "");
-  const std::string & GetBucketName() const { return name_; }
-  const std::string & GetObjectPath() const { return object_; }
+  const std::string& GetBucketName() const { return name_; }
+  const std::string& GetObjectPath() const { return object_; }
   void SetObjectPath(const std::string& object) { object_ = object; }
-  const std::string & GetRegion() const { return region_; }
-  void SetRegion(const std::string& region)  { region_ = region; }
+  const std::string& GetRegion() const { return region_; }
+  void SetRegion(const std::string& region) { region_ = region; }
 
   // Initializes the bucket properties for test purposes
   void TEST_Initialize(const std::string& name_prefix,
@@ -152,10 +153,10 @@ inline bool operator!=(const BucketOptions& lhs, const BucketOptions& rhs) {
 }
 
 class AwsCloudOptions {
-public:
-  static Status GetClientConfiguration(CloudEnv *env,
-                                       const std::string& region,
-                                       Aws::Client::ClientConfiguration* config);
+ public:
+  static Status GetClientConfiguration(
+      CloudEnv* env, const std::string& region,
+      Aws::Client::ClientConfiguration* config);
 };
 
 //
@@ -163,7 +164,7 @@ public:
 // Environent used for the cloud.
 //
 class CloudEnvOptions {
-private:
+ private:
  public:
   BucketOptions src_bucket;
   BucketOptions dest_bucket;
@@ -270,9 +271,8 @@ private:
   // Default: false
   bool use_aws_transfer_manager;
 
-  // The number of object's metadata that are fetched in every iteration when listing
-  // the results of a directory
-  // Default: 5000
+  // The number of object's metadata that are fetched in every iteration when
+  // listing the results of a directory Default: 5000
   int number_objects_listed_in_one_iteration;
 
   // During opening, we get the size of all SST files currently in the
@@ -341,7 +341,8 @@ private:
 
   // Sets result based on the value of name or alt in the environment
   // Returns true if the name/alt exists in the environment, false otherwise
-  static bool GetNameFromEnvironment(const char *name, const char *alt, std::string * result);
+  static bool GetNameFromEnvironment(const char* name, const char* alt,
+                                     std::string* result);
   void TEST_Initialize(const std::string& name_prefix,
                        const std::string& object_path,
                        const std::string& region = "");
@@ -361,16 +362,16 @@ typedef std::map<std::string, std::string> DbidList;
 class CloudEnv : public Env {
  protected:
   CloudEnvOptions cloud_env_options;
-  Env* base_env_; // The underlying env
+  Env* base_env_;  // The underlying env
 
-  CloudEnv(const CloudEnvOptions& options, Env *base, const std::shared_ptr<Logger>& logger);
-public:
+  CloudEnv(const CloudEnvOptions& options, Env* base,
+           const std::shared_ptr<Logger>& logger);
+
+ public:
   std::shared_ptr<Logger> info_log_;  // informational messages
   virtual ~CloudEnv();
   // Returns the underlying env
-  Env* GetBaseEnv() {
-    return base_env_;
-  }
+  Env* GetBaseEnv() { return base_env_; }
   virtual const char* Name() const { return "cloud"; }
 
   virtual Status PreloadCloudManifest(const std::string& local_dbname) = 0;

--- a/include/rocksdb/cloud/db_cloud.h
+++ b/include/rocksdb/cloud/db_cloud.h
@@ -60,8 +60,7 @@ class DBCloud : public StackableDB {
   // cloud path names.
   virtual Status ExecuteRemoteCompactionRequest(
       const PluggableCompactionParam& inputParams,
-      PluggableCompactionResult* result,
-      bool sanitize)  = 0;
+      PluggableCompactionResult* result, bool sanitize) = 0;
 
   virtual ~DBCloud() {}
 


### PR DESCRIPTION
With the addition of the CloudStorageProvider and CloudLogController, much of the Env methods were no longer specific to AWS.  This PR moves most of these methods into the CloudEnvImpl class, so that other cloud platforms need to implement fewer methods.

Note that Env::DeleteFile was not moved as part of this PR.  DeleteFile has more infrastructure around it and will be moved in a separate PR.