### PR TITLE
Clean up use of StorageProvider

### DIFF
--- a/cloud/cloud_env.cc
+++ b/cloud/cloud_env.cc
@@ -89,7 +89,10 @@ CloudEnv::CloudEnv(const CloudEnvOptions& options, Env* base,
                    const std::shared_ptr<Logger>& logger)
     : cloud_env_options(options), base_env_(base), info_log_(logger) {}
 
-CloudEnv::~CloudEnv() {}
+CloudEnv::~CloudEnv() {
+  cloud_env_options.cloud_log_controller.reset();
+  cloud_env_options.storage_provider.reset();
+}
 
 Status CloudEnv::NewAwsEnv(
     Env* base_env, const std::string& src_cloud_bucket,

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -12,6 +12,7 @@
 #include "rocksdb/status.h"
 
 namespace rocksdb {
+class CloudStorageReadableFile;
 
 //
 // The Cloud environment
@@ -218,6 +219,29 @@ class CloudEnvImpl : public CloudEnv {
   }
 
  protected:
+  // Checks to see if the input fname exists in the dest or src bucket
+  Status ExistsCloudObject(const std::string& fname);
+
+  // Gets the cloud object fname from the dest or src bucket
+  Status GetCloudObject(const std::string& fname);
+
+  // Gets the size of the named cloud object from the dest or src bucket
+  Status GetCloudObjectSize(const std::string& fname, uint64_t* remote_size);
+
+  // Gets the modification time of the named cloud object from the dest or src
+  // bucket
+  Status GetCloudObjectModificationTime(const std::string& fname,
+                                        uint64_t* time);
+
+  // Returns the list of cloud objects from the src and dest buckets.
+  Status ListCloudObjects(const std::string& path,
+                          std::vector<std::string>* result);
+
+  // Returns a CloudStorageReadableFile from the dest or src bucket
+  Status NewCloudReadableFile(const std::string& fname,
+                              std::unique_ptr<CloudStorageReadableFile>* result,
+                              const EnvOptions& options);
+
   // Copy IDENTITY file to cloud storage. Update dbid registry.
   Status SaveIdentityToCloud(const std::string& localfile,
                              const std::string& idfile);


### PR DESCRIPTION
There were a lot of places where the code would make two calls into the StorageProvider -- one for the dest bucket and one for source.  Some -- but not all -- of the calls were guarded by a "SrcMatchesDest" check to prevent an extra call.  This checkin moves most of the calls into a single method that will check the two buckets and perform the proper checks.

Also, makes sure the storage provider and log controller are deleted prior to the cloud env completely being deleted.  This can help guard against some cases where the provider attempts to access some cloud env resources during detruction.