### PR TITLE
Fix comment referring to AWS Kinesis in the Kafka impl

### DIFF
--- a/cloud/aws/aws_kafka.cc
+++ b/cloud/aws/aws_kafka.cc
@@ -1,7 +1,7 @@
 //  Copyright (c) 2016-present, Rockset, Inc.  All rights reserved.
 //
-// This file defines an AWS-Kinesis environment for rocksdb.
-// A log file maps to a stream in Kinesis.
+// This file defines an Apache Kafka environment for rocksdb.
+// A log file maps to a topic in Kafka.
 //
 
 #include <cinttypes>


### PR DESCRIPTION
I think this kafka CloudLogWritableFile implementation was copy pasted from the Kinesis one and accidentally carried over some incorrect comments.