### PR TITLE
Add shutting_down signal to remote compaction

### DIFF
--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1811,8 +1811,8 @@ void CompactionJob::RunRemote(PluggableCompactionService* service) {
   }
 
   // Install all remotely compacted file into local files.
-  auto statuses = service->InstallFiles(sources, destinations, file_options_,
-                                        env_, shutting_down_);
+  auto statuses =
+      service->InstallFiles(sources, destinations, file_options_, env_);
   compaction_stats_.micros = env_->NowMicros() - start_micros;
 
   for (uint32_t i = 0; i < statuses.size(); ++i) {

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1764,6 +1764,7 @@ void CompactionJob::RunRemote(PluggableCompactionService* service) {
     }
     param.input_files.push_back(files_in_one_level);
   }
+  param.shutting_down = shutting_down_;
 
   // make the RPC
   status = service->Run(param, &result);
@@ -1810,8 +1811,8 @@ void CompactionJob::RunRemote(PluggableCompactionService* service) {
   }
 
   // Install all remotely compacted file into local files.
-  auto statuses =
-      service->InstallFiles(sources, destinations, file_options_, env_);
+  auto statuses = service->InstallFiles(sources, destinations, file_options_,
+                                        env_, shutting_down_);
   compaction_stats_.micros = env_->NowMicros() - start_micros;
 
   for (uint32_t i = 0; i < statuses.size(); ++i) {

--- a/include/rocksdb/pluggable_compaction.h
+++ b/include/rocksdb/pluggable_compaction.h
@@ -82,8 +82,7 @@ class PluggableCompactionService {
   virtual std::vector<Status> InstallFiles(
       const std::vector<std::string>& remote_paths,
       const std::vector<std::string>& local_paths,
-      const EnvOptions& env_options, Env* local_env,
-      const std::atomic<bool>* shutting_down) = 0;
+      const EnvOptions& env_options, Env* local_env) = 0;
 
   virtual ~PluggableCompactionService() {}
 };

--- a/include/rocksdb/pluggable_compaction.h
+++ b/include/rocksdb/pluggable_compaction.h
@@ -39,6 +39,9 @@ class PluggableCompactionParam {
 
   // The level to which the files are compacted into
   int output_level;
+
+  // Control whether the DB is shutting down
+  const std::atomic<bool>* shutting_down;
 };
 
 //
@@ -79,7 +82,8 @@ class PluggableCompactionService {
   virtual std::vector<Status> InstallFiles(
       const std::vector<std::string>& remote_paths,
       const std::vector<std::string>& local_paths,
-      const EnvOptions& env_options, Env* local_env) = 0;
+      const EnvOptions& env_options, Env* local_env,
+      const std::atomic<bool>* shutting_down) = 0;
 
   virtual ~PluggableCompactionService() {}
 };


### PR DESCRIPTION
We create V2 of the interfaces for `PluggableCompactionService` which adds `Context` parameter. Right now this context only contains `shutting_down` variable, which allows clients to short circuit the remote compaction if we try to close the DB.