### PR TITLE
Fix a bug in PutCloudObject when using transfer manager

### DIFF
--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -864,9 +864,9 @@ Status S3StorageProvider::DoPutCloudObject(const std::string& local_file,
                                            const std::string& object_path,
                                            uint64_t file_size) {
   if (s3client_->HasTransferManager()) {
-    auto handle =
-        s3client_->UploadFile(ToAwsString(local_file), ToAwsString(bucket_name),
-                              ToAwsString(object_path), file_size);
+    auto handle = s3client_->UploadFile(ToAwsString(bucket_name),
+                                        ToAwsString(object_path),
+                                        ToAwsString(local_file), file_size);
     if (handle->GetStatus() != Aws::Transfer::TransferStatus::COMPLETED) {
       auto error = handle->GetLastError();
       std::string errmsg(error.GetMessage().c_str(), error.GetMessage().size());

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -118,6 +118,7 @@ class CloudTest : public testing::Test {
 
   void CreateAwsEnv() {
     CloudEnv* aenv;
+    cloud_env_options_.use_aws_transfer_manager = true;
     ASSERT_OK(CloudEnv::NewAwsEnv(base_env_, cloud_env_options_,
                                   options_.info_log, &aenv));
     // To catch any possible file deletion bugs, we set file deletion delay to


### PR DESCRIPTION
Reported by https://github.com/rockset/rocksdb-cloud/pull/101. Since I haven't received the SLA signed, I'll just make this PR instead.

Test plan: turn on `use_aws_transfer_manager` in the test and the test will fail without this patch.