### PR TITLE
Multiple Code Cleanups

### DIFF
--- a/cloud/aws/aws_env.h
+++ b/cloud/aws/aws_env.h
@@ -19,8 +19,6 @@
 #include <unordered_map>
 
 namespace ROCKSDB_NAMESPACE {
-class S3ReadableFile;
-
 //
 // The S3 environment for rocksdb. This class overrides all the
 // file/dir access methods and delegates all other methods to the
@@ -66,21 +64,6 @@ class AwsEnv : public CloudEnvImpl {
   // explicitly make the default region be us-west-2.
   static constexpr const char* default_region = "us-west-2";
 
-  virtual Status LockFile(const std::string& fname, FileLock** lock) override;
-
-  virtual Status UnlockFile(FileLock* lock) override;
-
-  std::string GetWALCacheDir();
-
-  // Saves and retrieves the dbid->dirname mapping in S3
-  Status SaveDbid(const std::string& bucket_name, const std::string& dbid,
-                  const std::string& dirname) override;
-  Status GetPathForDbid(const std::string& bucket, const std::string& dbid,
-                        std::string* dirname) override;
-  Status GetDbidList(const std::string& bucket, DbidList* dblist) override;
-  Status DeleteDbid(const std::string& bucket,
-                    const std::string& dbid) override;
-
  private:
   //
   // The AWS credentials are specified to the constructor via
@@ -88,9 +71,6 @@ class AwsEnv : public CloudEnvImpl {
   //
   explicit AwsEnv(Env* underlying_env, const CloudEnvOptions& cloud_options,
                   const std::shared_ptr<Logger>& info_log = nullptr);
-
-  // The pathname that contains a list of all db's inside a bucket.
-  static constexpr const char* dbid_registry_ = "/.rockset/dbid/";
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/cloud/aws/aws_retry.cc
+++ b/cloud/aws/aws_retry.cc
@@ -31,7 +31,7 @@ class AwsRetryStrategy : public Aws::Client::RetryStrategy {
     default_strategy_ =
         std::make_shared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
             retryableErrors);
-    Log(InfoLogLevel::INFO_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::INFO_LEVEL, env_->GetLogger(),
         "[aws] Configured custom retry policy");
   }
 
@@ -78,7 +78,7 @@ bool AwsRetryStrategy::ShouldRetry(
       ce == Aws::Client::CoreErrors::UNKNOWN ||
       err.find("try again") != std::string::npos) {
     if (attemptedRetries <= internal_failure_num_retries_) {
-      Log(InfoLogLevel::INFO_LEVEL, env_->info_log_,
+      Log(InfoLogLevel::INFO_LEVEL, env_->GetLogger(),
           "[aws] Encountered retriable failure: %s (code %d, http %d). "
           "Exception %s. retry attempt %ld is lesser than max retries %d. "
           "Retrying...",
@@ -87,7 +87,7 @@ bool AwsRetryStrategy::ShouldRetry(
           attemptedRetries, internal_failure_num_retries_);
       return true;
     }
-    Log(InfoLogLevel::INFO_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::INFO_LEVEL, env_->GetLogger(),
         "[aws] Encountered retriable failure: %s (code %d, http %d). Exception "
         "%s. retry attempt %ld exceeds max retries %d. Aborting...",
         err.c_str(), static_cast<int>(ce),
@@ -95,7 +95,7 @@ bool AwsRetryStrategy::ShouldRetry(
         attemptedRetries, internal_failure_num_retries_);
     return false;
   }
-  Log(InfoLogLevel::WARN_LEVEL, env_->info_log_,
+  Log(InfoLogLevel::WARN_LEVEL, env_->GetLogger(),
       "[aws] Encountered S3 failure %s (code %d, http %d). Exception %s."
       " retry attempt %ld max retries %d. Using default retry policy...",
       err.c_str(), static_cast<int>(ce),

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -47,12 +47,12 @@ CloudEnvImpl::~CloudEnvImpl() {
 Status CloudEnvImpl::ExistsCloudObject(const std::string& fname) {
   Status st = Status::NotFound();
   if (HasDestBucket()) {
-    st = cloud_env_options.storage_provider->ExistsCloudObject(
-        GetDestBucketName(), destname(fname));
+    st = GetStorageProvider()->ExistsCloudObject(GetDestBucketName(),
+                                                 destname(fname));
   }
   if (st.IsNotFound() && HasSrcBucket() && !SrcMatchesDest()) {
-    st = cloud_env_options.storage_provider->ExistsCloudObject(
-        GetSrcBucketName(), srcname(fname));
+    st = GetStorageProvider()->ExistsCloudObject(GetSrcBucketName(),
+                                                 srcname(fname));
   }
   return st;
 }
@@ -60,12 +60,12 @@ Status CloudEnvImpl::ExistsCloudObject(const std::string& fname) {
 Status CloudEnvImpl::GetCloudObject(const std::string& fname) {
   Status st = Status::NotFound();
   if (HasDestBucket()) {
-    st = cloud_env_options.storage_provider->GetCloudObject(
-        GetDestBucketName(), destname(fname), fname);
+    st = GetStorageProvider()->GetCloudObject(GetDestBucketName(),
+                                              destname(fname), fname);
   }
   if (st.IsNotFound() && HasSrcBucket() && !SrcMatchesDest()) {
-    st = cloud_env_options.storage_provider->GetCloudObject(
-        GetSrcBucketName(), srcname(fname), fname);
+    st = GetStorageProvider()->GetCloudObject(GetSrcBucketName(),
+                                              srcname(fname), fname);
   }
   return st;
 }
@@ -74,12 +74,12 @@ Status CloudEnvImpl::GetCloudObjectSize(const std::string& fname,
                                         uint64_t* remote_size) {
   Status st = Status::NotFound();
   if (HasDestBucket()) {
-    st = cloud_env_options.storage_provider->GetCloudObjectSize(
-        GetDestBucketName(), destname(fname), remote_size);
+    st = GetStorageProvider()->GetCloudObjectSize(GetDestBucketName(),
+                                                  destname(fname), remote_size);
   }
   if (st.IsNotFound() && HasSrcBucket() && !SrcMatchesDest()) {
-    st = cloud_env_options.storage_provider->GetCloudObjectSize(
-        GetSrcBucketName(), srcname(fname), remote_size);
+    st = GetStorageProvider()->GetCloudObjectSize(GetSrcBucketName(),
+                                                  srcname(fname), remote_size);
   }
   return st;
 }
@@ -88,11 +88,11 @@ Status CloudEnvImpl::GetCloudObjectModificationTime(const std::string& fname,
                                                     uint64_t* time) {
   Status st = Status::NotFound();
   if (HasDestBucket()) {
-    st = cloud_env_options.storage_provider->GetCloudObjectModificationTime(
+    st = GetStorageProvider()->GetCloudObjectModificationTime(
         GetDestBucketName(), destname(fname), time);
   }
   if (st.IsNotFound() && HasSrcBucket() && !SrcMatchesDest()) {
-    st = cloud_env_options.storage_provider->GetCloudObjectModificationTime(
+    st = GetStorageProvider()->GetCloudObjectModificationTime(
         GetSrcBucketName(), srcname(fname), time);
   }
   return st;
@@ -103,24 +103,24 @@ Status CloudEnvImpl::ListCloudObjects(const std::string& path,
   Status st;
   // Fetch the list of children from both cloud buckets
   if (HasSrcBucket()) {
-    st = cloud_env_options.storage_provider->ListCloudObjects(
-        GetSrcBucketName(), GetSrcObjectPath(), result);
+    st = GetStorageProvider()->ListCloudObjects(GetSrcBucketName(),
+                                                GetSrcObjectPath(), result);
     if (!st.ok()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
           "[%s] GetChildren src bucket %s %s error from %s %s", Name(),
           GetSrcBucketName().c_str(), path.c_str(),
-          cloud_env_options.storage_provider->Name(), st.ToString().c_str());
+          GetStorageProvider()->Name(), st.ToString().c_str());
       return st;
     }
   }
   if (HasDestBucket() && !SrcMatchesDest()) {
-    st = cloud_env_options.storage_provider->ListCloudObjects(
-        GetDestBucketName(), GetDestObjectPath(), result);
+    st = GetStorageProvider()->ListCloudObjects(GetDestBucketName(),
+                                                GetDestObjectPath(), result);
     if (!st.ok()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
           "[%s] GetChildren dest bucket %s %s error from %s %s", Name(),
           GetDestBucketName().c_str(), path.c_str(),
-          cloud_env_options.storage_provider->Name(), st.ToString().c_str());
+          GetStorageProvider()->Name(), st.ToString().c_str());
     }
   }
   return st;
@@ -131,14 +131,14 @@ Status CloudEnvImpl::NewCloudReadableFile(
     const EnvOptions& options) {
   Status st = Status::NotFound();
   if (HasDestBucket()) {  // read from destination
-    st = cloud_env_options.storage_provider->NewCloudReadableFile(
+    st = GetStorageProvider()->NewCloudReadableFile(
         GetDestBucketName(), destname(fname), result, options);
     if (st.ok()) {
       return st;
     }
   }
   if (HasSrcBucket() && !SrcMatchesDest()) {  // read from src bucket
-    st = cloud_env_options.storage_provider->NewCloudReadableFile(
+    st = GetStorageProvider()->NewCloudReadableFile(
         GetSrcBucketName(), srcname(fname), result, options);
   }
   return st;
@@ -201,8 +201,8 @@ Status CloudEnvImpl::NewSequentialFileCloud(
     const std::string& bucket, const std::string& fname,
     std::unique_ptr<SequentialFile>* result, const EnvOptions& options) {
   std::unique_ptr<CloudStorageReadableFile> file;
-  Status st = cloud_env_options.storage_provider->NewCloudReadableFile(
-      bucket, fname, &file, options);
+  Status st =
+      GetStorageProvider()->NewCloudReadableFile(bucket, fname, &file, options);
   if (!st.ok()) {
     return st;
   }
@@ -316,8 +316,8 @@ Status CloudEnvImpl::NewWritableFile(const std::string& logical_fname,
 
   if (HasDestBucket() && (sstfile || identity || manifest)) {
     std::unique_ptr<CloudStorageWritableFile> f;
-    cloud_env_options.storage_provider->NewCloudWritableFile(
-        fname, GetDestBucketName(), destname(fname), &f, options);
+    GetStorageProvider()->NewCloudWritableFile(fname, GetDestBucketName(),
+                                               destname(fname), &f, options);
     s = f->status();
     if (!s.ok()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
@@ -738,8 +738,8 @@ void CloudEnvImpl::RemoveFileFromDeletionQueue(const std::string& filename) {
 Status CloudEnvImpl::CopyLocalFileToDest(const std::string& local_name,
                                          const std::string& dest_name) {
   RemoveFileFromDeletionQueue(basename(local_name));
-  return cloud_env_options.storage_provider->PutCloudObject(
-      local_name, GetDestBucketName(), dest_name);
+  return GetStorageProvider()->PutCloudObject(local_name, GetDestBucketName(),
+                                              dest_name);
 }
 
 Status CloudEnvImpl::DeleteCloudFileFromDest(const std::string& fname) {
@@ -758,8 +758,8 @@ Status CloudEnvImpl::DeleteCloudFileFromDest(const std::string& fname) {
     }
     auto path = GetDestObjectPath() + "/" + base;
     // we are ready to delete the file!
-    auto st = cloud_env_options.storage_provider->DeleteCloudObject(
-        GetDestBucketName(), path);
+    auto st =
+        GetStorageProvider()->DeleteCloudObject(GetDestBucketName(), path);
     if (!st.ok() && !st.IsNotFound()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
           "[%s] DeleteFile file %s error %s", Name(), path.c_str(),
@@ -794,8 +794,8 @@ Status CloudEnvImpl::SaveIdentityToCloud(const std::string& localfile,
 
   // Upload ID file to provider
   if (st.ok()) {
-    st = cloud_env_options.storage_provider->PutCloudObject(
-        localfile, GetDestBucketName(), idfile);
+    st = GetStorageProvider()->PutCloudObject(localfile, GetDestBucketName(),
+                                              idfile);
   }
 
   // Save mapping from ID to cloud pathname
@@ -887,8 +887,8 @@ Status CloudEnvImpl::DeleteInvisibleFiles(const std::string& dbname) {
   Status s;
   if (HasDestBucket()) {
     std::vector<std::string> pathnames;
-    s = cloud_env_options.storage_provider->ListCloudObjects(
-        GetDestBucketName(), GetDestObjectPath(), &pathnames);
+    s = GetStorageProvider()->ListCloudObjects(GetDestBucketName(),
+                                               GetDestObjectPath(), &pathnames);
     if (!s.ok()) {
       return s;
     }
@@ -1345,7 +1345,7 @@ Status CloudEnvImpl::GetCloudDbid(const std::string& local_dir,
 
   // Read dbid from src bucket if it exists
   if (HasSrcBucket()) {
-    Status st = cloud_env_options.storage_provider->GetCloudObject(
+    Status st = GetStorageProvider()->GetCloudObject(
         GetSrcBucketName(), GetSrcObjectPath() + "/IDENTITY", tmpfile);
     if (!st.ok() && !st.IsNotFound()) {
       return st;
@@ -1368,7 +1368,7 @@ Status CloudEnvImpl::GetCloudDbid(const std::string& local_dir,
 
   // Read dbid from dest bucket if it exists
   if (HasDestBucket()) {
-    Status st = cloud_env_options.storage_provider->GetCloudObject(
+    Status st = GetStorageProvider()->GetCloudObject(
         GetDestBucketName(), GetDestObjectPath() + "/IDENTITY", tmpfile);
     if (!st.ok() && !st.IsNotFound()) {
       return st;
@@ -1586,7 +1586,7 @@ Status CloudEnvImpl::SanitizeDirectory(const DBOptions& options,
   // Download IDENTITY, first try destination, then source
   if (HasDestBucket()) {
     // download IDENTITY from dest
-    st = cloud_env_options.storage_provider->GetCloudObject(
+    st = GetStorageProvider()->GetCloudObject(
         GetDestBucketName(), IdentityFileName(GetDestObjectPath()),
         IdentityFileName(local_name));
     if (!st.ok() && !st.IsNotFound()) {
@@ -1597,7 +1597,7 @@ Status CloudEnvImpl::SanitizeDirectory(const DBOptions& options,
   }
   if (!got_identity_from_dest && HasSrcBucket() && !SrcMatchesDest()) {
     // download IDENTITY from src
-    st = cloud_env_options.storage_provider->GetCloudObject(
+    st = GetStorageProvider()->GetCloudObject(
         GetSrcBucketName(), IdentityFileName(GetSrcObjectPath()),
         IdentityFileName(local_name));
     if (!st.ok() && !st.IsNotFound()) {
@@ -1679,7 +1679,7 @@ Status CloudEnvImpl::FetchCloudManifest(const std::string& local_dbname,
   }
   // first try to get cloudmanifest from dest
   if (HasDestBucket()) {
-    Status st = cloud_env_options.storage_provider->GetCloudObject(
+    Status st = GetStorageProvider()->GetCloudObject(
         GetDestBucketName(), CloudManifestFile(GetDestObjectPath()),
         cloudmanifest);
     if (!st.ok() && !st.IsNotFound()) {
@@ -1701,7 +1701,7 @@ Status CloudEnvImpl::FetchCloudManifest(const std::string& local_dbname,
   }
   // we couldn't get cloud manifest from dest, need to try from src?
   if (HasSrcBucket() && !SrcMatchesDest()) {
-    Status st = cloud_env_options.storage_provider->GetCloudObject(
+    Status st = GetStorageProvider()->GetCloudObject(
         GetSrcBucketName(), CloudManifestFile(GetSrcObjectPath()),
         cloudmanifest);
     if (!st.ok() && !st.IsNotFound()) {
@@ -1778,7 +1778,7 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
     // upload new manifest, only if we have it (i.e. this is not a new
     // database, indicated by maxFileNumber)
     if (maxFileNumber > 0) {
-      st = cloud_env_options.storage_provider->PutCloudObject(
+      st = GetStorageProvider()->PutCloudObject(
           ManifestFileWithEpoch(local_dbname, newEpoch), GetDestBucketName(),
           ManifestFileWithEpoch(GetDestObjectPath(), newEpoch));
       if (!st.ok()) {
@@ -1786,7 +1786,7 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
       }
     }
     // upload new cloud manifest
-    st = cloud_env_options.storage_provider->PutCloudObject(
+    st = GetStorageProvider()->PutCloudObject(
         CloudManifestFile(local_dbname), GetDestBucketName(),
         CloudManifestFile(GetDestObjectPath()));
     if (!st.ok()) {
@@ -1794,6 +1794,131 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
     }
   }
   return Status::OK();
+}
+
+// All db in a bucket are stored in path /.rockset/dbid/<dbid>
+// The value of the object is the pathname where the db resides.
+Status CloudEnvImpl::SaveDbid(const std::string& bucket_name,
+                              const std::string& dbid,
+                              const std::string& dirname) {
+  Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "[%s] SaveDbid dbid %s dir '%s'",
+      Name(), dbid.c_str(), dirname.c_str());
+
+  std::string dbidkey = GetDbIdKey(dbid);
+  std::unordered_map<std::string, std::string> metadata;
+  metadata["dirname"] = dirname;
+
+  Status st = GetStorageProvider()->PutCloudObjectMetadata(bucket_name, dbidkey,
+                                                           metadata);
+
+  if (!st.ok()) {
+    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+        "[%s] Bucket %s SaveDbid error in saving dbid %s dirname %s %s", Name(),
+        bucket_name.c_str(), dbid.c_str(), dirname.c_str(),
+        st.ToString().c_str());
+  } else {
+    Log(InfoLogLevel::INFO_LEVEL, info_log_,
+        "[%s] Bucket %s SaveDbid dbid %s dirname %s %s", bucket_name.c_str(),
+        Name(), dbid.c_str(), dirname.c_str(), "ok");
+  }
+  return st;
+};
+
+//
+// Given a dbid, retrieves its pathname.
+//
+Status CloudEnvImpl::GetPathForDbid(const std::string& bucket,
+                                    const std::string& dbid,
+                                    std::string* dirname) {
+  std::string dbidkey = GetDbIdKey(dbid);
+
+  Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
+      "[%s] Bucket %s GetPathForDbid dbid %s", Name(), bucket.c_str(),
+      dbid.c_str());
+
+  CloudObjectInformation info;
+  Status st =
+      GetStorageProvider()->GetCloudObjectMetadata(bucket, dbidkey, &info);
+  if (!st.ok()) {
+    if (st.IsNotFound()) {
+      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+          "[%s] %s GetPathForDbid error non-existent dbid %s %s", Name(),
+          bucket.c_str(), dbid.c_str(), st.ToString().c_str());
+    } else {
+      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+          "[%s] %s GetPathForDbid error dbid %s %s", bucket.c_str(), Name(),
+          dbid.c_str(), st.ToString().c_str());
+    }
+    return st;
+  }
+
+  // Find "dirname" metadata that stores the pathname of the db
+  const char* kDirnameTag = "dirname";
+  auto it = info.metadata.find(kDirnameTag);
+  if (it != info.metadata.end()) {
+    *dirname = it->second;
+  } else {
+    st = Status::NotFound("GetPathForDbid");
+  }
+  Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] %s GetPathForDbid dbid %s %s",
+      Name(), bucket.c_str(), dbid.c_str(), st.ToString().c_str());
+  return st;
+}
+
+//
+// Retrieves the list of all registered dbids and their paths
+//
+Status CloudEnvImpl::GetDbidList(const std::string& bucket, DbidList* dblist) {
+  // fetch the list all all dbids
+  std::vector<std::string> dbid_list;
+  Status st = GetStorageProvider()->ListCloudObjects(bucket, kDbIdRegistry(),
+                                                     &dbid_list);
+  if (!st.ok()) {
+    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+        "[%s] %s GetDbidList error in GetChildrenFromS3 %s", Name(),
+        bucket.c_str(), st.ToString().c_str());
+    return st;
+  }
+  // for each dbid, fetch the db directory where the db data should reside
+  for (auto dbid : dbid_list) {
+    std::string dirname;
+    st = GetPathForDbid(bucket, dbid, &dirname);
+    if (!st.ok()) {
+      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+          "[%s] %s GetDbidList error in GetPathForDbid(%s) %s", Name(),
+          bucket.c_str(), dbid.c_str(), st.ToString().c_str());
+      return st;
+    }
+    // insert item into result set
+    (*dblist)[dbid] = dirname;
+  }
+  return st;
+}
+
+//
+// Deletes the specified dbid from the registry
+//
+Status CloudEnvImpl::DeleteDbid(const std::string& bucket,
+                                const std::string& dbid) {
+  // fetch the list all all dbids
+  std::string dbidkey = GetDbIdKey(dbid);
+  Status st = GetStorageProvider()->DeleteCloudObject(bucket, dbidkey);
+  Log(InfoLogLevel::DEBUG_LEVEL, info_log_,
+      "[%s] %s DeleteDbid DeleteDbid(%s) %s", Name(), bucket.c_str(),
+      dbid.c_str(), st.ToString().c_str());
+  return st;
+}
+
+Status CloudEnvImpl::LockFile(const std::string& /*fname*/, FileLock** lock) {
+  // there isn's a very good way to atomically check and create cloud file
+  *lock = nullptr;
+  return Status::OK();
+}
+
+Status CloudEnvImpl::UnlockFile(FileLock* /*lock*/) { return Status::OK(); }
+
+std::string CloudEnvImpl::GetWALCacheDir() {
+  return cloud_env_options.cloud_log_controller->GetCacheDir();
 }
 
 Status CloudEnvImpl::Prepare() {
@@ -1818,13 +1943,13 @@ Status CloudEnvImpl::Prepare() {
              cloud_env_options.dest_bucket.GetObjectPath().empty()) {
     s = Status::InvalidArgument("Must specify both dest bucket name and path");
   } else {
-    if (!cloud_env_options.storage_provider) {
+    if (!GetStorageProvider()) {
       s = Status::InvalidArgument(
           "Cloud environment requires a storage provider");
     } else {
       Header(info_log_, "     %s.storage_provider: %s", Name(),
-             cloud_env_options.storage_provider->Name());
-      s = cloud_env_options.storage_provider->Prepare(this);
+             GetStorageProvider()->Name());
+      s = GetStorageProvider()->Prepare(this);
     }
     if (s.ok()) {
       if (cloud_env_options.cloud_log_controller) {

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -143,6 +143,21 @@ class CloudEnvImpl : public CloudEnv {
     return base_env_->GetThreadID();
   }
 
+  virtual Status LockFile(const std::string& fname, FileLock** lock) override;
+
+  virtual Status UnlockFile(FileLock* lock) override;
+
+  std::string GetWALCacheDir();
+
+  // Saves and retrieves the dbid->dirname mapping in S3
+  Status SaveDbid(const std::string& bucket_name, const std::string& dbid,
+                  const std::string& dirname) override;
+  Status GetPathForDbid(const std::string& bucket, const std::string& dbid,
+                        std::string* dirname) override;
+  Status GetDbidList(const std::string& bucket, DbidList* dblist) override;
+  Status DeleteDbid(const std::string& bucket,
+                    const std::string& dbid) override;
+
   Status SanitizeDirectory(const DBOptions& options,
                            const std::string& clone_name, bool read_only);
   Status LoadCloudManifest(const std::string& local_dbname, bool read_only);
@@ -233,6 +248,13 @@ class CloudEnvImpl : public CloudEnv {
   }
 
  protected:
+  // The pathname that contains a list of all db's inside a bucket.
+  virtual const char* kDbIdRegistry() const { return "/.rockset/dbid/"; }
+
+  std::string GetDbIdKey(const std::string& dbid) {
+    return kDbIdRegistry() + dbid;
+  }
+
   // Checks to see if the input fname exists in the dest or src bucket
   Status ExistsCloudObject(const std::string& fname);
 

--- a/cloud/cloud_log_controller.cc
+++ b/cloud/cloud_log_controller.cc
@@ -37,11 +37,11 @@ CloudLogControllerImpl::~CloudLogControllerImpl() {
   if (running_) {
     // This is probably not a good situation as the derived class is partially
     // destroyed but the tailer might still be active.
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] CloudLogController closing.  Stopping stream.", Name());
     StopTailingStream();
   }
-  Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+  Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
       "[%s] CloudLogController closed.", Name());
 }
 
@@ -138,7 +138,7 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
 
   // Apply operation on cache file.
   if (operation == kAppend) {
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] Tailer: Appending %ld bytes to %s at offset %" PRIu64, Name(),
         payload.size(), pathname.c_str(), offset_in_file);
 
@@ -162,7 +162,7 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
 
       if (st.ok()) {
         cache_fds_[pathname] = std::move(result);
-        Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+        Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
             "[%s] Tailer: Successfully opened file %s and cached", Name(),
             pathname.c_str());
       } else {
@@ -173,7 +173,7 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
     RandomRWFile* fd = cache_fds_[pathname].get();
     st = fd->Write(offset_in_file, payload);
     if (!st.ok()) {
-      Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+      Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
           "[%s] Tailer: Error writing to cached file %s: %s", pathname.c_str(),
           Name(), st.ToString().c_str());
     }
@@ -181,7 +181,7 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
     // Delete file from cache directory.
     auto iter = cache_fds_.find(pathname);
     if (iter != cache_fds_.end()) {
-      Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+      Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
           "[%s] Tailer: Delete file %s, but it is still open."
           " Closing it now..",
           Name(), pathname.c_str());
@@ -191,7 +191,7 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
     }
 
     st = env_->GetBaseEnv()->DeleteFile(pathname);
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] Tailer: Deleted file: %s %s", Name(), pathname.c_str(),
         st.ToString().c_str());
 
@@ -205,12 +205,12 @@ Status CloudLogControllerImpl::Apply(const Slice& in) {
       st = fd->Close();
       cache_fds_.erase(iter);
     }
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] Tailer: Closed file %s %s", Name(), pathname.c_str(),
         st.ToString().c_str());
   } else {
     st = Status::IOError("Unknown operation");
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] Tailer: Unknown operation '%x': File %s %s", Name(), operation,
         pathname.c_str(), st.ToString().c_str());
   }
@@ -311,7 +311,7 @@ Status CloudLogControllerImpl::GetFileModificationTime(const std::string& fname,
   if (st.ok()) {
     // map  pathname to cache dir
     std::string pathname = GetCachePath(Slice(fname));
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[kinesis] GetFileModificationTime logfile %s %s", pathname.c_str(),
         "ok");
 
@@ -331,7 +331,7 @@ Status CloudLogControllerImpl::NewSequentialFile(
   if (st.ok()) {
     // map  pathname to cache dir
     std::string pathname = GetCachePath(Slice(fname));
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] NewSequentialFile logfile %s %s", Name(), pathname.c_str(), "ok");
 
     auto lambda = [this, pathname, &result, options]() -> Status {
@@ -349,7 +349,7 @@ Status CloudLogControllerImpl::NewRandomAccessFile(
   if (st.ok()) {
     // map  pathname to cache dir
     std::string pathname = GetCachePath(Slice(fname));
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] NewRandomAccessFile logfile %s %s", Name(), pathname.c_str(),
         "ok");
 
@@ -366,7 +366,7 @@ Status CloudLogControllerImpl::FileExists(const std::string& fname) {
   if (st.ok()) {
     // map  pathname to cache dir
     std::string pathname = GetCachePath(Slice(fname));
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] FileExists logfile %s %s", Name(), pathname.c_str(), "ok");
 
     auto lambda = [this, pathname]() -> Status {
@@ -383,7 +383,7 @@ Status CloudLogControllerImpl::GetFileSize(const std::string& fname,
   if (st.ok()) {
     // map  pathname to cache dir
     std::string pathname = GetCachePath(Slice(fname));
-    Log(InfoLogLevel::DEBUG_LEVEL, env_->info_log_,
+    Log(InfoLogLevel::DEBUG_LEVEL, env_->GetLogger(),
         "[%s] GetFileSize logfile %s %s", Name(), pathname.c_str(), "ok");
 
     auto lambda = [this, pathname, size]() -> Status {

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -9,8 +9,7 @@
 namespace ROCKSDB_NAMESPACE {
 class CloudStorageReadableFileImpl : public CloudStorageReadableFile {
  public:
-  CloudStorageReadableFileImpl(const std::shared_ptr<Logger>& info_log,
-                               const std::string& bucket,
+  CloudStorageReadableFileImpl(Logger* info_log, const std::string& bucket,
                                const std::string& fname, uint64_t size);
   // sequential access, read data at current offset in file
   virtual Status Read(size_t n, Slice* result, char* scratch) override;
@@ -25,7 +24,7 @@ class CloudStorageReadableFileImpl : public CloudStorageReadableFile {
   virtual Status DoCloudRead(uint64_t offset, size_t n, char* scratch,
                              uint64_t* bytes_read) const = 0;
 
-  std::shared_ptr<Logger> info_log_;
+  Logger* info_log_;
   std::string bucket_;
   std::string fname_;
   uint64_t offset_;

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -5,7 +5,6 @@
 
 #include <cinttypes>
 
-#include "cloud/aws/aws_env.h"
 #include "cloud/filename.h"
 #include "cloud/manifest_reader.h"
 #include "env/composite_env_wrapper.h"
@@ -97,7 +96,6 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
   if (!cenv->info_log_) {
     cenv->info_log_ = options.info_log;
   }
-
   // Use a constant sized SST File Manager if necesary.
   // NOTE: if user already passes in an SST File Manager, we will respect user's
   // SST File Manager instead.
@@ -215,7 +213,7 @@ Status DBCloudImpl::Savepoint() {
   std::vector<LiveFileMetaData> live_files;
   GetLiveFilesMetaData(&live_files);
 
-  auto& provider = cenv->GetCloudEnvOptions().storage_provider;
+  auto provider = cenv->GetStorageProvider();
   // If an sst file does not exist in the destination path, then remember it
   std::vector<std::string> to_copy;
   for (auto onefile : live_files) {
@@ -338,7 +336,7 @@ Status DBCloudImpl::DoCheckpointToCloud(
   thread_statuses.resize(thread_count);
 
   auto do_copy = [&](size_t threadId) {
-    auto& provider = cenv->GetCloudEnvOptions().storage_provider;
+    auto provider = cenv->GetStorageProvider();
     while (true) {
       size_t idx = next_file_to_copy.fetch_add(1);
       if (idx >= files_to_copy.size()) {

--- a/cloud/manifest_reader.cc
+++ b/cloud/manifest_reader.cc
@@ -3,7 +3,6 @@
 
 #include "cloud/manifest_reader.h"
 
-#include "cloud/aws/aws_env.h"
 #include "cloud/cloud_manifest.h"
 #include "cloud/db_cloud_impl.h"
 #include "cloud/filename.h"

--- a/cloud/purge.cc
+++ b/cloud/purge.cc
@@ -6,7 +6,6 @@
 #include <chrono>
 #include <set>
 
-#include "cloud/aws/aws_env.h"
 #include "cloud/db_cloud_impl.h"
 #include "cloud/filename.h"
 #include "cloud/manifest_reader.h"
@@ -133,8 +132,8 @@ Status CloudEnvImpl::FindObsoleteFiles(const std::string& bucket_name_prefix,
     std::string mpath = iter->second;
 
     std::vector<std::string> objects;
-    st = cloud_env_options.storage_provider->ListCloudObjects(
-        bucket_name_prefix, mpath, &objects);
+    st = GetStorageProvider()->ListCloudObjects(bucket_name_prefix, mpath,
+                                                &objects);
     if (!st.ok()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
           "[pg] Unable to list objects in bucketprefix %s path_prefix %s. %s",
@@ -171,8 +170,7 @@ Status CloudEnvImpl::FindObsoleteDbid(
     for (auto iter = dbid_list.begin(); iter != dbid_list.end(); ++iter) {
       std::unique_ptr<SequentialFile> result;
       std::string path = CloudManifestFile(iter->second);
-      st = GetCloudEnvOptions().storage_provider->ExistsCloudObject(
-          GetDestBucketName(), path);
+      st = GetStorageProvider()->ExistsCloudObject(GetDestBucketName(), path);
       // this dbid can be cleaned up
       if (st.IsNotFound()) {
         to_delete_list->push_back(iter->first);
@@ -204,8 +202,8 @@ Status CloudEnvImpl::extractParents(const std::string& bucket_name_prefix,
     // download IDENTITY
     std::string cloudfile = iter->second + "/IDENTITY";
     std::string localfile = scratch + "/.rockset_IDENTITY." + random;
-    st = GetCloudEnvOptions().storage_provider->GetCloudObject(
-        bucket_name_prefix, cloudfile, localfile);
+    st = GetStorageProvider()->GetCloudObject(bucket_name_prefix, cloudfile,
+                                              localfile);
     if (!st.ok() && !st.IsNotFound()) {
       Log(InfoLogLevel::ERROR_LEVEL, info_log_,
           "[pg] Unable to download IDENTITY file from "

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "cloud/aws/aws_env.h"
 #include "db/db_impl/db_impl.h"
 #include "db/dbformat.h"
 #include "env/mock_env.h"

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -369,9 +369,9 @@ class CloudEnv : public Env {
 
   CloudEnv(const CloudEnvOptions& options, Env* base,
            const std::shared_ptr<Logger>& logger);
-
  public:
   std::shared_ptr<Logger> info_log_;  // informational messages
+
   virtual ~CloudEnv();
   // Returns the underlying env
   Env* GetBaseEnv() { return base_env_; }
@@ -397,6 +397,10 @@ class CloudEnv : public Env {
   virtual Status DeleteDbid(const std::string& bucket_prefix,
                             const std::string& dbid) = 0;
 
+  Logger* GetLogger() const { return info_log_.get(); }
+  std::shared_ptr<CloudStorageProvider> GetStorageProvider() const {
+    return cloud_env_options.storage_provider;
+  }
   // The SrcBucketName identifies the cloud storage bucket and
   // GetSrcObjectPath specifies the path inside that bucket
   // where data files reside. The specified bucket is used in


### PR DESCRIPTION
- Remove the use of AwsEnv from most of the public API.  This will make it easier to use alternative implementations in a later PR
- Change the use of CloudEnv::info_log_.  This change will allow this value to be removed/changed from the public API (it should be part of the Options, not the CloudEnv itself)
- Add GetStorageProvider() API to simplify calls
- Moved the methods for DbId from AwsEnv to CloudEnvImpl.  This change makes CloudEnvImpl a concrete class and moves all of the standard functions to CloudEnvImpl.  AwsEnv deals only with AWS-specific code.