### PR TITLE
Make the Cloud classes into Configurable objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1066,6 +1066,7 @@ if(WITH_TESTS)
     list(APPEND TESTS
         cache/cache_test.cc
         cache/lru_cache_test.cc
+        cloud/cloud_env_test.cc
         cloud/db_cloud_test.cc
         cloud/cloud_manifest_test.cc
         cloud/cloud_scheduler_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1867,6 +1867,9 @@ remote_compaction_test: cloud/remote_compaction_test.o $(TEST_LIBRARY) $(LIBRARY
 db_cloud_test: cloud/db_cloud_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+cloud_env_test: cloud/cloud_env_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 cloud_manifest_test: cloud/cloud_manifest_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/cloud/aws/aws_env.cc
+++ b/cloud/aws/aws_env.cc
@@ -19,6 +19,7 @@
 #include "rocksdb/cloud/cloud_storage_provider.h"
 #include "rocksdb/env.h"
 #include "rocksdb/status.h"
+#include "rocksdb/utilities/object_registry.h"
 #include "rocksdb/utilities/options_type.h"
 #include "util/string_util.h"
 
@@ -42,6 +43,16 @@ static const std::unordered_map<std::string, AwsAccessType> AwsAccessTypeMap = {
     {"anonymous", AwsAccessType::kAnonymous},
 };
 
+AwsCloudAccessCredentials::AwsCloudAccessCredentials() {
+  std::string type_str;
+  if (CloudEnvOptions::GetNameFromEnvironment(
+          "ROCKSDB_AWS_ACCESS_TYPE", "rocksdb_aws_access_type", &type_str)) {
+    ParseEnum<AwsAccessType>(AwsAccessTypeMap, type_str, &type);
+  } else if (getenv("AWS_ACCESS_KEY_ID") != nullptr &&
+             getenv("AWS_SECRET_ACCESS_KEY") != nullptr) {
+    type = AwsAccessType::kEnvironment;
+  }
+}
 
 AwsAccessType AwsCloudAccessCredentials::GetAccessType() const {
   if (type != AwsAccessType::kUndefined) {
@@ -50,17 +61,12 @@ AwsAccessType AwsCloudAccessCredentials::GetAccessType() const {
     return AwsAccessType::kConfig;
   } else if (!access_key_id.empty() || !secret_key.empty()) {
     return AwsAccessType::kSimple;
+  } else if (getenv("AWS_ACCESS_KEY_ID") != nullptr &&
+             getenv("AWS_SECRET_ACCESS_KEY") != nullptr) {
+    return AwsAccessType::kEnvironment;
+  } else {
+    return AwsAccessType::kUndefined;
   }
-  return AwsAccessType::kUndefined;
-}
-
-Status AwsCloudAccessCredentials::TEST_Initialize() {
-  std::string type_str;
-  if (CloudEnvOptions::GetNameFromEnvironment(
-          "ROCKSDB_AWS_ACCESS_TYPE", "rocksdb_aws_access_type", &type_str)) {
-    ParseEnum<AwsAccessType>(AwsAccessTypeMap, type_str, &type);
-  }
-  return HasValid();
 }
 
 Status AwsCloudAccessCredentials::CheckCredentials(
@@ -193,8 +199,9 @@ Status AwsEnv::PrepareOptions(const ConfigOptions& options) {
   if (cloud_env_options.storage_provider == nullptr) {
     // If the user has not specified a storage provider, then use the default
     // provider for this CloudType
-    Status s = CloudStorageProvider::CreateFromString(options, CloudStorageProvider::kAws(),
-                                                      &cloud_env_options.storage_provider);
+    Status s = CloudStorageProvider::CreateFromString(
+        options, CloudStorageProviderImpl::kS3(),
+        &cloud_env_options.storage_provider);
     if (!s.ok()) {
       return s;
     }
@@ -215,6 +222,10 @@ Status AwsEnv::NewAwsEnv(Env* base_env, const CloudEnvOptions& cloud_options,
   if (!base_env) {
     base_env = Env::Default();
   }
+  std::unique_ptr<AwsEnv> aenv(new AwsEnv(base_env, cloud_options, info_log));
+  ConfigOptions config_options;
+  config_options.env = aenv.get();
+  status = aenv->PrepareOptions(config_options);
   if (status.ok()) {
     *cenv = aenv.release();
   }
@@ -232,5 +243,48 @@ Status AwsEnv::NewAwsEnv(Env* env, std::unique_ptr<CloudEnv>* cenv) {
   return Status::NotSupported("AWS not supported");
 #endif // USE_AWS
 }
+
+int CloudEnvImpl::RegisterAwsObjects(ObjectLibrary& library,
+                                     const std::string& /*arg*/) {
+  int count = 0;
+  library.Register<Env>(CloudEnvImpl::kAws(),
+                        [](const std::string& /*uri*/,
+                           std::unique_ptr<Env>* guard, std::string* errmsg) {
+                          std::unique_ptr<CloudEnv> cguard;
+                          Status s = AwsEnv::NewAwsEnv(Env::Default(), &cguard);
+                          if (s.ok()) {
+                            guard->reset(cguard.release());
+                            return guard->get();
+                          } else {
+                            *errmsg = s.ToString();
+                            return static_cast<Env*>(nullptr);
+                          }
+                        });
+  count++;
+  library.Register<CloudLogController>(
+      CloudLogControllerImpl::kKinesis(),
+      [](const std::string& /*uri*/, std::unique_ptr<CloudLogController>* guard,
+         std::string* errmsg) {
+        Status s = CloudLogControllerImpl::CreateKinesisController(guard);
+        if (!s.ok()) {
+          *errmsg = s.ToString();
+        }
+        return guard->get();
+      });
+  count++;
+  library.Register<CloudStorageProvider>(  // s3
+      CloudStorageProviderImpl::kS3(),
+      [](const std::string& /*uri*/,
+         std::unique_ptr<CloudStorageProvider>* guard, std::string* errmsg) {
+        Status s = CloudStorageProviderImpl::CreateS3Provider(guard);
+        if (!s.ok()) {
+          *errmsg = s.ToString();
+        }
+        return guard->get();
+      });
+  count++;
+  return count;
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 #endif // ROCKSDB_LITE

--- a/cloud/aws/aws_env.h
+++ b/cloud/aws/aws_env.h
@@ -48,10 +48,11 @@ class AwsEnv : public CloudEnvImpl {
   static Status NewAwsEnv(Env* env, const CloudEnvOptions& env_options,
                           const std::shared_ptr<Logger>& info_log,
                           CloudEnv** cenv);
-
+  static Status NewAwsEnv(Env* env, std::unique_ptr<CloudEnv>* cenv);
   virtual ~AwsEnv() {}
 
-  const char* Name() const override { return "aws"; }
+  static const char* kName() { return kAws(); }
+  const char* Name() const override { return kAws(); }
 
   // We cannot invoke Aws::ShutdownAPI from the destructor because there could
   // be
@@ -59,6 +60,7 @@ class AwsEnv : public CloudEnvImpl {
   // only once by the entire process when all AwsEnvs are destroyed.
   static void Shutdown();
 
+  Status PrepareOptions(const ConfigOptions& options) override;
   // If you do not specify a region, then S3 buckets are created in the
   // standard-region which might not satisfy read-your-own-writes. So,
   // explicitly make the default region be us-west-2.

--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -48,6 +48,7 @@
 #include "port/port.h"
 #include "rocksdb/cloud/cloud_env_options.h"
 #include "rocksdb/cloud/cloud_storage_provider.h"
+#include "rocksdb/convenience.h"
 #include "rocksdb/options.h"
 #include "util/stderr_logger.h"
 #include "util/string_util.h"
@@ -356,14 +357,16 @@ class S3WritableFile : public CloudStorageWritableFileImpl {
                  const EnvOptions& options)
       : CloudStorageWritableFileImpl(env, local_fname, bucket, cloud_fname,
                                      options) {}
-  virtual const char* Name() const override { return "s3"; }
+  virtual const char* Name() const override {
+    return CloudStorageProvider::kAws();
+  }
 };
 
 /******************** S3StorageProvider ******************/
 class S3StorageProvider : public CloudStorageProviderImpl {
  public:
   ~S3StorageProvider() override {}
-  virtual const char* Name() const override { return "s3"; }
+  virtual const char* Name() const override { return kAws(); }
   Status CreateBucket(const std::string& bucket) override;
   Status ExistsBucket(const std::string& bucket) override;
   Status EmptyBucket(const std::string& bucket_name,
@@ -409,9 +412,9 @@ class S3StorageProvider : public CloudStorageProviderImpl {
                               const std::string& object_path,
                               std::unique_ptr<CloudStorageWritableFile>* result,
                               const EnvOptions& options) override;
+  Status PrepareOptions(const ConfigOptions& options) override;
 
  protected:
-  Status Initialize(CloudEnv* env) override;
   Status DoGetCloudObject(const std::string& bucket_name,
                           const std::string& object_path,
                           const std::string& destination,
@@ -433,17 +436,18 @@ class S3StorageProvider : public CloudStorageProviderImpl {
   std::shared_ptr<AwsS3ClientWrapper> s3client_;
 };
 
-Status S3StorageProvider::Initialize(CloudEnv* env) {
-  Status status = CloudStorageProviderImpl::Initialize(env);
-  if (!status.ok()) {
-    return status;
-  }
-  const CloudEnvOptions& cloud_opts = env->GetCloudEnvOptions();
+Status S3StorageProvider::PrepareOptions(const ConfigOptions& options) {
+  auto cenv = static_cast<CloudEnv*>(options.env);
+  const CloudEnvOptions& cloud_opts = cenv->GetCloudEnvOptions();
+  if (std::string(cenv->Name()) != CloudEnv::kAws()) {
+    return Status::InvalidArgument("S3 Provider requires AWS Environment");
+  }    
   // TODO: support buckets being in different regions
-  if (!env->SrcMatchesDest() && env->HasSrcBucket() && env->HasDestBucket()) {
+  if (!cenv->SrcMatchesDest() && cenv->HasSrcBucket() &&
+      cenv->HasDestBucket()) {
     if (cloud_opts.src_bucket.GetRegion() !=
         cloud_opts.dest_bucket.GetRegion()) {
-      Log(InfoLogLevel::ERROR_LEVEL, env->GetLogger(),
+      Log(InfoLogLevel::ERROR_LEVEL, cenv->GetLogger(),
           "[aws] NewAwsEnv Buckets %s, %s in two different regions %s, %s "
           "is not supported",
           cloud_opts.src_bucket.GetBucketName().c_str(),
@@ -454,22 +458,26 @@ Status S3StorageProvider::Initialize(CloudEnv* env) {
     }
   }
   Aws::Client::ClientConfiguration config;
-  status = AwsCloudOptions::GetClientConfiguration(
-      env, cloud_opts.src_bucket.GetRegion(), &config);
+  Status status = AwsCloudOptions::GetClientConfiguration(
+      cenv, cloud_opts.src_bucket.GetRegion(), &config);
   if (status.ok()) {
     std::shared_ptr<Aws::Auth::AWSCredentialsProvider> creds;
     status = cloud_opts.credentials.GetCredentialsProvider(&creds);
     if (!status.ok()) {
-      Log(InfoLogLevel::INFO_LEVEL, env->GetLogger(),
+      Log(InfoLogLevel::INFO_LEVEL, cenv->GetLogger(),
           "[aws] NewAwsEnv - Bad AWS credentials");
     } else {
-      Header(env->GetLogger(), "S3 connection to endpoint in region: %s",
+      Header(cenv->GetLogger(), "S3 connection to endpoint in region: %s",
              config.region.c_str());
       s3client_ =
           std::make_shared<AwsS3ClientWrapper>(creds, config, cloud_opts);
     }
   }
-  return status;
+  if (!status.ok()) {
+    return status;
+  } else {
+    return CloudStorageProviderImpl::PrepareOptions(options);
+  }
 }
 
 //
@@ -906,7 +914,7 @@ Status S3StorageProvider::DoPutCloudObject(const std::string& local_file,
 #endif /* USE_AWS */
   
 Status CloudStorageProviderImpl::CreateS3Provider(
-    std::shared_ptr<CloudStorageProvider>* provider) {
+    std::unique_ptr<CloudStorageProvider>* provider) {
 #ifndef USE_AWS
   provider->reset();
   return Status::NotSupported(

--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -358,7 +358,7 @@ class S3WritableFile : public CloudStorageWritableFileImpl {
       : CloudStorageWritableFileImpl(env, local_fname, bucket, cloud_fname,
                                      options) {}
   virtual const char* Name() const override {
-    return CloudStorageProvider::kAws();
+    return CloudStorageProviderImpl::kS3();
   }
 };
 
@@ -366,7 +366,7 @@ class S3WritableFile : public CloudStorageWritableFileImpl {
 class S3StorageProvider : public CloudStorageProviderImpl {
  public:
   ~S3StorageProvider() override {}
-  virtual const char* Name() const override { return kAws(); }
+  virtual const char* Name() const override { return kS3(); }
   Status CreateBucket(const std::string& bucket) override;
   Status ExistsBucket(const std::string& bucket) override;
   Status EmptyBucket(const std::string& bucket_name,
@@ -439,9 +439,9 @@ class S3StorageProvider : public CloudStorageProviderImpl {
 Status S3StorageProvider::PrepareOptions(const ConfigOptions& options) {
   auto cenv = static_cast<CloudEnv*>(options.env);
   const CloudEnvOptions& cloud_opts = cenv->GetCloudEnvOptions();
-  if (std::string(cenv->Name()) != CloudEnv::kAws()) {
+  if (std::string(cenv->Name()) != CloudEnvImpl::kAws()) {
     return Status::InvalidArgument("S3 Provider requires AWS Environment");
-  }    
+  }
   // TODO: support buckets being in different regions
   if (!cenv->SrcMatchesDest() && cenv->HasSrcBucket() &&
       cenv->HasDestBucket()) {

--- a/cloud/cloud_env.cc
+++ b/cloud/cloud_env.cc
@@ -6,18 +6,26 @@
 #else
 #include <windows.h>
 #endif
+#include <unordered_map>
 
 #include "cloud/aws/aws_env.h"
 #include "cloud/cloud_env_impl.h"
 #include "cloud/cloud_env_wrapper.h"
+#include "cloud/cloud_log_controller_impl.h"
+#include "cloud/cloud_storage_provider_impl.h"
 #include "cloud/db_cloud_impl.h"
 #include "cloud/filename.h"
+#include "options/configurable_helper.h"
+#include "options/options_helper.h"
 #include "port/likely.h"
 #include "rocksdb/cloud/cloud_log_controller.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
+#include "rocksdb/utilities/object_registry.h"
+#include "rocksdb/utilities/options_type.h"
+#include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -100,10 +108,198 @@ void BucketOptions::TEST_Initialize(const std::string& bucket,
     region_ = region;
   }
 }
+static std::unordered_map<std::string, OptionTypeInfo>
+    bucket_options_type_info = {
+        {"object",
+         {0, OptionType::kString,
+          OptionVerificationType::kNormal, OptionTypeFlags::kCompareNever,
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const std::string& value, char* addr) {
+            auto bucket = reinterpret_cast<BucketOptions*>(addr);
+            bucket->SetObjectPath(value);
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr, std::string* value) {
+            auto bucket = reinterpret_cast<const BucketOptions*>(addr);
+            *value = bucket->GetObjectPath();
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr1, const char* addr2, std::string* /*mismatch*/) {
+            auto bucket1 = reinterpret_cast<const BucketOptions*>(addr1);
+            auto bucket2 = reinterpret_cast<const BucketOptions*>(addr2);
+            return bucket1->GetObjectPath() == bucket2->GetObjectPath();
+          }}},
+        {"region",
+         {0, OptionType::kString,
+          OptionVerificationType::kNormal, OptionTypeFlags::kCompareNever,
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const std::string& value, char* addr) {
+            auto bucket = reinterpret_cast<BucketOptions*>(addr);
+            bucket->SetRegion(value);
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr, std::string* value) {
+            auto bucket = reinterpret_cast<const BucketOptions*>(addr);
+            *value = bucket->GetRegion();
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr1, const char* addr2, std::string* /*mismatch*/) {
+            auto bucket1 = reinterpret_cast<const BucketOptions*>(addr1);
+            auto bucket2 = reinterpret_cast<const BucketOptions*>(addr2);
+            return bucket1->GetRegion() == bucket2->GetRegion();
+          }}},
+        {"prefix",
+         {0, OptionType::kString,
+          OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const std::string& value, char* addr) {
+            auto bucket = reinterpret_cast<BucketOptions*>(addr);
+            bucket->SetBucketName(bucket->GetBucketName(false), value);
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr, std::string* value) {
+            auto bucket = reinterpret_cast<const BucketOptions*>(addr);
+            *value = bucket->GetBucketPrefix();
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr1, const char* addr2, std::string* /*mismatch*/) {
+            auto bucket1 = reinterpret_cast<const BucketOptions*>(addr1);
+            auto bucket2 = reinterpret_cast<const BucketOptions*>(addr2);
+            return bucket1->GetBucketPrefix() == bucket2->GetBucketPrefix();
+          }}},
+        {"bucket",
+         {0, OptionType::kString,
+          OptionVerificationType::kNormal, OptionTypeFlags::kNone,
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const std::string& value, char* addr) {
+            auto bucket = reinterpret_cast<BucketOptions*>(addr);
+            bucket->SetBucketName(value);
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr, std::string* value) {
+            auto bucket = reinterpret_cast<const BucketOptions*>(addr);
+            *value = bucket->GetBucketName(false);
+            return Status::OK();
+          },
+          [](const ConfigOptions& /*opts*/, const std::string& /*name*/,
+             const char* addr1, const char* addr2, std::string* /*mismatch*/) {
+            auto bucket1 = reinterpret_cast<const BucketOptions*>(addr1);
+            auto bucket2 = reinterpret_cast<const BucketOptions*>(addr2);
+            return bucket1->GetBucketName(false) == bucket2->GetBucketName(false);
+          }}},
+};
+
+static CloudEnvOptions dummy_ceo_options;
+template <typename T1>
+int offset_of(T1 CloudEnvOptions::*member) {
+  return int(size_t(&(dummy_ceo_options.*member)) - size_t(&dummy_ceo_options));
+}
+
+  
+static std::unordered_map<std::string, OptionTypeInfo>
+    cloud_env_option_type_info = {
+        {"keep_local_sst_files",
+         {offset_of(&CloudEnvOptions::keep_local_sst_files), OptionType::kBoolean}},
+        {"keep_local_log_files",
+         {offset_of(&CloudEnvOptions::keep_local_log_files), OptionType::kBoolean}},
+        {"create_bucket_if_missing",
+         {offset_of(&CloudEnvOptions::create_bucket_if_missing), OptionType::kBoolean}},
+        {"validate_filesize",
+         {offset_of(&CloudEnvOptions::validate_filesize), OptionType::kBoolean}},
+        {"skip_dbid_verification",
+         {offset_of(&CloudEnvOptions::skip_dbid_verification), OptionType::kBoolean}},
+        {"ephemeral_resync_on_open",
+         {offset_of(&CloudEnvOptions::ephemeral_resync_on_open), OptionType::kBoolean}},
+        {"skip_cloud_children_files",
+         {offset_of(&CloudEnvOptions::skip_cloud_files_in_getchildren), OptionType::kBoolean}},
+        {"constant_sst_file_size_in_manager",
+         {offset_of(&CloudEnvOptions::constant_sst_file_size_in_sst_file_manager), OptionType::kInt64T}},
+        {"run_purger",
+         {offset_of(&CloudEnvOptions::run_purger), OptionType::kBoolean}},
+        {"purger_periodicity_ms",
+         {offset_of(&CloudEnvOptions::purger_periodicity_millis), OptionType::kUInt64T}},
+        
+        {"provider",
+         {offset_of(&CloudEnvOptions::storage_provider),
+          OptionType::kConfigurable, OptionVerificationType::kByNameAllowNull,
+          (OptionTypeFlags::kShared | OptionTypeFlags::kCompareLoose |
+           OptionTypeFlags::kCompareNever | OptionTypeFlags::kAllowNull),
+          [](const ConfigOptions& opts, const std::string& /*name*/,
+             const std::string& value, char* addr) {
+            auto provider =
+                reinterpret_cast<std::shared_ptr<CloudStorageProvider>*>(addr);
+            return CloudStorageProvider::CreateFromString(opts, value,
+                                                          provider);
+          }}},
+        {"controller",
+         {offset_of(&CloudEnvOptions::cloud_log_controller),
+          OptionType::kConfigurable, OptionVerificationType::kByNameAllowNull,
+          (OptionTypeFlags::kShared | OptionTypeFlags::kCompareLoose |
+           OptionTypeFlags::kCompareNever | OptionTypeFlags::kAllowNull),
+          // Creates a new TableFactory based on value
+          [](const ConfigOptions& opts, const std::string& /*name*/,
+             const std::string& value, char* addr) {
+            auto controller =
+                reinterpret_cast<std::shared_ptr<CloudLogController>*>(addr);
+            return CloudLogController::CreateFromString(opts, value,
+                                                        controller);
+          }}},
+        {"src",
+         OptionTypeInfo::Struct("src",
+                                &bucket_options_type_info, 
+                                offset_of(&CloudEnvOptions::src_bucket),
+                                OptionVerificationType::kNormal, OptionTypeFlags::kNone)
+        },
+        {"dest",
+         OptionTypeInfo::Struct("dest",
+                                &bucket_options_type_info, 
+                                offset_of(&CloudEnvOptions::dest_bucket),
+                                OptionVerificationType::kNormal, OptionTypeFlags::kNone)
+        },
+};
+  
+Status CloudEnvOptions::Configure(const ConfigOptions& config_options,
+                                  const std::string& opts_str) {
+  std::string current;
+  Status s;
+  if (!config_options.ignore_unknown_options) {
+    s = Serialize(config_options, &current);
+    if (!s.ok()) {
+      return s;
+    }
+  }
+  if (s.ok()) {
+    s = OptionTypeInfo::ParseStruct(config_options, CloudEnvOptions::kName(),
+                                    &cloud_env_option_type_info,
+                                    CloudEnvOptions::kName(), opts_str, reinterpret_cast<char*>(this));
+    if (!s.ok()) { // Something went wrong.  Attempt to reset
+      OptionTypeInfo::ParseStruct(config_options, CloudEnvOptions::kName(),
+                                  &cloud_env_option_type_info,
+                                  CloudEnvOptions::kName(), current, reinterpret_cast<char*>(this));
+    }
+  }
+  return s;
+}
+  
+Status CloudEnvOptions::Serialize(const ConfigOptions& config_options, std::string* value) const {
+  return OptionTypeInfo::SerializeStruct(config_options, CloudEnvOptions::kName(),
+                                         &cloud_env_option_type_info,
+                                         CloudEnvOptions::kName(), reinterpret_cast<const char*>(this), value);
+}
 
 CloudEnv::CloudEnv(const CloudEnvOptions& options, Env* base,
                    const std::shared_ptr<Logger>& logger)
-    : cloud_env_options(options), base_env_(base), info_log_(logger) {}
+    : cloud_env_options(options), base_env_(base), info_log_(logger) {
+  ConfigurableHelper::RegisterOptions(*this, &cloud_env_options,
+                                      &cloud_env_option_type_info);
+}
 
 CloudEnv::~CloudEnv() {
   cloud_env_options.cloud_log_controller.reset();
@@ -131,6 +327,188 @@ Status CloudEnv::NewAwsEnv(
   return NewAwsEnv(base_env, options, logger, cenv);
 }
 
+  int DoRegisterCloudObjects(ObjectLibrary& library, const std::string& /*arg*/) {
+  int count = 0;
+  // Register the Env types
+  library.Register<Env>(
+        CloudEnv::kName(),
+        [](const std::string& /*uri*/, std::unique_ptr<Env>* guard,
+           std::string* /*errmsg*/) {
+          guard->reset(new CloudEnvImpl(CloudEnvOptions(), Env::Default(), nullptr));
+          return guard->get();
+        });
+  count++;
+  library.Register<Env>(
+      CloudEnv::kAws(),
+      [](const std::string& /*uri*/, std::unique_ptr<Env>* guard,
+         std::string* errmsg) {
+        std::unique_ptr<CloudEnv> cguard;
+        Status s = AwsEnv::NewAwsEnv(Env::Default(), &cguard);
+        if (s.ok()) {
+          guard->reset(cguard.release());
+          return guard->get();
+        } else {
+          *errmsg = s.ToString();
+          return static_cast<Env*>(nullptr);
+        }
+      });
+  count++;
+
+  // Register the Cloud Log Controllers
+
+  library.Register<CloudLogController>(
+      CloudLogController::kKinesis(), 
+      [](const std::string& /*uri*/, std::unique_ptr<CloudLogController>* guard,
+         std::string* errmsg) {
+        Status s = CloudLogControllerImpl::CreateKinesisController(guard);
+        if (!s.ok()) {
+          *errmsg = s.ToString();
+        }
+        return guard->get();
+      });
+  count++;
+  
+  library.Register<CloudLogController>(
+      CloudLogController::kKafka(), 
+      [](const std::string& /*uri*/, std::unique_ptr<CloudLogController>* guard,
+         std::string* errmsg) {
+        Status s = CloudLogControllerImpl::CreateKafkaController(guard);
+        if (!s.ok()) {
+          *errmsg = s.ToString();
+        }
+        return guard->get();
+      });
+  count++;
+     
+
+  // Register the Cloud Storage Providers
+  
+  library.Register<CloudStorageProvider>( // s3
+        CloudStorageProvider::kAws(), 
+        [](const std::string& /*uri*/, std::unique_ptr<CloudStorageProvider>* guard,
+           std::string* errmsg) {
+          Status s = CloudStorageProviderImpl::CreateS3Provider(guard);
+          if (!s.ok()) {
+            *errmsg = s.ToString();
+          }
+          return guard->get();
+        });
+  count++;
+  
+  return count;
+}
+  
+void CloudEnv::RegisterCloudObjects(const std::string& arg) {
+  static std::once_flag do_once;
+  std::call_once(do_once,
+    [&]() {
+      auto library = ObjectLibrary::Default();
+      DoRegisterCloudObjects(*library, arg);
+    });
+}     
+
+Status CloudEnv::CreateFromString(const ConfigOptions& config_options, const std::string& value,
+                                  std::unique_ptr<CloudEnv>* result) {
+  RegisterCloudObjects();
+  std::string id;
+  std::unordered_map<std::string, std::string> options;  
+  Status s;
+  if (value.find("=") == std::string::npos) {
+    id = value;
+  } else {
+    s = StringToMap(value, &options);
+    if (s.ok()) {
+      auto iter = options.find("id");
+      if (iter != options.end()) {
+        id = iter->second;
+        options.erase(iter);
+      } else {
+        id = CloudEnv::kName();
+      }
+    }
+  }
+  if (!s.ok()) {
+    return s;
+  }
+  ConfigOptions copy = config_options;
+  std::unique_ptr<Env> env;
+  copy.invoke_prepare_options = false;  // Prepare here, not there
+  s = ObjectRegistry::NewInstance()->NewUniqueObject<Env>(id, &env);
+  if (s.ok()) {
+    CloudEnv* cenv = static_cast<CloudEnv*>(env.get());
+    if (!options.empty()) {
+      s = cenv->ConfigureFromMap(copy, options);
+    }
+    if (s.ok() && config_options.invoke_prepare_options) {
+      copy.invoke_prepare_options = config_options.invoke_prepare_options;
+      copy.env = cenv;
+      s = cenv->PrepareOptions(copy);
+      if (s.ok()) {
+        Options tmp;
+        s = cenv->ValidateOptions(tmp, tmp);
+      }
+    }
+  }
+  
+  if (s.ok()) {
+    result->reset(static_cast<CloudEnv*>(env.release()));
+  }
+  
+  return s;  
+}
+Status CloudEnv::CreateFromString(const ConfigOptions& config_options, const std::string& value,
+                                  const CloudEnvOptions& cloud_options,
+                                  std::unique_ptr<CloudEnv>* result) {
+  RegisterCloudObjects();
+  std::string id;
+  std::unordered_map<std::string, std::string> options;  
+  Status s;
+  if (value.find("=") == std::string::npos) {
+    id = value;
+  } else {
+    s = StringToMap(value, &options);
+    if (s.ok()) {
+      auto iter = options.find("id");
+      if (iter != options.end()) {
+        id = iter->second;
+        options.erase(iter);
+      } else {
+        id = CloudEnv::kName();
+      }
+    }
+  }
+  if (!s.ok()) {
+    return s;
+  }
+  ConfigOptions copy = config_options;
+  std::unique_ptr<Env> env;
+  copy.invoke_prepare_options = false;  // Prepare here, not there
+  s = ObjectRegistry::NewInstance()->NewUniqueObject<Env>(id, &env);
+  if (s.ok()) {
+    CloudEnv* cenv = static_cast<CloudEnv*>(env.get());
+    auto copts = cenv->GetOptions<CloudEnvOptions>();
+    *copts = cloud_options;
+    if (!options.empty()) {
+      s = cenv->ConfigureFromMap(copy, options);
+    }
+    if (s.ok() && config_options.invoke_prepare_options) {
+      copy.invoke_prepare_options = config_options.invoke_prepare_options;
+      copy.env = cenv;
+      s = cenv->PrepareOptions(copy);
+      if (s.ok()) {
+        Options tmp;
+        s = cenv->ValidateOptions(tmp, tmp);
+      }
+    }
+  }
+  
+  if (s.ok()) {
+    result->reset(static_cast<CloudEnv*>(env.release()));
+  }
+  
+  return s;  
+}
+  
 #ifndef USE_AWS
 Status CloudEnv::NewAwsEnv(Env* /*base_env*/,
                            const CloudEnvOptions& /*options*/,
@@ -142,6 +520,7 @@ Status CloudEnv::NewAwsEnv(Env* /*base_env*/,
 Status CloudEnv::NewAwsEnv(Env* base_env, const CloudEnvOptions& options,
                            const std::shared_ptr<Logger>& logger,
                            CloudEnv** cenv) {
+  CloudEnv::RegisterCloudObjects();
   // Dump out cloud env options
   options.Dump(logger.get());
 

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1932,11 +1932,11 @@ Status CloudEnvImpl::PrepareOptions(const ConfigOptions& options) {
       !cloud_env_options.keep_local_log_files) {
     if (cloud_env_options.log_type == LogType::kLogKinesis) {
       status = CloudLogController::CreateFromString(
-          options, CloudLogController::kKinesis(),
+          options, CloudLogControllerImpl::kKinesis(),
           &cloud_env_options.cloud_log_controller);
     } else if (cloud_env_options.log_type == LogType::kLogKafka) {
       status = CloudLogController::CreateFromString(
-          options, CloudLogController::kKafka(),
+          options, CloudLogControllerImpl::kKafka(),
           &cloud_env_options.cloud_log_controller);
     } else {
       status = Status::NotSupported("Unsupported log controller type");

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -14,6 +14,7 @@
 namespace ROCKSDB_NAMESPACE {
 class CloudScheduler;
 class CloudStorageReadableFile;
+class ObjectLibrary;
 
 //
 // The Cloud environment
@@ -22,6 +23,7 @@ class CloudEnvImpl : public CloudEnv {
   friend class CloudEnv;
 
  public:
+  static int RegisterAwsObjects(ObjectLibrary& library, const std::string& arg);
   // Constructor
   CloudEnvImpl(const CloudEnvOptions& options, Env* base_env,
                const std::shared_ptr<Logger>& logger);

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -25,9 +25,10 @@ class CloudEnvImpl : public CloudEnv {
   // Constructor
   CloudEnvImpl(const CloudEnvOptions& options, Env* base_env,
                const std::shared_ptr<Logger>& logger);
-
+  
   virtual ~CloudEnvImpl();
-
+  static const char *kName() { return "cloud-impl"; }
+  
   const CloudType& GetCloudType() const { return cloud_env_options.cloud_type; }
 
   Status NewSequentialFile(const std::string& fname,
@@ -247,7 +248,13 @@ class CloudEnvImpl : public CloudEnv {
     file_deletion_delay_ = delay;
   }
 
+  Status PrepareOptions(const ConfigOptions& config_options) override;
+  Status ValidateOptions(const DBOptions& /*db_opts*/,
+                         const ColumnFamilyOptions& /*cf_opts*/) const override;
+
  protected:
+  Status CheckValidity() const;
+  // Status TEST_Initialize(const std::string& name) override;
   // The pathname that contains a list of all db's inside a bucket.
   virtual const char* kDbIdRegistry() const { return "/.rockset/dbid/"; }
 
@@ -285,7 +292,6 @@ class CloudEnvImpl : public CloudEnv {
   // Check if options are compatible with the storage system
   virtual Status CheckOption(const EnvOptions& options);
 
-  virtual Status Prepare();
   // Converts a local pathname to an object name in the src bucket
   std::string srcname(const std::string& localname);
 

--- a/cloud/cloud_env_test.cc
+++ b/cloud/cloud_env_test.cc
@@ -1,0 +1,198 @@
+// Copyright (c) 2017 Rockset
+
+#include "rocksdb/convenience.h"
+#include "rocksdb/cloud/cloud_env_options.h"
+#include "rocksdb/cloud/cloud_log_controller.h"
+#include "rocksdb/cloud/cloud_storage_provider.h"
+#include "rocksdb/env.h"
+#include "test_util/testharness.h"
+
+namespace ROCKSDB_NAMESPACE {
+class CloudEnvTest : public testing::Test {
+public:
+  std::unique_ptr<CloudEnv> cenv_;
+
+  virtual ~CloudEnvTest() {
+  }
+  
+};
+
+TEST_F(CloudEnvTest, TestBucket) {
+  CloudEnvOptions copts;
+  copts.src_bucket.SetRegion("North");
+  copts.src_bucket.SetBucketName("Input", "src.");
+  ASSERT_FALSE(copts.src_bucket.IsValid());
+  copts.src_bucket.SetObjectPath("Here");
+  ASSERT_TRUE(copts.src_bucket.IsValid());
+  
+  copts.dest_bucket.SetRegion("South");
+  copts.dest_bucket.SetObjectPath("There");
+  ASSERT_FALSE(copts.dest_bucket.IsValid());  
+  copts.dest_bucket.SetBucketName("Output", "dest.");
+  ASSERT_TRUE(copts.dest_bucket.IsValid());  
+}
+
+TEST_F(CloudEnvTest, ConfigureOptions) {
+  ConfigOptions config_options;
+  CloudEnvOptions copts, copy;
+  copts.keep_local_sst_files = false;
+  copts.keep_local_log_files = false;
+  copts.create_bucket_if_missing = false;
+  copts.validate_filesize = false;
+  copts.skip_dbid_verification = false;
+  copts.ephemeral_resync_on_open = false;
+  copts.skip_cloud_files_in_getchildren = false;
+  copts.constant_sst_file_size_in_sst_file_manager = 100;
+  copts.run_purger = false;
+  copts.purger_periodicity_millis = 101;
+  
+  std::string str;
+  ASSERT_OK(copts.Serialize(config_options, &str));
+  ASSERT_OK(copy.Configure(config_options, str));
+  ASSERT_FALSE(copy.keep_local_sst_files);
+  ASSERT_FALSE(copy.keep_local_log_files);
+  ASSERT_FALSE(copy.create_bucket_if_missing);
+  ASSERT_FALSE(copy.validate_filesize);
+  ASSERT_FALSE(copy.skip_dbid_verification);
+  ASSERT_FALSE(copy.ephemeral_resync_on_open);
+  ASSERT_FALSE(copy.skip_cloud_files_in_getchildren);
+  ASSERT_FALSE(copy.run_purger);
+  ASSERT_EQ(copy.constant_sst_file_size_in_sst_file_manager, 100);
+  ASSERT_EQ(copy.purger_periodicity_millis, 101);
+
+  // Now try a different value
+  copts.keep_local_sst_files = true;
+  copts.keep_local_log_files = true;
+  copts.create_bucket_if_missing = true;
+  copts.validate_filesize = true;
+  copts.skip_dbid_verification = true;
+  copts.ephemeral_resync_on_open = true;
+  copts.skip_cloud_files_in_getchildren = true;
+  copts.constant_sst_file_size_in_sst_file_manager = 200;
+  copts.run_purger = true;
+  copts.purger_periodicity_millis = 201;
+  
+  ASSERT_OK(copts.Serialize(config_options, &str));
+  ASSERT_OK(copy.Configure(config_options, str));
+  ASSERT_TRUE(copy.keep_local_sst_files);
+  ASSERT_TRUE(copy.keep_local_log_files);
+  ASSERT_TRUE(copy.create_bucket_if_missing);
+  ASSERT_TRUE(copy.validate_filesize);
+  ASSERT_TRUE(copy.skip_dbid_verification);
+  ASSERT_TRUE(copy.ephemeral_resync_on_open);
+  ASSERT_TRUE(copy.skip_cloud_files_in_getchildren);
+  ASSERT_TRUE(copy.run_purger);
+  ASSERT_EQ(copy.constant_sst_file_size_in_sst_file_manager, 200);
+  ASSERT_EQ(copy.purger_periodicity_millis, 201);
+}
+  
+TEST_F(CloudEnvTest, ConfigureBucketOptions) {
+  ConfigOptions config_options;
+  CloudEnvOptions copts, copy;
+  std::string str;
+  copts.src_bucket.SetBucketName("source", "src.");
+  copts.src_bucket.SetObjectPath("foo");
+  copts.src_bucket.SetRegion("north");
+  copts.dest_bucket.SetBucketName("dest");
+  copts.dest_bucket.SetObjectPath("bar");
+  ASSERT_OK(copts.Serialize(config_options, &str));
+  
+  ASSERT_OK(copy.Configure(config_options, str));
+  ASSERT_EQ(copts.src_bucket.GetBucketName(), copy.src_bucket.GetBucketName());
+  ASSERT_EQ(copts.src_bucket.GetObjectPath(), copy.src_bucket.GetObjectPath());
+  ASSERT_EQ(copts.src_bucket.GetRegion(), copy.src_bucket.GetRegion());
+
+  ASSERT_EQ(copts.dest_bucket.GetBucketName(), copy.dest_bucket.GetBucketName());
+  ASSERT_EQ(copts.dest_bucket.GetObjectPath(), copy.dest_bucket.GetObjectPath());
+  ASSERT_EQ(copts.dest_bucket.GetRegion(), copy.dest_bucket.GetRegion());
+}
+  
+TEST_F(CloudEnvTest, ConfigureEnv) {
+  std::unique_ptr<CloudEnv> cenv;
+  
+  ConfigOptions config_options;
+  config_options.invoke_prepare_options = false;
+  ASSERT_OK(CloudEnv::CreateFromString(config_options, "keep_local_sst_files=true", &cenv));
+  ASSERT_NE(cenv, nullptr);
+  ASSERT_STREQ(cenv->Name(), "cloud");
+  auto copts = cenv->GetOptions<CloudEnvOptions>();
+  ASSERT_NE(copts, nullptr);
+  ASSERT_TRUE(copts->keep_local_sst_files);
+}
+  
+TEST_F(CloudEnvTest, ConfigureAwsEnv) {
+  std::unique_ptr<CloudEnv> cenv;
+  
+  ConfigOptions config_options;
+  Status s = CloudEnv::CreateFromString(config_options, "id=aws; keep_local_sst_files=true", &cenv);
+#ifdef USE_AWS
+  ASSERT_OK(s);
+  ASSERT_NE(cenv, nullptr);
+  ASSERT_STREQ(cenv->Name(), "aws");
+  auto copts = cenv->GetOptions<CloudEnvOptions>();
+  ASSERT_NE(copts, nullptr);
+  ASSERT_TRUE(copts->keep_local_sst_files);
+  ASSERT_NE(cenv->GetStorageProvider(), nullptr);
+  ASSERT_STREQ(cenv->GetStorageProvider()->Name(), CloudStorageProvider::kAws());
+#else
+  ASSERT_NOK(s);
+  ASSERT_EQ(cenv, nullptr);
+#endif
+}
+  
+TEST_F(CloudEnvTest, ConfigureS3Provider) {
+  std::unique_ptr<CloudEnv> cenv;
+  
+  ConfigOptions config_options;
+  Status s = CloudEnv::CreateFromString(config_options, "provider=s3", &cenv);
+  ASSERT_NOK(s);
+  ASSERT_EQ(cenv, nullptr);
+  
+#ifdef USE_AWS
+  ASSERT_OK(CloudEnv::CreateFromString(config_options, "id=aws; provider=s3", &cenv));
+  ASSERT_STREQ(cenv->Name(), "aws");
+  ASSERT_NE(cenv->GetStorageProvider(), nullptr);
+  ASSERT_STREQ(cenv->GetStorageProvider()->Name(), CloudStorageProvider::kAws());
+#endif
+}
+  
+TEST_F(CloudEnvTest, ConfigureKinesisController) {
+  std::unique_ptr<CloudEnv> cenv;
+  
+  ConfigOptions config_options;
+  Status s = CloudEnv::CreateFromString(config_options, "provider=mock; controller=kinesis", &cenv);
+  ASSERT_NOK(s);
+  ASSERT_EQ(cenv, nullptr);
+  
+#ifdef USE_AWS
+  ASSERT_OK(CloudEnv::CreateFromString(config_options, "id=aws; controller=kinesis", &cenv));
+  ASSERT_STREQ(cenv->Name(), "aws");
+  ASSERT_NE(cenv->GetLogController(), nullptr);
+  ASSERT_STREQ(cenv->GetLogController()->Name(), CloudLogController::kKinesis());
+#endif
+}
+  
+TEST_F(CloudEnvTest, ConfigureKafkaController) {
+  std::unique_ptr<CloudEnv> cenv;
+  
+  ConfigOptions config_options;
+  Status s = CloudEnv::CreateFromString(config_options, "provider=mock; controller=kafka", &cenv);
+#ifdef USE_KAFKA
+  ASSERT_OK(s);
+  ASSERT_NE(cenv, nullptr);
+  ASSERT_NE(cenv->GetLogController(), nullptr);
+  ASSERT_STREQ(cenv->GetLogController()->Name(), CloudLogController::kKafka());
+#else
+  ASSERT_NOK(s);
+  ASSERT_EQ(cenv, nullptr);
+#endif
+}
+
+  
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+  

--- a/cloud/cloud_log_controller_impl.h
+++ b/cloud/cloud_log_controller_impl.h
@@ -17,9 +17,9 @@ class CloudLogControllerImpl : public CloudLogController {
   // Delay in Cloud Log stream: writes to read visibility
   static const std::chrono::microseconds kRetryPeriod;
   static Status CreateKinesisController(
-      std::shared_ptr<CloudLogController>* result);
+      std::unique_ptr<CloudLogController>* result);
   static Status CreateKafkaController(
-      std::shared_ptr<CloudLogController>* result);
+      std::unique_ptr<CloudLogController>* result);
 
   static const uint32_t kAppend = 0x1;  // add a new record to a logfile
   static const uint32_t kDelete = 0x2;  // delete a log file
@@ -54,10 +54,9 @@ class CloudLogControllerImpl : public CloudLogController {
                              const EnvOptions& options) override;
   Status FileExists(const std::string& fname) override;
   Status GetFileSize(const std::string& logical_fname, uint64_t* size) override;
-  virtual Status Prepare(CloudEnv* env) override;
+  Status PrepareOptions(const ConfigOptions& options) override;
 
  protected:
-  virtual Status Initialize(CloudEnv* env);
   // Converts an original pathname to a pathname in the cache.
   std::string GetCachePath(const Slice& original_pathname) const;
 

--- a/cloud/cloud_log_controller_impl.h
+++ b/cloud/cloud_log_controller_impl.h
@@ -13,6 +13,9 @@ class CloudEnvOptions;
 
 class CloudLogControllerImpl : public CloudLogController {
  public:
+  static const char* kKafka() { return "kafka"; }
+  static const char* kKinesis() { return "kinesis"; }
+
   static constexpr const char* kCacheDir = "/tmp/ROCKSET";
   // Delay in Cloud Log stream: writes to read visibility
   static const std::chrono::microseconds kRetryPeriod;

--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -12,11 +12,12 @@
 #include "cloud/filename.h"
 #include "file/filename.h"
 #include "rocksdb/cloud/cloud_env_options.h"
+#include "rocksdb/convenience.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
+#include "rocksdb/utilities/object_registry.h"
 #include "util/coding.h"
-#include "util/stderr_logger.h"
 #include "util/string_util.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -237,28 +238,41 @@ Status CloudStorageWritableFileImpl::Sync() {
 
 CloudStorageProvider::~CloudStorageProvider() {}
 
-Status CloudStorageProvider::Prepare(CloudEnv* env) {
-  Status st;
-  if (env->HasDestBucket()) {
+Status CloudStorageProvider::CreateFromString(
+    const ConfigOptions& /*config_options*/, const std::string& id,
+    std::shared_ptr<CloudStorageProvider>* provider) {
+  if (id.empty()) {
+    provider->reset();
+    return Status::OK();
+  } else {
+    return ObjectRegistry::NewInstance()->NewSharedObject<CloudStorageProvider>(id, provider);
+  }
+}
+
+Status CloudStorageProviderImpl::PrepareOptions(const ConfigOptions& options) {
+  env_ = static_cast<CloudEnv*>(options.env);
+  Status st = CloudStorageProvider::PrepareOptions(options);
+  if (!st.ok()) {
+    return st;
+  } else if (env_->HasDestBucket()) {
     // create dest bucket if specified
-    if (ExistsBucket(env->GetDestBucketName()).ok()) {
-      Log(InfoLogLevel::INFO_LEVEL, env->GetLogger(),
+    if (ExistsBucket(env_->GetDestBucketName()).ok()) {
+      Log(InfoLogLevel::INFO_LEVEL, env_->GetLogger(),
           "[%s] Bucket %s already exists", Name(),
-          env->GetDestBucketName().c_str());
-    } else if (env->GetCloudEnvOptions().create_bucket_if_missing) {
-      Log(InfoLogLevel::INFO_LEVEL, env->GetLogger(),
+          env_->GetDestBucketName().c_str());
+    } else if (env_->GetCloudEnvOptions().create_bucket_if_missing) {
+      Log(InfoLogLevel::INFO_LEVEL, env_->GetLogger(),
           "[%s] Going to create bucket %s", Name(),
-          env->GetDestBucketName().c_str());
-      st = CreateBucket(env->GetDestBucketName());
+          env_->GetDestBucketName().c_str());
+      st = CreateBucket(env_->GetDestBucketName());
     } else {
       st = Status::NotFound(
           "Bucket not found and create_bucket_if_missing is false");
     }
     if (!st.ok()) {
-      Log(InfoLogLevel::ERROR_LEVEL, env->GetLogger(),
+      Log(InfoLogLevel::ERROR_LEVEL, env_->GetLogger(),
           "[%s] Unable to create bucket %s %s", Name(),
-          env->GetDestBucketName().c_str(), st.ToString().c_str());
-      return st;
+          env_->GetDestBucketName().c_str(), st.ToString().c_str());
     }
   }
   return st;
@@ -268,21 +282,6 @@ CloudStorageProviderImpl::CloudStorageProviderImpl() : rng_(time(nullptr)) {}
 
 CloudStorageProviderImpl::~CloudStorageProviderImpl() {}
 
-Status CloudStorageProviderImpl::Prepare(CloudEnv* env) {
-  status_ = Initialize(env);
-  if (status_.ok()) {
-    status_ = CloudStorageProvider::Prepare(env);
-  }
-  if (status_.ok()) {
-    env_ = env;
-  }
-  return status_;
-}
-
-Status CloudStorageProviderImpl::Initialize(CloudEnv* env) {
-  env_ = env;
-  return Status::OK();
-}
 
 Status CloudStorageProviderImpl::NewCloudReadableFile(
     const std::string& bucket, const std::string& fname,

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -99,7 +99,7 @@ class CloudStorageWritableFileImpl : public CloudStorageWritableFile {
 //
 class CloudStorageProviderImpl : public CloudStorageProvider {
  public:
-  static Status CreateS3Provider(std::shared_ptr<CloudStorageProvider>* result);
+  static Status CreateS3Provider(std::unique_ptr<CloudStorageProvider>* result);
 
   CloudStorageProviderImpl();
   virtual ~CloudStorageProviderImpl();
@@ -113,12 +113,10 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
                               const std::string& fname,
                               std::unique_ptr<CloudStorageReadableFile>* result,
                               const EnvOptions& options) override;
-  virtual Status Prepare(CloudEnv* env) override;
+  virtual Status PrepareOptions(const ConfigOptions& options) override;
 
  protected:
   Random64 rng_;
-  virtual Status Initialize(CloudEnv* env);
-
   virtual Status DoNewCloudReadableFile(
       const std::string& bucket, const std::string& fname, uint64_t fsize,
       const std::string& content_hash,

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -100,6 +100,7 @@ class CloudStorageWritableFileImpl : public CloudStorageWritableFile {
 class CloudStorageProviderImpl : public CloudStorageProvider {
  public:
   static Status CreateS3Provider(std::unique_ptr<CloudStorageProvider>* result);
+  static const char* kS3() { return "s3"; }
 
   CloudStorageProviderImpl();
   virtual ~CloudStorageProviderImpl();

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -56,6 +56,7 @@ enum class AwsAccessType {
 // Credentials needed to access AWS cloud service
 class AwsCloudAccessCredentials {
  public:
+  AwsCloudAccessCredentials();
   // functions to support AWS credentials
   //
   // Initialize AWS credentials using access_key_id and secret_key
@@ -63,8 +64,6 @@ class AwsCloudAccessCredentials {
                         const std::string& aws_secret_key);
   // Initialize AWS credentials using a config file
   void InitializeConfig(const std::string& aws_config_file);
-  // Initialize credentials for tests (relies on config vars)
-  Status TEST_Initialize();
 
   // test if valid AWS credentials are present
   Status HasValid() const;

--- a/include/rocksdb/cloud/cloud_log_controller.h
+++ b/include/rocksdb/cloud/cloud_log_controller.h
@@ -57,8 +57,6 @@ class CloudLogController : public Configurable {
   static Status CreateFromString(
       const ConfigOptions& config_options, const std::string& id,
       std::shared_ptr<CloudLogController>* controller);
-  static const char* kKafka() { return "kafka"; }
-  static const char* kKinesis() { return "kinesis"; }
 
   // Returns name of the cloud log type (Kinesis, etc.).
   virtual const char* Name() const = 0;

--- a/include/rocksdb/cloud/cloud_log_controller.h
+++ b/include/rocksdb/cloud/cloud_log_controller.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <thread>
 
+#include "rocksdb/configurable.h"
 #include "rocksdb/env.h"
 #include "rocksdb/status.h"
 
@@ -47,9 +48,20 @@ class CloudLogWritableFile : public WritableFile {
   Status status_;
 };
 
-class CloudLogController {
+class CloudLogController : public Configurable {
  public:
   virtual ~CloudLogController();
+  static const char* Type() { return "CloudStorageProvider"; }
+  // Creates and configures a new CloudLogController from the input options and
+  // id.
+  static Status CreateFromString(
+      const ConfigOptions& config_options, const std::string& id,
+      std::shared_ptr<CloudLogController>* controller);
+  static const char* kKafka() { return "kafka"; }
+  static const char* kKinesis() { return "kinesis"; }
+
+  // Returns name of the cloud log type (Kinesis, etc.).
+  virtual const char* Name() const = 0;
 
   // Create a stream to store all log files.
   virtual Status CreateStream(const std::string& topic) = 0;
@@ -65,8 +77,6 @@ class CloudLogController {
   virtual CloudLogWritableFile* CreateWritableFile(
       const std::string& fname, const EnvOptions& options) = 0;
 
-  // Returns name of the cloud log type (Kinesis, etc.).
-  virtual const char* Name() const { return "cloudlog"; }
 
   // Directory where files are cached locally.
   virtual const std::string& GetCacheDir() const = 0;
@@ -85,8 +95,6 @@ class CloudLogController {
   virtual Status FileExists(const std::string& fname) = 0;
   virtual Status GetFileSize(const std::string& logical_fname,
                              uint64_t* size) = 0;
-  // Prepares/Initializes the log controller for the input cloud environment
-  virtual Status Prepare(CloudEnv* env) = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/cloud/cloud_storage_provider.h
+++ b/include/rocksdb/cloud/cloud_storage_provider.h
@@ -47,9 +47,6 @@ struct CloudObjectInformation {
 
 class CloudStorageProvider : public Configurable {
  public:
-  // Create a storage provider for S3
-  static Status CreateS3Provider(std::shared_ptr<CloudStorageProvider>* result);
-
   virtual ~CloudStorageProvider();
   static const char* Type() { return "CloudStorageProvider"; }
   // Creates and configures a new CloudStorageProvider from the input options
@@ -57,7 +54,6 @@ class CloudStorageProvider : public Configurable {
   static Status CreateFromString(
       const ConfigOptions& config_options, const std::string& id,
       std::shared_ptr<CloudStorageProvider>* provider);
-  static const char* kAws() { return "s3"; }
 
   // Returns name of the cloud storage provider type (e.g., S3)
   virtual const char* Name() const = 0;

--- a/src.mk
+++ b/src.mk
@@ -371,6 +371,7 @@ TEST_MAIN_SOURCES =                                                     \
   cache/cache_test.cc                                                   \
   cache/lru_cache_test.cc                                               \
   cloud/db_cloud_test.cc                                                \
+  cloud/cloud_env_test.cc                                               \
   cloud/cloud_manifest_test.cc                                          \
   cloud/cloud_scheduler_test.cc                                         \
   cloud/remote_compaction_test.cc                                       \


### PR DESCRIPTION
Makes the Cloud classes into Configurable objects.
- Introduces a means of getting and setting the properties from name=value pairs
- Introduces CreateFromString for creating these objects from name-value pair maps
- Changes the configuration/initialization to use the Configurable infrastructure
- Adds tests for using the Configurable methods

Note that not every property in the CloudEnvOptions has been made into a name-value property. Some of these properties probably do not belong in CloudEnvOptions long-term, as they apply more to the specific type of environment or providers.