### PR TITLE
Add support to use a LRU cache to keep sst files on local storage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,6 +850,7 @@ set(SOURCES
         cloud/cloud_manifest.cc
         cloud/cloud_scheduler.cc
         cloud/cloud_storage_provider.cc
+        cloud/cloud_file_cache.cc
         db/db_impl/db_impl_remote_compaction.cc
         $<TARGET_OBJECTS:build_version>)
 

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -247,6 +247,11 @@ class CloudEnvImpl : public CloudEnv {
     file_deletion_delay_ = delay;
   }
 
+  void FileCacheDeleter(const std::string& fname);
+  void FileCacheErase(const std::string& fname);
+  uint64_t FileCacheGetCharge();
+  uint64_t FileCacheGetNumItems();
+
  protected:
   // The pathname that contains a list of all db's inside a bucket.
   virtual const char* kDbIdRegistry() const { return "/.rockset/dbid/"; }
@@ -307,6 +312,11 @@ class CloudEnvImpl : public CloudEnv {
   Status FetchCloudManifest(const std::string& local_dbname, bool force);
 
   Status RollNewEpoch(const std::string& local_dbname);
+
+  // helper methods to access the file cache
+  void FileCacheAccess(const std::string& fname);
+  void FileCacheInsert(const std::string& fname, uint64_t filesize);
+
   // The dbid of the source database that is cloned
   std::string src_dbid_;
 

--- a/cloud/cloud_file_cache.cc
+++ b/cloud/cloud_file_cache.cc
@@ -1,0 +1,120 @@
+// Copyright (c) 2021 Rockset.
+#ifndef ROCKSDB_LITE
+
+#include <cinttypes>
+
+#include "cloud/cloud_env_impl.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+namespace {
+// static method to use as a callback from the cache.
+static void DeleteEntry(const Slice& key, void* value) {
+  std::string filename(key.data());
+  CloudEnvImpl* cenv = reinterpret_cast<CloudEnvImpl*>(value);
+  cenv->FileCacheDeleter(filename);
+}
+
+// These are used to retrieve all the values from the cache.
+// Only used for unit tests.
+static CloudEnvImpl* DecodeValue(void* v) {
+  return static_cast<CloudEnvImpl*>(reinterpret_cast<CloudEnvImpl*>(v));
+}
+static std::vector<std::pair<CloudEnvImpl*, uint64_t>> callback_state;
+static void callback(void* entry, size_t charge) {
+  callback_state.push_back({DecodeValue(entry), charge});
+}
+static void clear_callback_state() { callback_state.clear(); }
+}  // namespace
+
+//
+// Touch the file so that is the the most-recent LRU item in cache.
+//
+void CloudEnvImpl::FileCacheAccess(const std::string& fname) {
+  if (!GetCloudEnvOptions().sst_file_cache) {
+    return;
+  }
+  Slice key(fname);
+  Cache::Handle* handle =
+      GetCloudEnvOptions().sst_file_cache->get()->Lookup(key);
+  if (handle) {
+    GetCloudEnvOptions().sst_file_cache->get()->Release(handle);
+  }
+  Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache access %s", Name(),
+      fname.c_str());
+}
+
+//
+// Record the file into the cache.
+//
+void CloudEnvImpl::FileCacheInsert(const std::string& fname,
+                                   uint64_t filesize) {
+  if (!GetCloudEnvOptions().sst_file_cache) {
+    return;
+  }
+
+  // insert into cache, key is the file path.
+  Slice key(fname);
+  GetCloudEnvOptions().sst_file_cache->get()->Insert(key, this, filesize,
+                                                     DeleteEntry);
+  Log(InfoLogLevel::INFO_LEVEL, info_log_,
+      "[%s] File Cache insert %s size %" PRIu64 "", Name(), fname.c_str(),
+      filesize);
+}
+
+//
+// Remove a specific entry from the cache.
+//
+void CloudEnvImpl::FileCacheErase(const std::string& fname) {
+  if (!GetCloudEnvOptions().sst_file_cache) {
+    return;
+  }
+
+  Slice key(fname);
+  GetCloudEnvOptions().sst_file_cache->get()->Erase(key);
+
+  Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache Erase %s",
+      Name(), fname.c_str());
+}
+
+//
+// When the cache is full, delete files from local store
+//
+void CloudEnvImpl::FileCacheDeleter(const std::string& fname) {
+  assert(GetCloudEnvOptions().sst_file_cache);
+
+  Status st = base_env_->DeleteFile(fname);
+  Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache purging %s %s",
+      Name(), fname.c_str(), st.ToString().c_str());
+}
+
+//
+// Get total charge in the cache.
+// This is not thread-safe and is used only for unit tests.
+//
+uint64_t CloudEnvImpl::FileCacheGetCharge() {
+  assert(GetCloudEnvOptions().sst_file_cache);
+  clear_callback_state();
+  GetCloudEnvOptions().sst_file_cache->get()->ApplyToAllCacheEntries(callback,
+                                                                     true);
+  uint64_t total = 0;
+  for (auto& it : callback_state) {
+    total += it.second;
+  }
+  return total;
+}
+
+//
+// Get total number of items in the cache.
+// This is not thread-safe and is used only for unit tests.
+//
+uint64_t CloudEnvImpl::FileCacheGetNumItems() {
+  assert(GetCloudEnvOptions().sst_file_cache);
+  clear_callback_state();
+  GetCloudEnvOptions().sst_file_cache->get()->ApplyToAllCacheEntries(callback,
+                                                                     true);
+  return callback_state.size();
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+#endif  // ROCKSDB_LITE

--- a/src.mk
+++ b/src.mk
@@ -19,6 +19,7 @@ LIB_SOURCES =                                                   \
   cloud/cloud_manifest.cc                                       \
   cloud/cloud_scheduler.cc                                      \
   cloud/cloud_storage_provider.cc                               \
+  cloud/cloud_file_cache.cc                                     \
   db/arena_wrapped_db_iter.cc                                   \
   db/blob/blob_file_addition.cc                                 \
   db/blob/blob_file_builder.cc                                  \


### PR DESCRIPTION
Summary:
Prior to this commit, you can either have all sst files in
cloud storage (which is the default) or you can have all sst files
cached in local storage (by setting keep_local_sst_files = true).

Add a CloudEnvOption sst_file_cache that uses an LRU to
cache sst files in local storage. The default setting for
sst_file_cache is null, which disables any new behaviour.

An sst file is cached in its entirety in local storage if needed.
This does not cache specific blocks of an sst file. This feature does
not cache any non-sst file (e.g logfile, manifest, etc ) at all.

1. The Get or a Scan request on the database generates a random read
request on the sst file and such a request causes the sst file to
be inserted into the local file cache. The assumtion is that sst files
that are used for serving read requests would be needed for serving
future read requests as well.

2. A compaction request generates a sequential read request on the sst
file and it does not cause the sst file to be inserted into the
local file cache. The assumption is that a sequential read for compaction
can be best served by a streaming read from the cloud storage.

3. A memtable flush generates a write request to a new sst file and this
sst file is not inserted into the local file cache.

Test Plan: added unit tests

Reviewers: igor, hieu

Subscribers: #platform

Differential Revision: https://rockset.phacility.com/D11373