### PR TITLE
Fixed initialization of sst_file_cache in the CloudEnvOptions construtor

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -238,9 +238,9 @@ Status CloudEnvImpl::NewRandomAccessFile(
 
     // Found in local storage. Update LRU cache.
     // There is a loose coupling between the sst_file_cache and the files on
-    // local storage. The sst_file_cache is only used for accounting of sst files.
-    // We do not keep a reference to the LRU cache handle when
-    // the sst file remains open by the db. If the LRU policy causes the file to be
+    // local storage. The sst_file_cache is only used for accounting of sst
+    // files. We do not keep a reference to the LRU cache handle when the sst
+    // file remains open by the db. If the LRU policy causes the file to be
     // evicted, it will be deleted from local storage, but because the db
     // already has an open file handle to it, it can continue to occupy local
     // storage space until the time the db decides to close the sst file.

--- a/cloud/cloud_file_cache.cc
+++ b/cloud/cloud_file_cache.cc
@@ -73,8 +73,8 @@ void CloudEnvImpl::FileCacheErase(const std::string& fname) {
   Slice key(fname);
   GetCloudEnvOptions().sst_file_cache->get()->Erase(key);
 
-  Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache Erase %s",
-      Name(), fname.c_str());
+  Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache Erase %s", Name(),
+      fname.c_str());
 }
 
 //

--- a/cloud/cloud_scheduler_test.cc
+++ b/cloud/cloud_scheduler_test.cc
@@ -184,7 +184,8 @@ int main(int argc, char **argv) {
 #include <stdio.h>
 
 int main(int /*argc*/, char** /*argv*/) {
-  fprintf(stderr, "SKIPPED as CloudSchedulerTest is not supported in ROCKSDB_LITE\n");
+  fprintf(stderr,
+          "SKIPPED as CloudSchedulerTest is not supported in ROCKSDB_LITE\n");
   return 0;
 }
 

--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -361,5 +361,5 @@ Status CloudStorageProviderImpl::PutCloudObject(
   return DoPutCloudObject(local_file, bucket_name, object_path, fsize);
 }
 
-#endif //ROCKSDB_LITE
+#endif  // ROCKSDB_LITE
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -336,9 +336,11 @@ class CloudEnvOptions {
       bool _use_aws_transfer_manager = false,
       int _number_objects_listed_in_one_iteration = 5000,
       int _constant_sst_file_size_in_sst_file_manager = -1,
-      bool _skip_cloud_files_in_getchildren = false)
+      bool _skip_cloud_files_in_getchildren = false,
+      std::shared_ptr<Cache>* _sst_file_cache = nullptr)
       : cloud_type(_cloud_type),
         log_type(_log_type),
+        sst_file_cache(_sst_file_cache),
         keep_local_sst_files(_keep_local_sst_files),
         keep_local_log_files(_keep_local_log_files),
         purger_periodicity_millis(_purger_periodicity_millis),


### PR DESCRIPTION

The other changes are cosmetic and are done by clang lint fixes.