### PR TITLE
If the sst_file_cache size is zero, then consider it to be disabled.

### DIFF
--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -249,6 +249,7 @@ class CloudEnvImpl : public CloudEnv {
 
   void FileCacheDeleter(const std::string& fname);
   void FileCacheErase(const std::string& fname);
+  void FileCachePurge();
   uint64_t FileCacheGetCharge();
   uint64_t FileCacheGetNumItems();
 

--- a/cloud/cloud_file_cache.cc
+++ b/cloud/cloud_file_cache.cc
@@ -8,19 +8,31 @@
 namespace ROCKSDB_NAMESPACE {
 
 namespace {
+
+// The Value inside every cached entry
+struct Value {
+  std::string path;
+  CloudEnvImpl* cenv;
+
+  Value(const std::string& _path, CloudEnvImpl* _cenv)
+      : path(_path), cenv(_cenv) {}
+};
+
 // static method to use as a callback from the cache.
-static void DeleteEntry(const Slice& key, void* value) {
+static void DeleteEntry(const Slice& key, void* v) {
+  Value* value = reinterpret_cast<Value*>(v);
   std::string filename(key.data());
-  CloudEnvImpl* cenv = reinterpret_cast<CloudEnvImpl*>(value);
-  cenv->FileCacheDeleter(filename);
+  value->cenv->FileCacheDeleter(filename);
+  delete value;
 }
 
 // These are used to retrieve all the values from the cache.
 // Only used for unit tests.
-static CloudEnvImpl* DecodeValue(void* v) {
-  return static_cast<CloudEnvImpl*>(reinterpret_cast<CloudEnvImpl*>(v));
+static Value* DecodeValue(void* v) {
+  return static_cast<Value*>(reinterpret_cast<Value*>(v));
 }
-static std::vector<std::pair<CloudEnvImpl*, uint64_t>> callback_state;
+
+static std::vector<std::pair<Value*, uint64_t>> callback_state;
 static void callback(void* entry, size_t charge) {
   callback_state.push_back({DecodeValue(entry), charge});
 }
@@ -31,14 +43,13 @@ static void clear_callback_state() { callback_state.clear(); }
 // Touch the file so that is the the most-recent LRU item in cache.
 //
 void CloudEnvImpl::FileCacheAccess(const std::string& fname) {
-  if (!GetCloudEnvOptions().sst_file_cache) {
+  if (!cloud_env_options.hasSstFileCache()) {
     return;
   }
   Slice key(fname);
-  Cache::Handle* handle =
-      GetCloudEnvOptions().sst_file_cache->get()->Lookup(key);
+  Cache::Handle* handle = cloud_env_options.sst_file_cache->Lookup(key);
   if (handle) {
-    GetCloudEnvOptions().sst_file_cache->get()->Release(handle);
+    cloud_env_options.sst_file_cache->Release(handle);
   }
   Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache access %s", Name(),
       fname.c_str());
@@ -49,14 +60,14 @@ void CloudEnvImpl::FileCacheAccess(const std::string& fname) {
 //
 void CloudEnvImpl::FileCacheInsert(const std::string& fname,
                                    uint64_t filesize) {
-  if (!GetCloudEnvOptions().sst_file_cache) {
+  if (!cloud_env_options.hasSstFileCache()) {
     return;
   }
 
   // insert into cache, key is the file path.
   Slice key(fname);
-  GetCloudEnvOptions().sst_file_cache->get()->Insert(key, this, filesize,
-                                                     DeleteEntry);
+  cloud_env_options.sst_file_cache->Insert(key, new Value(fname, this),
+                                           filesize, DeleteEntry);
   Log(InfoLogLevel::INFO_LEVEL, info_log_,
       "[%s] File Cache insert %s size %" PRIu64 "", Name(), fname.c_str(),
       filesize);
@@ -66,12 +77,15 @@ void CloudEnvImpl::FileCacheInsert(const std::string& fname,
 // Remove a specific entry from the cache.
 //
 void CloudEnvImpl::FileCacheErase(const std::string& fname) {
-  if (!GetCloudEnvOptions().sst_file_cache) {
+  // We erase from the cache even if the cache size is zero. This is needed
+  // to protect against the when the cache size was dynamically reduced to zero
+  // on a running database.
+  if (!cloud_env_options.sst_file_cache) {
     return;
   }
 
   Slice key(fname);
-  GetCloudEnvOptions().sst_file_cache->get()->Erase(key);
+  cloud_env_options.sst_file_cache->Erase(key);
 
   Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache Erase %s", Name(),
       fname.c_str());
@@ -81,8 +95,6 @@ void CloudEnvImpl::FileCacheErase(const std::string& fname) {
 // When the cache is full, delete files from local store
 //
 void CloudEnvImpl::FileCacheDeleter(const std::string& fname) {
-  assert(GetCloudEnvOptions().sst_file_cache);
-
   Status st = base_env_->DeleteFile(fname);
   Log(InfoLogLevel::INFO_LEVEL, info_log_, "[%s] File Cache purging %s %s",
       Name(), fname.c_str(), st.ToString().c_str());
@@ -93,10 +105,8 @@ void CloudEnvImpl::FileCacheDeleter(const std::string& fname) {
 // This is not thread-safe and is used only for unit tests.
 //
 uint64_t CloudEnvImpl::FileCacheGetCharge() {
-  assert(GetCloudEnvOptions().sst_file_cache);
   clear_callback_state();
-  GetCloudEnvOptions().sst_file_cache->get()->ApplyToAllCacheEntries(callback,
-                                                                     true);
+  cloud_env_options.sst_file_cache->ApplyToAllCacheEntries(callback, true);
   uint64_t total = 0;
   for (auto& it : callback_state) {
     total += it.second;
@@ -109,11 +119,35 @@ uint64_t CloudEnvImpl::FileCacheGetCharge() {
 // This is not thread-safe and is used only for unit tests.
 //
 uint64_t CloudEnvImpl::FileCacheGetNumItems() {
-  assert(GetCloudEnvOptions().sst_file_cache);
   clear_callback_state();
-  GetCloudEnvOptions().sst_file_cache->get()->ApplyToAllCacheEntries(callback,
-                                                                     true);
+  cloud_env_options.sst_file_cache->ApplyToAllCacheEntries(callback, true);
   return callback_state.size();
+}
+
+// Removes all items for the env from the cache.
+// This is not thread-safe.
+void CloudEnvImpl::FileCachePurge() {
+  // We erase from the cache even if the cache size is zero. This is needed
+  // to protect against the when the cache size was dynamically reduced to zero
+  // on a running database.
+  if (!cloud_env_options.sst_file_cache) {
+    return;
+  }
+  // fetch all items from cache
+  clear_callback_state();
+  cloud_env_options.sst_file_cache->ApplyToAllCacheEntries(callback, true);
+  // for all those items that have a matching cenv, remove them from cache.
+  uint64_t count = 0;
+  for (auto& it : callback_state) {
+    Value* value = it.first;
+    if (value->cenv == this) {
+      Slice key(value->path);
+      cloud_env_options.sst_file_cache->Erase(key);
+      count++;
+    }
+  }
+  Log(InfoLogLevel::INFO_LEVEL, info_log_,
+      "[%s] File Cache purged %" PRIu64 " items", Name(), count);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -199,7 +199,7 @@ class CloudEnvOptions {
   // sst file is not inserted into the local file cache.
   // Cannot be set if keep_local_log_files is true.
   // Default: null (disabled)
-  std::shared_ptr<Cache>* sst_file_cache;
+  std::shared_ptr<Cache> sst_file_cache;
 
   // Access credentials
   AwsCloudAccessCredentials credentials;
@@ -337,7 +337,7 @@ class CloudEnvOptions {
       int _number_objects_listed_in_one_iteration = 5000,
       int _constant_sst_file_size_in_sst_file_manager = -1,
       bool _skip_cloud_files_in_getchildren = false,
-      std::shared_ptr<Cache>* _sst_file_cache = nullptr)
+      std::shared_ptr<Cache> _sst_file_cache = nullptr)
       : cloud_type(_cloud_type),
         log_type(_log_type),
         sst_file_cache(_sst_file_cache),
@@ -370,6 +370,11 @@ class CloudEnvOptions {
   void TEST_Initialize(const std::string& name_prefix,
                        const std::string& object_path,
                        const std::string& region = "");
+
+  // Is the sst file cache configured?
+  bool hasSstFileCache() {
+    return sst_file_cache != nullptr && sst_file_cache->GetCapacity() > 0;
+  }
 };
 
 struct CheckpointToCloudOptions {


### PR DESCRIPTION
This allows dynamically enabling the sst file cache on a running db  by setting its size. 