### PR TITLE
Add use_options_file option

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -3963,6 +3963,10 @@ Status DestroyDB(const std::string& dbname, const Options& options,
 Status DBImpl::WriteOptionsFile(bool need_mutex_lock,
                                 bool need_enter_write_thread) {
 #ifndef ROCKSDB_LITE
+  if (!immutable_db_options_.use_options_file) {
+      return Status::OK();
+  }
+
   WriteThread::Writer w;
   if (need_mutex_lock) {
     mutex_.Lock();

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1024,6 +1024,10 @@ struct DBOptions {
   // DEFAULT: false
   bool fail_if_options_file_error = false;
 
+  // If false, we won't use options file.
+  // DEFAULT: true
+  bool use_options_file = true;
+
   // If true, then print malloc stats together with rocksdb.stats
   // when printing to LOG.
   // DEFAULT: false

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -284,6 +284,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, fail_if_options_file_error),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"use_options_file",
+         {offsetof(struct ImmutableDBOptions, use_options_file),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         {"enable_pipelined_write",
          {offsetof(struct ImmutableDBOptions, enable_pipelined_write),
           OptionType::kBoolean, OptionVerificationType::kNormal,
@@ -554,6 +558,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       wal_filter(options.wal_filter),
 #endif  // ROCKSDB_LITE
       fail_if_options_file_error(options.fail_if_options_file_error),
+      use_options_file(options.use_options_file),
       dump_malloc_stats(options.dump_malloc_stats),
       avoid_flush_during_recovery(options.avoid_flush_during_recovery),
       allow_ingest_behind(options.allow_ingest_behind),

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -75,6 +75,7 @@ struct ImmutableDBOptions {
   WalFilter* wal_filter;
 #endif  // ROCKSDB_LITE
   bool fail_if_options_file_error;
+  bool use_options_file;
   bool dump_malloc_stats;
   bool avoid_flush_during_recovery;
   bool allow_ingest_behind;


### PR DESCRIPTION
Writing options file is incredibly expensive, taking most CPU time when RocksDB workload creates many column families. This PR adds an option to turn off the options file. No behavior changes in the default setting.