### PR TITLE
add aws init for cloud examples

### DIFF
--- a/cloud/examples/clone_example.cc
+++ b/cloud/examples/clone_example.cc
@@ -87,6 +87,8 @@ int main() {
   // with every new cloud-db.
   std::unique_ptr<CloudEnv> cloud_env;
 
+  cloud_env_options.credentials.InitializeSimple(
+      getenv("AWS_ACCESS_KEY_ID"), getenv("AWS_SECRET_ACCESS_KEY"));
   if (!cloud_env_options.credentials.HasValid().ok()) {
     fprintf(
         stderr,

--- a/cloud/examples/cloud_dump.cc
+++ b/cloud/examples/cloud_dump.cc
@@ -28,6 +28,8 @@ int main() {
   // with every new cloud-db.
   std::unique_ptr<CloudEnv> cloud_env;
 
+  cloud_env_options.credentials.InitializeSimple(
+      getenv("AWS_ACCESS_KEY_ID"), getenv("AWS_SECRET_ACCESS_KEY"));
   if (!cloud_env_options.credentials.HasValid().ok()) {
     fprintf(
         stderr,

--- a/cloud/examples/cloud_durable_example.cc
+++ b/cloud/examples/cloud_durable_example.cc
@@ -31,6 +31,8 @@ int main() {
   // with every new cloud-db.
   std::unique_ptr<CloudEnv> cloud_env;
 
+  cloud_env_options.credentials.InitializeSimple(
+      getenv("AWS_ACCESS_KEY_ID"), getenv("AWS_SECRET_ACCESS_KEY"));
   if (!cloud_env_options.credentials.HasValid().ok()) {
     fprintf(
         stderr,


### PR DESCRIPTION
The `clone_example.cc` and other cloud examples could not be run as the AWS credentials were not setup. Not sure why they work before.