### PR TITLE
Introduce unsafe_disable_sync parameter in ingest external files

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1633,6 +1633,10 @@ struct IngestExternalFileOptions {
   // ingestion. However, if no checksum information is provided with the
   // ingested files, DB will generate the checksum and store in the Manifest.
   bool verify_file_checksum = true;
+  // Only set unsafe_disable_sync to true if you know what you're doing. If set
+  // to true no file sync operations will be performed when ingesting the
+  // external file.
+  bool unsafe_disable_sync = false;
 };
 
 enum TraceFilterType : uint64_t {

--- a/include/rocksdb/sst_file_writer.h
+++ b/include/rocksdb/sst_file_writer.h
@@ -88,14 +88,17 @@ class SstFileWriter {
   // passed.
   // If unsafe_add is true, SstFileWriter doesn't check that keys are written in
   // ascending order.
+  // If unsafe_disable_sync is false, SstFileWriter will not sync new sst file
+  // on close.
   SstFileWriter(const EnvOptions& env_options, const Options& options,
                 ColumnFamilyHandle* column_family = nullptr,
                 bool invalidate_page_cache = true,
                 Env::IOPriority io_priority = Env::IOPriority::IO_TOTAL,
-                bool skip_filters = false, bool unsafe_add = false)
+                bool skip_filters = false, bool unsafe_add = false,
+                bool unsafe_disable_sync = false)
       : SstFileWriter(env_options, options, options.comparator, column_family,
                       invalidate_page_cache, io_priority, skip_filters,
-                      unsafe_add) {}
+                      unsafe_add, unsafe_disable_sync) {}
 
   // Deprecated API
   SstFileWriter(const EnvOptions& env_options, const Options& options,
@@ -103,7 +106,8 @@ class SstFileWriter {
                 ColumnFamilyHandle* column_family = nullptr,
                 bool invalidate_page_cache = true,
                 Env::IOPriority io_priority = Env::IOPriority::IO_TOTAL,
-                bool skip_filters = false, bool unsafe_add = false);
+                bool skip_filters = false, bool unsafe_add = false,
+                bool unsafe_disable_sync = false);
 
   ~SstFileWriter();
 


### PR DESCRIPTION
We don't need to fsync the file on close in our use case and syncing is
adding a considerable performance overhead. This commit introduces a
parameter unsafe_disable_sync that lets us disable the file sync.