### PR TITLE
Introduce new DBOption disable_manifest_sync

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4036,7 +4036,9 @@ Status VersionSet::ProcessManifestWrites(
         }
       }
       if (s.ok()) {
-        io_s = SyncManifest(env_, db_options_, descriptor_log_->file());
+        if (!db_options_->disable_manifest_sync) {
+          io_s = SyncManifest(env_, db_options_, descriptor_log_->file());
+        }
         TEST_SYNC_POINT_CALLBACK(
             "VersionSet::ProcessManifestWrites:AfterSyncManifest", &io_s);
       }

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1171,6 +1171,14 @@ struct DBOptions {
   //
   // Default: false
   bool allow_data_in_errors = false;
+
+  // If disable_manifest_sync is set to true the MANIFEST file will not be
+  // synced (using fsync or fdatasync) after every write. Use this only in
+  // situations where you don't care about database integrity after a power
+  // cycle.
+  //
+  // Default: false
+  bool disable_manifest_sync = false;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -423,6 +423,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableDBOptions, allow_data_in_errors),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"disable_manifest_sync",
+         {offsetof(struct ImmutableDBOptions, disable_manifest_sync),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
 };
 
 const std::string OptionsHelper::kDBOptionsName = "DBOptions";
@@ -574,7 +578,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       best_efforts_recovery(options.best_efforts_recovery),
       max_bgerror_resume_count(options.max_bgerror_resume_count),
       bgerror_resume_retry_interval(options.bgerror_resume_retry_interval),
-      allow_data_in_errors(options.allow_data_in_errors) {
+      allow_data_in_errors(options.allow_data_in_errors),
+      disable_manifest_sync(options.disable_manifest_sync) {
 }
 
 void ImmutableDBOptions::Dump(Logger* log) const {
@@ -732,6 +737,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    bgerror_resume_retry_interval);
   ROCKS_LOG_HEADER(log, "            Options.allow_data_in_errors: %d",
                    allow_data_in_errors);
+  ROCKS_LOG_HEADER(log, "           Options.disable_manifest_sync: %d",
+                   disable_manifest_sync);
 }
 
 MutableDBOptions::MutableDBOptions()

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -92,6 +92,7 @@ struct ImmutableDBOptions {
   int max_bgerror_resume_count;
   uint64_t bgerror_resume_retry_interval;
   bool allow_data_in_errors;
+  bool disable_manifest_sync;
 };
 
 struct MutableDBOptions {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -165,6 +165,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.max_bgerror_resume_count;
   options.bgerror_resume_retry_interval =
       immutable_db_options.bgerror_resume_retry_interval;
+  options.disable_manifest_sync = immutable_db_options.disable_manifest_sync;
   return options;
 }
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -321,6 +321,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "preserve_deletes=false;"
                              "concurrent_prepare=false;"
                              "two_write_queues=false;"
+                             "disable_manifest_sync=false;"
                              "manual_wal_flush=false;"
                              "seq_per_batch=false;"
                              "atomic_flush=false;"


### PR DESCRIPTION
For our use case syncing the MANIFEST file is not important, while
adding a big performance overhead. This new option allows us to disable
manfiest sync.