### PR TITLE
Allow read/write path to use cloud storage provider

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -137,7 +137,7 @@ Status BuildTable(
       bool use_direct_writes = file_options.use_direct_writes;
       TEST_SYNC_POINT_CALLBACK("BuildTable:create_file", &use_direct_writes);
 #endif  // !NDEBUG
-      
+
       CloudEnvImpl* cenv = static_cast<CloudEnvImpl*>(ioptions.env);
       if (cenv->GetCloudEnvOptions().read_write_through_cloud_storage) {
         std::unique_ptr<WritableFile> result;
@@ -152,7 +152,7 @@ Status BuildTable(
           *io_status = io_s;
         }
       }
-      
+
       if (!s.ok()) {
         EventHelpers::LogAndNotifyTableFileCreationFinished(
             event_logger, ioptions.listeners, dbname, column_family_name, fname,
@@ -256,7 +256,8 @@ Status BuildTable(
       meta->fd.file_size = file_size;
       meta->marked_for_compaction = builder->NeedCompact();
       assert(meta->fd.GetFileSize() > 0);
-      tp = builder->GetTableProperties(); // refresh now that builder is finished
+      tp = builder
+               ->GetTableProperties();  // refresh now that builder is finished
       if (table_properties) {
         *table_properties = tp;
       }

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -8,6 +8,7 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #include "db/table_cache.h"
+
 #include <memory>
 
 #include "cloud/cloud_storage_provider_impl.h"
@@ -87,8 +88,7 @@ TableCache::TableCache(const ImmutableCFOptions& ioptions,
   }
 }
 
-TableCache::~TableCache() {
-}
+TableCache::~TableCache() {}
 
 TableReader* TableCache::GetTableReaderFromHandle(Cache::Handle* handle) {
   return reinterpret_cast<TableReader*>(cache_->Value(handle));
@@ -105,8 +105,7 @@ Status TableCache::GetTableReader(
     std::unique_ptr<TableReader>* table_reader,
     const SliceTransform* prefix_extractor, bool skip_filters, int level,
     bool prefetch_index_and_filter_in_cache,
-    size_t max_file_size_for_l0_meta_pin,
-    GetContext* get_context) {
+    size_t max_file_size_for_l0_meta_pin, GetContext* get_context) {
   std::string fname =
       TableFileName(ioptions_.cf_paths, fd.GetNumber(), fd.GetPathId());
   std::unique_ptr<FSRandomAccessFile> file;
@@ -167,16 +166,13 @@ void TableCache::EraseHandle(const FileDescriptor& fd, Cache::Handle* handle) {
   cache_->Erase(key);
 }
 
-Status TableCache::FindTable(const ReadOptions& ro,
-                             const FileOptions& file_options,
-                             const InternalKeyComparator& internal_comparator,
-                             const FileDescriptor& fd, Cache::Handle** handle,
-                             const SliceTransform* prefix_extractor,
-                             const bool no_io, bool record_read_stats,
-                             HistogramImpl* file_read_hist, bool skip_filters,
-                             int level, bool prefetch_index_and_filter_in_cache,
-                             size_t max_file_size_for_l0_meta_pin,
-                             GetContext* get_context) {
+Status TableCache::FindTable(
+    const ReadOptions& ro, const FileOptions& file_options,
+    const InternalKeyComparator& internal_comparator, const FileDescriptor& fd,
+    Cache::Handle** handle, const SliceTransform* prefix_extractor,
+    const bool no_io, bool record_read_stats, HistogramImpl* file_read_hist,
+    bool skip_filters, int level, bool prefetch_index_and_filter_in_cache,
+    size_t max_file_size_for_l0_meta_pin, GetContext* get_context) {
   PERF_TIMER_GUARD_WITH_ENV(find_table_nanos, ioptions_.env);
   uint64_t number = fd.GetNumber();
   Slice key = GetSliceForFileNumber(&number);
@@ -256,10 +252,9 @@ InternalIterator* TableCache::NewIterator(
         !options.table_filter(*table_reader->GetTableProperties())) {
       result = NewEmptyInternalIterator<Slice>(arena);
     } else {
-      result = table_reader->NewIterator(options, prefix_extractor, arena,
-                                   skip_filters, caller,
-                                   file_options.compaction_readahead_size,
-                                   allow_unprepared_value);
+      result = table_reader->NewIterator(
+          options, prefix_extractor, arena, skip_filters, caller,
+          file_options.compaction_readahead_size, allow_unprepared_value);
     }
     if (handle != nullptr) {
       result->RegisterCleanup(&UnrefEntry, cache_, handle);

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <stdint.h>
 
+#include "cloud/cloud_storage_provider_impl.h"
 #include "db/dbformat.h"
 #include "db/range_del_aggregator.h"
 #include "options/cf_options.h"
@@ -139,7 +140,8 @@ class TableCache {
                    HistogramImpl* file_read_hist = nullptr,
                    bool skip_filters = false, int level = -1,
                    bool prefetch_index_and_filter_in_cache = true,
-                   size_t max_file_size_for_l0_meta_pin = 0);
+                   size_t max_file_size_for_l0_meta_pin = 0,
+                   GetContext* get_context = nullptr);
 
   // Get TableReader from a cache handle.
   TableReader* GetTableReaderFromHandle(Cache::Handle* handle);
@@ -205,7 +207,8 @@ class TableCache {
                         const SliceTransform* prefix_extractor = nullptr,
                         bool skip_filters = false, int level = -1,
                         bool prefetch_index_and_filter_in_cache = true,
-                        size_t max_file_size_for_l0_meta_pin = 0);
+                        size_t max_file_size_for_l0_meta_pin = 0,
+                        GetContext* get_context = nullptr);
 
   // Create a key prefix for looking up the row cache. The prefix is of the
   // format row_cache_id + fd_number + seq_no. Later, the user key can be

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -10,9 +10,10 @@
 // Thread-safe (provides internal synchronization)
 
 #pragma once
+#include <stdint.h>
+
 #include <string>
 #include <vector>
-#include <stdint.h>
 
 #include "cloud/cloud_storage_provider_impl.h"
 #include "db/dbformat.h"

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -5,8 +5,8 @@
 #include <memory>
 #include <unordered_map>
 
-#include "rocksdb/configurable.h"
 #include "rocksdb/cache.h"
+#include "rocksdb/configurable.h"
 #include "rocksdb/env.h"
 #include "rocksdb/status.h"
 
@@ -190,7 +190,7 @@ class CloudEnvOptions {
 
   // Specifies the class responsible for accessing objects in the cloud.
   // A null value indicates that the default storage provider based on
-  // the cloud env be used. 
+  // the cloud env be used.
   // Default:  null
   std::shared_ptr<CloudStorageProvider> storage_provider;
 
@@ -333,12 +333,14 @@ class CloudEnvOptions {
   // recommended to set this to true, the only reason the default is false is to
   // avoid behavior changes with default configuration.
   // The options is ignored if use_aws_transfer_manager = true.
+  //
   // Default: false
   bool use_direct_io_for_cloud_download;
 
-  // When set to true, Rocks-cloud will no longer does any local file read-write, but 
-  // instead going through the cloud storage provider specified in the options
-  // to open files backed up by cloud storage.
+  // When set to true, Rocks-cloud will no longer does any local file
+  // read-write, but instead going through the cloud storage provider specified
+  // in the options to open files backed up by cloud storage.
+  //
   // Default: false
   bool read_write_through_cloud_storage;
 
@@ -382,7 +384,7 @@ class CloudEnvOptions {
         skip_cloud_files_in_getchildren(_skip_cloud_files_in_getchildren),
         use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download),
         read_write_through_cloud_storage(_read_write_through_cloud_storage) {
-    (void) _cloud_type;
+    (void)_cloud_type;
   }
 
   // print out all options to the log
@@ -396,8 +398,10 @@ class CloudEnvOptions {
                        const std::string& object_path,
                        const std::string& region = "");
 
-  Status Configure(const ConfigOptions& config_options, const std::string& opts_str);
-  Status Serialize(const ConfigOptions& config_options, std::string* result) const;
+  Status Configure(const ConfigOptions& config_options,
+                   const std::string& opts_str);
+  Status Serialize(const ConfigOptions& config_options,
+                   std::string* result) const;
 
   // Is the sst file cache configured?
   bool hasSstFileCache() {
@@ -423,15 +427,18 @@ class CloudEnv : public Env, public Configurable {
 
   CloudEnv(const CloudEnvOptions& options, Env* base,
            const std::shared_ptr<Logger>& logger);
+
  public:
   mutable std::shared_ptr<Logger> info_log_;  // informational messages
 
   virtual ~CloudEnv();
 
   static void RegisterCloudObjects(const std::string& mode = "");
-  static Status CreateFromString(const ConfigOptions& config_options, const std::string& id,
+  static Status CreateFromString(const ConfigOptions& config_options,
+                                 const std::string& id,
                                  std::unique_ptr<CloudEnv>* env);
-  static Status CreateFromString(const ConfigOptions& config_options, const std::string& id,
+  static Status CreateFromString(const ConfigOptions& config_options,
+                                 const std::string& id,
                                  const CloudEnvOptions& cloud_options,
                                  std::unique_ptr<CloudEnv>* env);
   static const char* kCloud() { return "cloud"; }
@@ -460,14 +467,14 @@ class CloudEnv : public Env, public Configurable {
                             const std::string& dbid) = 0;
 
   Logger* GetLogger() const { return info_log_.get(); }
-  const std::shared_ptr<CloudStorageProvider>&  GetStorageProvider() const {
+  const std::shared_ptr<CloudStorageProvider>& GetStorageProvider() const {
     return cloud_env_options.storage_provider;
   }
-  
+
   const std::shared_ptr<CloudLogController>& GetLogController() const {
     return cloud_env_options.cloud_log_controller;
   }
-  
+
   // The SrcBucketName identifies the cloud storage bucket and
   // GetSrcObjectPath specifies the path inside that bucket
   // where data files reside. The specified bucket is used in

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -336,6 +336,12 @@ class CloudEnvOptions {
   // Default: false
   bool use_direct_io_for_cloud_download;
 
+  // When set to true, Rocks-cloud will no longer does any local file read-write, but 
+  // instead going through the cloud storage provider specified in the options
+  // to open files backed up by cloud storage.
+  // Default: false
+  bool read_write_through_cloud_storage;
+
   CloudEnvOptions(
       CloudType _cloud_type = CloudType::kCloudAws,
       LogType _log_type = LogType::kLogKafka,
@@ -352,6 +358,7 @@ class CloudEnvOptions {
       int _constant_sst_file_size_in_sst_file_manager = -1,
       bool _skip_cloud_files_in_getchildren = false,
       bool _use_direct_io_for_cloud_download = false,
+      bool _read_write_through_cloud_storage = false,
       std::shared_ptr<Cache> _sst_file_cache = nullptr)
       : log_type(_log_type),
         sst_file_cache(_sst_file_cache),
@@ -373,7 +380,8 @@ class CloudEnvOptions {
         constant_sst_file_size_in_sst_file_manager(
             _constant_sst_file_size_in_sst_file_manager),
         skip_cloud_files_in_getchildren(_skip_cloud_files_in_getchildren),
-        use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download) {
+        use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download),
+        read_write_through_cloud_storage(_read_write_through_cloud_storage) {
     (void) _cloud_type;
   }
 

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <string>
+#include "cloud/cloud_env_impl.h"
 #include "db/dbformat.h"
 #include "db/merge_context.h"
 #include "db/read_callback.h"
@@ -159,6 +160,10 @@ class GetContext {
       return callback_->IsVisible(seq);
     }
     return true;
+  }
+
+  CloudEnvImpl* GetCloudEnv() {
+    return static_cast<CloudEnvImpl*>(env_);
   }
 
   void ReportCounters();

--- a/table/get_context.h
+++ b/table/get_context.h
@@ -5,6 +5,7 @@
 
 #pragma once
 #include <string>
+
 #include "cloud/cloud_env_impl.h"
 #include "db/dbformat.h"
 #include "db/merge_context.h"
@@ -98,8 +99,8 @@ class GetContext {
   // merge_context and they are never merged. The value pointer is untouched.
   GetContext(const Comparator* ucmp, const MergeOperator* merge_operator,
              Logger* logger, Statistics* statistics, GetState init_state,
-             const Slice& user_key, PinnableSlice* value,
-             bool* value_found, MergeContext* merge_context, bool do_merge,
+             const Slice& user_key, PinnableSlice* value, bool* value_found,
+             MergeContext* merge_context, bool do_merge,
              SequenceNumber* max_covering_tombstone_seq, Env* env,
              SequenceNumber* seq = nullptr,
              PinnedIteratorsManager* _pinned_iters_mgr = nullptr,
@@ -162,9 +163,7 @@ class GetContext {
     return true;
   }
 
-  CloudEnvImpl* GetCloudEnv() {
-    return static_cast<CloudEnvImpl*>(env_);
-  }
+  CloudEnvImpl* GetCloudEnv() { return static_cast<CloudEnvImpl*>(env_); }
 
   void ReportCounters();
 


### PR DESCRIPTION
Add a mode for leveraging cloud storage provider for all the local RocksDB file read/writes.

One thing open for suggestion is whether we need to add unit test for this change, since so far there is no good test mock for storage provider.