### PR TITLE
add remote file system using CloudStorageProvider

### DIFF
--- a/env/remote_file_system.cc
+++ b/env/remote_file_system.cc
@@ -1,0 +1,96 @@
+
+#include <cloud/filename.h>
+#include <include/rocksdb/remote_file_system.h>
+#include <rocksdb/env.h>
+
+#include "env/composite_env_wrapper.h"
+#include "rocksdb/io_status.h"
+
+namespace rocksdb {
+
+IOStatus RemoteFileSystem::NewSequentialFile(
+    const std::string& f, const FileOptions& file_opts,
+    std::unique_ptr<FSSequentialFile>* r, IODebugContext* dbg) {
+  r->reset();
+
+  auto baseFileName = cloud_env_->RemapFilename(f);
+
+  auto fType = GetFileType(baseFileName);
+  if (fType != RocksDBFileType::kSstFile) {
+    return FileSystemWrapper::NewSequentialFile(f, file_opts, r, dbg);
+  }
+
+  std::unique_ptr<CloudStorageReadableFile> cloud_file;
+  auto st = cloud_storage_provider_->NewCloudReadableFile(
+      cloud_env_->GetSrcBucketName(), f, &cloud_file, EnvOptions());
+
+  std::unique_ptr<SequentialFile> result;
+  if (st.ok()) {
+    result.reset(cloud_file.release());
+    r->reset(NewLegacySequentialFileWrapper(result).release());
+    return IOStatus::OK();
+  }
+  return status_to_io_status(std::move(st));
+}
+
+IOStatus RemoteFileSystem::NewRandomAccessFile(
+    const std::string& f, const FileOptions& file_opts,
+    std::unique_ptr<FSRandomAccessFile>* r, IODebugContext* dbg) {
+  r->reset();
+
+  auto baseFileName = cloud_env_->RemapFilename(f);
+
+  auto fType = GetFileType(baseFileName);
+  if (fType != RocksDBFileType::kSstFile) {
+    return FileSystemWrapper::NewRandomAccessFile(f, file_opts, r, dbg);
+  }
+
+  std::unique_ptr<CloudStorageReadableFile> cloud_file;
+  auto st = cloud_storage_provider_->NewCloudReadableFile(
+      cloud_env_->GetSrcBucketName(), f, &cloud_file, EnvOptions());
+
+  std::unique_ptr<RandomAccessFile> result;
+  if (st.ok()) {
+    result.reset(cloud_file.release());
+    r->reset(NewLegacyRandomAccessFileWrapper(result).release());
+    return IOStatus::OK();
+  }
+
+  return status_to_io_status(std::move(st));
+}
+
+std::string RemoteFileSystem::destname(const std::string& localname) {
+  assert(cloud_env_.dest_bucket.IsValid());
+  return cloud_env_->GetDestObjectPath() + "/" + basename(localname);
+}
+
+bool RemoteFileSystem::isSstFile(const std::string& f) {
+  auto baseFileName = cloud_env_->RemapFilename(f);
+  return GetFileType(baseFileName) == RocksDBFileType::kSstFile;
+}
+
+IOStatus RemoteFileSystem::NewWritableFile(const std::string& f,
+                                           const FileOptions& file_opts,
+                                           std::unique_ptr<FSWritableFile>* r,
+                                           IODebugContext* dbg) {
+  r->reset();
+
+  if (!isSstFile(f)) {
+    return FileSystemWrapper::NewWritableFile(f, file_opts, r, dbg);
+  }
+
+  std::unique_ptr<CloudStorageWritableFile> cloud_file;
+  auto st = cloud_storage_provider_->NewCloudWritableFile(
+      f, cloud_env_->GetDestBucketName(), destname(f), &cloud_file,
+      EnvOptions());
+
+  std::unique_ptr<WritableFile> result;
+  if (st.ok()) {
+    result.reset(cloud_file.release());
+    r->reset(NewLegacyWritableFileWrapper(std::move(result)).release());
+    return IOStatus::OK();
+  }
+
+  return status_to_io_status(std::move(st));
+}
+}  // namespace rocksdb

--- a/include/rocksdb/remote_file_system.h
+++ b/include/rocksdb/remote_file_system.h
@@ -5,6 +5,7 @@
 
 namespace rocksdb {
 class RemoteFileSystem : public FileSystemWrapper {
+ public:
   RemoteFileSystem(std::shared_ptr<FileSystem> default_fs,
                    const CloudEnvOptions& cloud_options)
       : FileSystemWrapper(default_fs),

--- a/include/rocksdb/remote_file_system.h
+++ b/include/rocksdb/remote_file_system.h
@@ -1,0 +1,38 @@
+#include <rocksdb/cloud/cloud_env_options.h>
+#include <rocksdb/cloud/cloud_storage_provider.h>
+#include <rocksdb/file_system.h>
+#include <rocksdb/io_status.h>
+
+namespace rocksdb {
+class RemoteFileSystem : public FileSystemWrapper {
+  RemoteFileSystem(std::shared_ptr<FileSystem> default_fs,
+                   const CloudEnvOptions& cloud_options)
+      : FileSystemWrapper(default_fs),
+        cloud_storage_provider_(cloud_options.storage_provider),
+        src_bucket_(cloud_options.src_bucket),
+        dest_bucket_(cloud_options.dest_bucket) {}
+
+  IOStatus NewSequentialFile(const std::string& f, const FileOptions& file_opts,
+                             std::unique_ptr<FSSequentialFile>* r,
+                             IODebugContext* dbg);
+
+  IOStatus NewRandomAccessFile(const std::string& f,
+                               const FileOptions& file_opts,
+                               std::unique_ptr<FSRandomAccessFile>* r,
+                               IODebugContext* dbg);
+
+  IOStatus NewWritableFile(const std::string& f, const FileOptions& file_opts,
+                           std::unique_ptr<FSWritableFile>* r,
+                           IODebugContext* dbg);
+
+ private:
+  std::string destname(const std::string& localname);
+  bool isSstFile(const std::string& f);
+
+  const std::shared_ptr<CloudStorageProvider>& cloud_storage_provider_;
+  BucketOptions src_bucket_;
+  BucketOptions dest_bucket_;
+  CloudEnv* cloud_env_;
+};
+
+}  // namespace rocksdb


### PR DESCRIPTION
Compared with https://github.com/rockset/rocksdb-cloud/pull/139, this solution make less intrusive changes to RocksDB itself by overriding the file system interface to allow accessing the low-level file system. It also limits the access only to sst files instead of doing all read/write through cloud, which is against our goal to use cloud storage provider solely for sst access.