### PR TITLE
add S3Client factory as a config option

### DIFF
--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -114,7 +114,9 @@ class AwsS3ClientWrapper {
       const Aws::Client::ClientConfiguration& config,
       const CloudEnvOptions& cloud_options)
       : cloud_request_callback_(cloud_options.cloud_request_callback) {
-    if (creds) {
+    if (cloud_options.s3_client_factory) {
+      client_ = cloud_options.s3_client_factory(creds, config);
+    } else if (creds) {
       client_ = std::make_shared<Aws::S3::S3Client>(creds, config);
     } else {
       client_ = std::make_shared<Aws::S3::S3Client>(config);

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -17,6 +17,9 @@ class AWSCredentialsProvider;
 namespace Client {
 struct ClientConfiguration;
 }  // namespace Client
+namespace S3 {
+class S3Client;
+}
 }  // namespace Aws
 
 namespace ROCKSDB_NAMESPACE {
@@ -86,6 +89,10 @@ class AwsCloudAccessCredentials {
   // If non-nullptr, all of the above options are ignored.
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> provider;
 };
+
+using S3ClientFactory = std::function<std::shared_ptr<Aws::S3::S3Client>(
+    const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>&,
+    const Aws::Client::ClientConfiguration&)>;
 
 // Defines parameters required to connect to Kafka
 class KafkaLogOptions {
@@ -210,6 +217,9 @@ class CloudEnvOptions {
 
   // Access credentials
   AwsCloudAccessCredentials credentials;
+
+  // If present, s3_client_factory will be used to create S3Client instances
+  S3ClientFactory s3_client_factory;
 
   // Only used if keep_local_log_files is true and log_type is kKafka.
   KafkaLogOptions kafka_log_options;


### PR DESCRIPTION
Summary:
This diff adds CloudEnvOptions::s3_client_factory, which gives
callers the ability to manage the full S3Client lifecycle.

Test Plan:
1. rocksdb cloud compiles
2. rockset internal E2E tests pass