### PR TITLE
Revert "Snapshot release triggered compaction without multiple tombstones (#8357)"

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3302,7 +3302,8 @@ void VersionStorageInfo::ComputeBottommostFilesMarkedForCompaction() {
   bottommost_files_mark_threshold_ = kMaxSequenceNumber;
   for (auto& level_and_file : bottommost_files_) {
     if (!level_and_file.second->being_compacted &&
-        level_and_file.second->fd.largest_seqno != 0) {
+        level_and_file.second->fd.largest_seqno != 0 &&
+        level_and_file.second->num_deletions > 1) {
       // largest_seqno might be nonzero due to containing the final key in an
       // earlier compaction, whose seqnum we didn't zero out. Multiple deletions
       // ensures the file really contains deleted or overwritten keys.

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -571,6 +571,7 @@ TEST_F(BlobDBTest, EnableDisableCompressionGC) {
   Random rnd(301);
   BlobDBOptions bdb_options;
   bdb_options.min_blob_size = 0;
+  bdb_options.enable_garbage_collection = true;
   bdb_options.garbage_collection_cutoff = 1.0;
   bdb_options.disable_background_tasks = true;
   bdb_options.compression = kSnappyCompression;
@@ -598,11 +599,6 @@ TEST_F(BlobDBTest, EnableDisableCompressionGC) {
   blob_files = blob_db_impl()->TEST_GetBlobFiles();
   ASSERT_EQ(2, blob_files.size());
   ASSERT_EQ(kNoCompression, blob_files[1]->GetCompressionType());
-
-  // Enable GC. If we do it earlier the snapshot release triggered compaction
-  // may compact files and trigger GC before we can verify there are two files.
-  bdb_options.enable_garbage_collection = true;
-  Reopen(bdb_options);
 
   // Trigger compaction
   ASSERT_OK(blob_db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
@@ -642,6 +638,7 @@ TEST_F(BlobDBTest, ChangeCompressionGC) {
   Random rnd(301);
   BlobDBOptions bdb_options;
   bdb_options.min_blob_size = 0;
+  bdb_options.enable_garbage_collection = true;
   bdb_options.garbage_collection_cutoff = 1.0;
   bdb_options.disable_background_tasks = true;
   bdb_options.compression = kLZ4Compression;
@@ -670,11 +667,6 @@ TEST_F(BlobDBTest, ChangeCompressionGC) {
   blob_files = blob_db_impl()->TEST_GetBlobFiles();
   ASSERT_EQ(2, blob_files.size());
   ASSERT_EQ(kSnappyCompression, blob_files[1]->GetCompressionType());
-
-  // Enable GC. If we do it earlier the snapshot release triggered compaction
-  // may compact files and trigger GC before we can verify there are two files.
-  bdb_options.enable_garbage_collection = true;
-  Reopen(bdb_options);
 
   ASSERT_OK(blob_db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   VerifyDB(data);

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -2587,7 +2587,6 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
   const size_t snapshot_cache_bits = 7;  // same as default
   const size_t commit_cache_bits = 0;    // minimum commit cache
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
-  options.disable_auto_compactions = true;
   ASSERT_OK(ReOpen());
 
   ASSERT_OK(db->Put(WriteOptions(), "key1", "value1_1"));
@@ -2607,13 +2606,7 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
   VerifyKeys({{"key1", "value1_1"}}, snapshot2);
   // Add a flush to avoid compaction to fallback to trivial move.
 
-  // The callback might be called twice, record the calling state to
-  // prevent double calling.
-  bool callback_finished = false;
   auto callback = [&](void*) {
-    if (callback_finished) {
-      return;
-    }
     // Release snapshot1 after CompactionIterator init.
     // CompactionIterator need to figure out the earliest snapshot
     // that can see key1:value1_2 is kMaxSequenceNumber, not
@@ -2622,7 +2615,6 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction) {
     // Add some keys to advance max_evicted_seq.
     ASSERT_OK(db->Put(WriteOptions(), "key3", "value3"));
     ASSERT_OK(db->Put(WriteOptions(), "key4", "value4"));
-    callback_finished = true;
   };
   SyncPoint::GetInstance()->SetCallBack("CompactionIterator:AfterInit",
                                         callback);
@@ -2644,7 +2636,6 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction2) {
   const size_t snapshot_cache_bits = 7;  // same as default
   const size_t commit_cache_bits = 0;    // minimum commit cache
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
-  options.disable_auto_compactions = true;
   ASSERT_OK(ReOpen());
 
   ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));
@@ -2695,7 +2686,6 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction3) {
   const size_t snapshot_cache_bits = 7;  // same as default
   const size_t commit_cache_bits = 1;    // commit cache size = 2
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
-  options.disable_auto_compactions = true;
   ASSERT_OK(ReOpen());
 
   // Add a dummy key to evict v2 commit cache, but keep v1 commit cache.
@@ -2725,18 +2715,11 @@ TEST_P(WritePreparedTransactionTest, ReleaseSnapshotDuringCompaction3) {
   add_dummy();
   auto* s2 = db->GetSnapshot();
 
-  // The callback might be called twice, record the calling state to
-  // prevent double calling.
-  bool callback_finished = false;
   auto callback = [&](void*) {
-    if (callback_finished) {
-      return;
-    }
     db->ReleaseSnapshot(s1);
     // Add some dummy entries to trigger s1 being cleanup from old_commit_map.
     add_dummy();
     add_dummy();
-    callback_finished = true;
   };
   SyncPoint::GetInstance()->SetCallBack("CompactionIterator:AfterInit",
                                         callback);
@@ -2754,7 +2737,6 @@ TEST_P(WritePreparedTransactionTest, ReleaseEarliestSnapshotDuringCompaction) {
   const size_t snapshot_cache_bits = 7;  // same as default
   const size_t commit_cache_bits = 0;    // minimum commit cache
   UpdateTransactionDBOptions(snapshot_cache_bits, commit_cache_bits);
-  options.disable_auto_compactions = true;
   ASSERT_OK(ReOpen());
 
   ASSERT_OK(db->Put(WriteOptions(), "key1", "value1"));


### PR DESCRIPTION
This reverts commit f89423a57a78e28de68c9a618a6e5f2f00ec5270.

See my comment here for the explanation:
https://github.com/facebook/rocksdb/pull/8438#issuecomment-1005603929.
This change is causing problems in our production environment.