### PR TITLE
Fix GetCloudObject return status

### DIFF
--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -317,12 +317,9 @@ Status CloudStorageProviderImpl::GetCloudObject(
   // Check if our local file is the same as promised
   uint64_t local_size{0};
   s = localenv->GetFileSize(tmp_destination, &local_size);
-  if (!s.ok()) {
-    return s;
-  }
-  if (local_size != remote_size) {
+  if (!s.ok() || local_size != remote_size) {
     localenv->DeleteFile(tmp_destination);
-    s = Status::IOError("Partial download of a file " + local_destination);
+    s = Status::IOError("File download failed: " + local_destination);
     Log(InfoLogLevel::ERROR_LEVEL, env_->GetLogger(),
         "[%s] GetCloudObject %s/%s local size %" PRIu64
         " != cloud size "


### PR DESCRIPTION
It is possible that `DoGetCloudObject()` suceeds, but the local file is not
successfully created. In that case `GetCloudObject()` would return
`Status::NotFound`, wihch is incorrect, as higher levels of the code assume
`NotFound` to mean the file is not present in the cloud.

This PR fixes this.
