### PR TITLE
Improve DB initalization

### DIFF
--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -558,7 +558,7 @@ Status S3StorageProvider::EmptyBucket(const std::string& bucket_name,
 
   // Delete all objects from bucket
   for (const auto& path : results) {
-    st = DeleteCloudObject(bucket_name, path);
+    st = DeleteCloudObject(bucket_name, object_path + "/" + path);
     if (!st.ok()) {
       Log(InfoLogLevel::ERROR_LEVEL, env_->GetLogger(),
           "[s3] EmptyBucket Unable to delete %s in bucket %s %s", path.c_str(),

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -175,7 +175,8 @@ class CloudEnvImpl : public CloudEnv {
                           std::vector<std::string>* dbids);
   Status extractParents(const std::string& bucket_name_prefix,
                         const DbidList& dbid_list, DbidParents* parents);
-  virtual Status PreloadCloudManifest(const std::string& local_dbname) override;
+  Status PreloadCloudManifest(const std::string& local_dbname) override;
+  Status MigrateFromPureRocksDB(const std::string& local_dbname) override;
 
   // Load CLOUDMANIFEST if exists in local disk to current env.
   Status LoadLocalCloudManifest(const std::string& dbname);
@@ -184,6 +185,8 @@ class CloudEnvImpl : public CloudEnv {
   static Status LoadLocalCloudManifest(
       const std::string& dbname, Env* base_env,
       std::unique_ptr<CloudManifest>* cloud_manifest);
+
+  Status CreateCloudManifest(const std::string& local_dbname);
 
   // Transfers the filename from RocksDB's domain to the physical domain, based
   // on information stored in CLOUDMANIFEST.
@@ -317,8 +320,7 @@ class CloudEnvImpl : public CloudEnv {
   Status CreateNewIdentityFile(const std::string& dbid,
                                const std::string& local_name);
 
-  Status MaybeMigrateManifestFile(const std::string& local_dbname);
-  Status FetchCloudManifest(const std::string& local_dbname, bool force);
+  Status FetchCloudManifest(const std::string& local_dbname);
 
   Status RollNewEpoch(const std::string& local_dbname);
 

--- a/cloud/cloud_manifest.cc
+++ b/cloud/cloud_manifest.cc
@@ -168,17 +168,10 @@ Status CloudManifest::WriteToLog(std::unique_ptr<WritableFileWriter> log) {
 
 void CloudManifest::AddEpoch(uint64_t startFileNumber, std::string epochId) {
   assert(!finalized_);
-  if (startFileNumber == 0) {
-    // meaning, we didn't write any files under currentEpoch_ (most likely
-    // because the database is empty). Instead of storing the past epoch, just
-    // set the currentEpoch_
-    assert(pastEpochs_.empty());
-  } else {
-    assert(pastEpochs_.empty() || pastEpochs_.back().first <= startFileNumber);
-    if (pastEpochs_.empty() || pastEpochs_.back().first < startFileNumber) {
+  assert(pastEpochs_.empty() || pastEpochs_.back().first <= startFileNumber);
+  if (pastEpochs_.empty() || pastEpochs_.back().first < startFileNumber) {
       pastEpochs_.emplace_back(startFileNumber, std::move(currentEpoch_));
-    }  // Else current epoch hasn't written any files, I can just ignore it
-  }
+  }  // Else current epoch hasn't written any files, I can just ignore it
   currentEpoch_ = std::move(epochId);
 }
 

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -442,6 +442,9 @@ class CloudEnv : public Env, public Configurable {
   // Returns the underlying env
   Env* GetBaseEnv() { return base_env_; }
   virtual Status PreloadCloudManifest(const std::string& local_dbname) = 0;
+  // This method will mgirate the database that is using pure RocksDB into
+  // RocksDB-Cloud. Call this before opening the database with RocksDB-Cloud.
+  virtual Status MigrateFromPureRocksDB(const std::string& local_dbname) = 0;
 
   // Reads a file from the cloud
   virtual Status NewSequentialFileCloud(const std::string& bucket_prefix,


### PR DESCRIPTION
This PR improves the DB initialization in several ways:
* Detecting if the database is new is handled explicitly in `DBCloud::Open()`.
  Previously, low-level methods such as `CloudEnvImpl::RollNewEpoch()` handled
  new database creation. `RollNewEpoch()` is no longer called for new databases.
* No automatic migration from non-cloud RocksDB. Migration is now executed
  explicitly through `CloudEnv::MigrateFromPureRocksDB()`. This simplifies the
  initialization when migration from RocksDB is not necessary and reduces its
  surface area.
* CLOUDMANIFEST is created explicitly in `DBCloud::Open()` if it's not found.
  It is uploaded to the cloud after `DB::Open()`, which means the cloud
  database will never be left in an inconsistent state where CLOUDMANIFEST
  exists, but MANIFEST doesn't. In the cloud, CLOUDMANIFEST always needs to
  point to a valid MANIFEST.

The PR also contains important fixes to db_cloud_test, which were failing
before this. They now succeed.
