### PR TITLE
[SYS-2483] Add an option to not roll cloud manifest on startup

### DIFF
--- a/cloud/cloud_env_options.cc
+++ b/cloud/cloud_env_options.cc
@@ -39,6 +39,8 @@ void CloudEnvOptions::Dump(Logger* log) const {
          number_objects_listed_in_one_iteration);
   Header(log, "   COptions.use_direct_io_for_cloud_download: %d",
          use_direct_io_for_cloud_download);
+  Header(log, "        COptions.roll_cloud_manifest_on_open: %d",
+         roll_cloud_manifest_on_open);
   if (sst_file_cache != nullptr) {
     Header(log, "           COptions.sst_file_cache size: %ld bytes",
            sst_file_cache->GetCapacity());

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -346,6 +346,11 @@ class CloudEnvOptions {
   // Default: false
   bool use_direct_io_for_cloud_download;
 
+  // Experimental option!
+  // If false, we don't roll cloud manifest when opening the database.
+  // Default: true
+  bool roll_cloud_manifest_on_open;
+
   CloudEnvOptions(
       CloudType _cloud_type = CloudType::kCloudAws,
       LogType _log_type = LogType::kLogKafka,
@@ -362,7 +367,8 @@ class CloudEnvOptions {
       int _constant_sst_file_size_in_sst_file_manager = -1,
       bool _skip_cloud_files_in_getchildren = false,
       bool _use_direct_io_for_cloud_download = false,
-      std::shared_ptr<Cache> _sst_file_cache = nullptr)
+      std::shared_ptr<Cache> _sst_file_cache = nullptr,
+      bool _roll_cloud_manifest_on_open = true)
       : log_type(_log_type),
         sst_file_cache(_sst_file_cache),
         keep_local_sst_files(_keep_local_sst_files),
@@ -383,7 +389,8 @@ class CloudEnvOptions {
         constant_sst_file_size_in_sst_file_manager(
             _constant_sst_file_size_in_sst_file_manager),
         skip_cloud_files_in_getchildren(_skip_cloud_files_in_getchildren),
-        use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download) {
+        use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download),
+        roll_cloud_manifest_on_open(_roll_cloud_manifest_on_open) {
     (void) _cloud_type;
   }
 


### PR DESCRIPTION
Follower in physical replication shouldn't roll cloud manifest epoch on open.
Otherwise, it can't find the files that the leader created. This PR adds an
option that lets us skip epoch roll on startup.

This code will change in the future when we start propagating CLOUDMANIFEST
updates in the replication log, which is why I'm marking the option as
experimental.
