### PR TITLE
[SYS-2536] Fix memtable switch replication bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,6 +940,7 @@ set(SOURCES
         cloud/cloud_storage_provider.cc
         cloud/cloud_file_cache.cc
         db/db_impl/db_impl_remote_compaction.cc
+        db/db_impl/replication_codec.cc
         $<TARGET_OBJECTS:build_version>)
 
 list(APPEND SOURCES

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1092,6 +1092,7 @@ Status DeserializeReplicationLogManifestWrite(Slice* src,
 }  // namespace
 
 Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
+                                         std::string replication_sequence,
                                          ApplyReplicationLogRecordInfo* info) {
   JobContext job_context(0, true);
   Status s;
@@ -1145,7 +1146,9 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
           }
 
           cfd->Ref();
-          s = SwitchMemtableWithoutCreatingWAL(cfd, &write_context, mem_switch_record);
+          s = SwitchMemtableWithoutCreatingWAL(cfd, &write_context,
+                                               mem_switch_record.next_log_num,
+                                               replication_sequence);
           cfd->UnrefAndTryDelete();
           if (!s.ok()) {
             break;

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1132,13 +1132,13 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
       }
       case ReplicationLogRecord::kMemtableSwitch: {
         WriteContext write_context;
-        MemtableSwitchRecord mem_switch_record;
+        MemTableSwitchRecord mem_switch_record;
         Slice contents_slice(record.contents);
         DeserializeMemtableSwitchRecord(&contents_slice, &mem_switch_record);
 
         auto cf_set = versions_->GetColumnFamilySet();
         for (size_t i = 0; i < mem_switch_record.lognums.size(); i++) {
-          MemtableLogNumAndReplSeq lognum_and_repl_seq = mem_switch_record.GetLogNumAndReplSeq(i);
+          MemTableLogNumAndReplSeq lognum_and_repl_seq = mem_switch_record.GetLogNumAndReplSeq(i);
           auto cfd = cf_set->GetColumnFamily(lognum_and_repl_seq.lognum->column_family);
           assert(cfd != nullptr && !cfd->IsDropped() && !cfd->IsEmpty());
           cfd->Ref();

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -22,6 +22,7 @@
 #include "db/column_family.h"
 #include "db/compaction/compaction_iterator.h"
 #include "db/compaction/compaction_job.h"
+#include "db/db_impl/replication_codec.h"
 #include "db/error_handler.h"
 #include "db/event_helpers.h"
 #include "db/external_sst_file_ingestion_job.h"
@@ -1718,16 +1719,14 @@ class DBImpl : public DB {
 
   Status TrimMemtableHistory(WriteContext* context);
 
-  // Depending on `lognum_and_repl_seq`, different actions can be taken when
-  // switching memtable.
-  // 1) lognum_and_repl_seq is null: create new log when !log_empty
-  // 2) lognum_and_repl_seq is not null & it contains valid log number: always
-  // create new log, use the log number specified in lognum_and_repl_seq
-  // 3) lognum_and_repl_seq is not null & no valid log number: always create new
-  // log, generate log number based on manifest next_file_num and initialize lognum
-  // in lognum_and_repl_seq as the generated log number
+  // Switch memtable without creating new WAL. Also set the next_log_num as
+  // specified in mem_switch_record.
+  //
+  // NOTE: this function should only be used when WAL is disabled
   Status SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
-                        MemTableLogNumAndReplSeq* lognum_and_repl_seq);
+                        const MemTableSwitchRecord& mem_switch_record);
+
+  Status SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context);
 
   void SelectColumnFamiliesForAtomicFlush(autovector<ColumnFamilyData*>* cfds);
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -86,7 +86,7 @@ class WriteCallback;
 struct JobContext;
 struct ExternalSstFileInfo;
 struct MemTableInfo;
-struct MemtableLogNumAndReplSeq;
+struct MemTableLogNumAndReplSeq;
 
 // Class to maintain directories for all database paths other than main one.
 class Directories {
@@ -1727,7 +1727,7 @@ class DBImpl : public DB {
   // log, generate log number based on manifest next_file_num and initialize lognum
   // in lognum_and_repl_seq as the generated log number
   Status SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
-                        MemtableLogNumAndReplSeq* lognum_and_repl_seq);
+                        MemTableLogNumAndReplSeq* lognum_and_repl_seq);
 
   void SelectColumnFamiliesForAtomicFlush(autovector<ColumnFamilyData*>* cfds);
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -86,6 +86,7 @@ class WriteCallback;
 struct JobContext;
 struct ExternalSstFileInfo;
 struct MemTableInfo;
+struct MemtableLogNumAndReplSeq;
 
 // Class to maintain directories for all database paths other than main one.
 class Directories {
@@ -1717,8 +1718,16 @@ class DBImpl : public DB {
 
   Status TrimMemtableHistory(WriteContext* context);
 
+  // Depending on `lognum_and_repl_seq`, different actions can be taken when
+  // switching memtable.
+  // 1) lognum_and_repl_seq is null: create new log when !log_empty
+  // 2) lognum_and_repl_seq is not null & it contains valid log number: always
+  // create new log, use the log number specified in lognum_and_repl_seq
+  // 3) lognum_and_repl_seq is not null & no valid log number: always create new
+  // log, generate log number based on manifest next_file_num and initialize lognum
+  // in lognum_and_repl_seq as the generated log number
   Status SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
-                        std::string replication_sequence);
+                        MemtableLogNumAndReplSeq* lognum_and_repl_seq);
 
   void SelectColumnFamiliesForAtomicFlush(autovector<ColumnFamilyData*>* cfds);
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -333,6 +333,7 @@ class DBImpl : public DB {
 
   Status ApplyReplicationLogRecord(
       ReplicationLogRecord record,
+      std::string replication_sequence,
       ApplyReplicationLogRecordInfo* info) override;
   Status GetPersistedReplicationSequence(std::string* out) override;
 
@@ -1720,7 +1721,7 @@ class DBImpl : public DB {
   Status TrimMemtableHistory(WriteContext* context);
 
   // Switch memtable without creating new WAL. Also set the next_log_num and
-  // replication_sequence as specified in mem_switch_record.
+  // replication_sequence in switched memtable
   //
   // NOTE:
   // - this function should only be used when WAL is disabled.
@@ -1731,8 +1732,9 @@ class DBImpl : public DB {
   // REQUIRES: this thread is currently at the front of the writer queue
   // REQUIRES: this thread is currently at the front of the 2nd writer queue if
   // two_write_queues_ is true (This is to simplify the reasoning.)
-  Status SwitchMemtableWithoutCreatingWAL(ColumnFamilyData* cfd, WriteContext* context,
-                        const MemTableSwitchRecord& mem_switch_record);
+  Status SwitchMemtableWithoutCreatingWAL(
+      ColumnFamilyData* cfd, WriteContext* context, uint64_t next_log_num,
+      const std::string& replication_sequence);
 
   Status SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context);
 

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2164,7 +2164,7 @@ Status DBImpl::AtomicFlushMemTables(
       }
     }
 
-    MemtableSwitchRecord mem_switch_record;
+    MemTableSwitchRecord mem_switch_record;
     if (immutable_db_options_.replication_log_listener) {
       mem_switch_record.replication_sequence = immutable_db_options_.replication_log_listener->NewReplicationSequence();
     }

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -136,10 +136,10 @@ Status DBImpl::TEST_SwitchMemtable(ColumnFamilyData* cfd) {
   if (two_write_queues_) {
     WriteThread::Writer nonmem_w;
     nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
-    s = SwitchMemtable(cfd, &write_context, "");
+    s = SwitchMemtable(cfd, &write_context, nullptr );
     nonmem_write_thread_.ExitUnbatched(&nonmem_w);
   } else {
-    s = SwitchMemtable(cfd, &write_context, "");
+    s = SwitchMemtable(cfd, &write_context, nullptr);
   }
   TEST_EndWrite(writer);
   return s;

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -136,10 +136,10 @@ Status DBImpl::TEST_SwitchMemtable(ColumnFamilyData* cfd) {
   if (two_write_queues_) {
     WriteThread::Writer nonmem_w;
     nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
-    s = SwitchMemtable(cfd, &write_context, nullptr );
+    s = SwitchMemtable(cfd, &write_context);
     nonmem_write_thread_.ExitUnbatched(&nonmem_w);
   } else {
-    s = SwitchMemtable(cfd, &write_context, nullptr);
+    s = SwitchMemtable(cfd, &write_context);
   }
   TEST_EndWrite(writer);
   return s;

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2021,6 +2021,9 @@ Status DBImpl::SwitchMemtableWithoutCreatingWAL(
 // REQUIRES: this thread is currently at the front of the 2nd writer queue if
 // two_write_queues_ is true (This is to simplify the reasoning.)
 Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
+  // SwitchMemtableWithoutCreatingWAL should be used when
+  // replication_log_listener is set
+  assert(!immutable_db_options_.replication_log_listener);
   mutex_.AssertHeld();
   log::Writer* new_log = nullptr;
   MemTable* new_mem = nullptr;

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1622,7 +1622,7 @@ Status DBImpl::HandleWriteBufferManagerFlush(WriteContext* write_context) {
     MaybeFlushStatsCF(&cfds);
   }
 
-  MemtableSwitchRecord mem_switch_record;
+  MemTableSwitchRecord mem_switch_record;
   if (immutable_db_options_.replication_log_listener) {
     mem_switch_record.replication_sequence =
         immutable_db_options_.replication_log_listener
@@ -1897,7 +1897,7 @@ Status DBImpl::ScheduleFlushes(WriteContext* context) {
     nonmem_write_thread_.EnterUnbatched(&nonmem_w, &mutex_);
   }
 
-  MemtableSwitchRecord mem_switch_record;
+  MemTableSwitchRecord mem_switch_record;
   if (immutable_db_options_.replication_log_listener) {
     mem_switch_record.replication_sequence =
         immutable_db_options_.replication_log_listener
@@ -1965,7 +1965,7 @@ void DBImpl::NotifyOnMemTableSealed(ColumnFamilyData* /*cfd*/,
 // REQUIRES: this thread is currently at the front of the 2nd writer queue if
 // two_write_queues_ is true (This is to simplify the reasoning.)
 Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
-                              MemtableLogNumAndReplSeq* lognum_and_repl_seq) {
+                              MemTableLogNumAndReplSeq* lognum_and_repl_seq) {
   mutex_.AssertHeld();
   log::Writer* new_log = nullptr;
   MemTable* new_mem = nullptr;
@@ -2166,7 +2166,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context,
   if (lognum_and_repl_seq != nullptr) {
     cfd->mem()->SetReplicationSequence(*lognum_and_repl_seq->replication_sequence);
     if (!lognum_and_repl_seq->lognum_initialized) {
-      *lognum_and_repl_seq->lognum = MemtableLogNumber{cfd->GetID(), cfd->mem()->GetID(), logfile_number_};
+      *lognum_and_repl_seq->lognum = MemTableLogNumber{cfd->GetID(), cfd->mem()->GetID(), logfile_number_};
     }
   }
   assert(new_mem != nullptr);

--- a/db/db_impl/replication_codec.cc
+++ b/db/db_impl/replication_codec.cc
@@ -1,0 +1,62 @@
+#include "db/db_impl/replication_codec.h"
+#include "util/coding.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+Status SerializeMemtableSwitchRecord(std::string* dst, const MemtableSwitchRecord &record) {
+  PutFixed16(dst, 1); // version
+  PutLengthPrefixedSlice(dst, record.replication_sequence);
+  PutVarint64(dst, record.lognums.size());
+  for (auto lognum: record.lognums) {
+    PutVarint64(dst, lognum.column_family);
+    PutVarint64(dst, lognum.memtable_id);
+    PutVarint64(dst, lognum.memtable_next_log_num);
+  }
+  return Status::OK();
+}
+Status DeserializeMemtableSwitchRecord(Slice* src, MemtableSwitchRecord* record) {
+  uint16_t version;
+  if (!GetFixed16(src, &version)) {
+    return Status::Corruption("Unable to decode memtable switch record version");
+  }
+  Slice replication_sequence_slice;
+  if (!GetLengthPrefixedSlice(src, &replication_sequence_slice)) {
+    return Status::Corruption("Unable to decode memtable switch replication sequence");
+  }
+  uint64_t size;
+  if (!GetVarint64(src, &size)) {
+    return Status::Corruption("Unable to decode memtable switch lognums array size");
+  }
+  autovector<MemtableLogNumber> lognums;
+  for (uint64_t i = 0; i < size; i++) {
+    uint64_t column_family, memtable_id, next_log_num;
+    if (!GetVarint64(src, &column_family)) {
+      return Status::Corruption("Unable to decode memtable switch record column family");
+    }
+    if (!GetVarint64(src, &memtable_id)) {
+      return Status::Corruption("Unable to decode memtable switch record memtable id");
+    }
+    if (!GetVarint64(src, &next_log_num)) {
+      return Status::Corruption("Unable to decode memtable switch next log num");
+    }
+    lognums.push_back({column_family, memtable_id, next_log_num});
+  }
+  record->replication_sequence = replication_sequence_slice.ToString(false);
+  record->lognums = std::move(lognums);
+  return Status::OK();
+}
+
+void MaybeRecordMemtableSwitch(
+    const std::shared_ptr<rocksdb::ReplicationLogListener>&
+        replication_log_listener,
+    const MemtableSwitchRecord& mem_switch_record) {
+  if (replication_log_listener) {
+    ReplicationLogRecord rlr;
+    rlr.type = ReplicationLogRecord::kMemtableSwitch;
+    SerializeMemtableSwitchRecord(&rlr.contents, mem_switch_record);
+    replication_log_listener->OnReplicationLogRecord(
+      mem_switch_record.replication_sequence,
+      std::move(rlr));
+  }
+}
+}

--- a/db/db_impl/replication_codec.cc
+++ b/db/db_impl/replication_codec.cc
@@ -3,13 +3,13 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-Status SerializeMemtableSwitchRecord(std::string* dst, const MemTableSwitchRecord &record) {
+Status SerializeMemTableSwitchRecord(std::string* dst, const MemTableSwitchRecord &record) {
   PutFixed16(dst, 1); // version
   PutVarint64(dst, record.next_log_num);
   PutLengthPrefixedSlice(dst, record.replication_sequence);
   return Status::OK();
 }
-Status DeserializeMemtableSwitchRecord(Slice* src, MemTableSwitchRecord* record) {
+Status DeserializeMemTableSwitchRecord(Slice* src, MemTableSwitchRecord* record) {
   uint16_t version;
   if (!GetFixed16(src, &version)) {
     return Status::Corruption("Unable to decode memtable switch record version");
@@ -28,14 +28,18 @@ Status DeserializeMemtableSwitchRecord(Slice* src, MemTableSwitchRecord* record)
   return Status::OK();
 }
 
-void MaybeRecordMemtableSwitch(
+void MaybeRecordMemTableSwitch(
     const std::shared_ptr<rocksdb::ReplicationLogListener>&
         replication_log_listener,
-    const MemTableSwitchRecord& mem_switch_record) {
+    uint64_t next_log_num, MemTableSwitchRecord* mem_switch_record) {
   if (replication_log_listener) {
+    mem_switch_record->replication_sequence =
+        replication_log_listener->NewReplicationSequence();
+    mem_switch_record->next_log_num = next_log_num;
+
     ReplicationLogRecord rlr;
     rlr.type = ReplicationLogRecord::kMemtableSwitch;
-    SerializeMemtableSwitchRecord(&rlr.contents, mem_switch_record);
+    SerializeMemTableSwitchRecord(&rlr.contents, *mem_switch_record);
     replication_log_listener->OnReplicationLogRecord(std::move(rlr));
   }
 }

--- a/db/db_impl/replication_codec.h
+++ b/db/db_impl/replication_codec.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+
+#include "db/memtable.h"
+#include "rocksdb/options.h"
+#include "util/autovector.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// log number related info we store in the log with each `kMemtableSwitch` event
+struct MemtableLogNumber {
+  uint64_t column_family;
+  uint64_t memtable_id;
+  uint64_t memtable_next_log_num;
+};
+
+struct MemtableLogNumAndReplSeq {
+  MemtableLogNumber* lognum{nullptr};
+  std::string* replication_sequence{nullptr};
+  bool lognum_initialized{false};
+};
+
+// A record corresponds to `kMemtableSwitch` event
+struct MemtableSwitchRecord {
+  void AddLogNum(MemtableLogNumber lognum) {
+    lognums.push_back(std::move(lognum));
+  }
+
+  MemtableLogNumAndReplSeq AddUninitializedLogNum() {
+    lognums.push_back({});
+    return {&lognums.back(), &replication_sequence, false};
+  }
+
+  // Assuming all the lognums has been initialized
+  MemtableLogNumAndReplSeq GetLogNumAndReplSeq(size_t idx) {
+    return MemtableLogNumAndReplSeq{
+      &lognums[idx],
+      &replication_sequence,
+      true};
+  }
+
+  // next_log_number for all the switched memtables
+  autovector<MemtableLogNumber> lognums;
+  std::string replication_sequence;
+};
+
+
+Status SerializeMemtableSwitchRecord(
+    std::string* dst,
+    const MemtableSwitchRecord &record);
+Status DeserializeMemtableSwitchRecord(
+    Slice* src,
+    MemtableSwitchRecord* record);
+
+void MaybeRecordMemtableSwitch(
+  const std::shared_ptr<rocksdb::ReplicationLogListener> &replication_log_listener,
+  const MemtableSwitchRecord& mem_switch_record);
+}

--- a/db/db_impl/replication_codec.h
+++ b/db/db_impl/replication_codec.h
@@ -15,10 +15,6 @@ struct MemTableSwitchRecord {
   // share same next_log_num. next_log_num is used to determine whether a
   // memtable is flushed and can be removed
   uint64_t next_log_num;
-  // replication sequence number for the switched memtables. All CFDs flushed
-  // atomically will share the same replication_sequence. We rely on the
-  // replication_sequence when recovering based on Manifest + replication log
-  std::string replication_sequence;
 };
 
 Status SerializeMemTableSwitchRecord(
@@ -30,11 +26,13 @@ Status DeserializeMemTableSwitchRecord(
 
 // Record `kMemtableSwitch` event, also initializes `mem_switch_record`
 //
+// @return replication_sequence for the log record
+//
 // NOTE: this function has to be called before corresponding `kManifestWrite`.
 // We rely on this assumption during recovery based on Manifest and repliation
 // log
-void MaybeRecordMemTableSwitch(
-  const std::shared_ptr<rocksdb::ReplicationLogListener> &replication_log_listener,
-  uint64_t next_log_num,
-  MemTableSwitchRecord *mem_switch_record);
-}
+std::string RecordMemTableSwitch(
+    const std::shared_ptr<rocksdb::ReplicationLogListener>&
+        replication_log_listener,
+    const MemTableSwitchRecord& mem_switch_record);
+}  // namespace ROCKSDB_NAMESPACE

--- a/db/db_impl/replication_codec.h
+++ b/db/db_impl/replication_codec.h
@@ -21,19 +21,20 @@ struct MemTableSwitchRecord {
   std::string replication_sequence;
 };
 
-Status SerializeMemtableSwitchRecord(
+Status SerializeMemTableSwitchRecord(
     std::string* dst,
     const MemTableSwitchRecord &record);
-Status DeserializeMemtableSwitchRecord(
+Status DeserializeMemTableSwitchRecord(
     Slice* src,
     MemTableSwitchRecord* record);
 
-// Record `kMemtableSwitch` event.
+// Record `kMemtableSwitch` event, also initializes `mem_switch_record`
 //
 // NOTE: this function has to be called before corresponding `kManifestWrite`.
 // We rely on this assumption during recovery based on Manifest and repliation
 // log
-void MaybeRecordMemtableSwitch(
+void MaybeRecordMemTableSwitch(
   const std::shared_ptr<rocksdb::ReplicationLogListener> &replication_log_listener,
-  const MemTableSwitchRecord& mem_switch_record);
+  uint64_t next_log_num,
+  MemTableSwitchRecord *mem_switch_record);
 }

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -391,6 +391,17 @@ class MemTableList {
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
 
+  std::vector<std::pair<uint64_t, uint64_t>> TEST_GetNextLogNumbers() const {
+    const auto& memlist = current_->memlist_;
+    std::vector<std::pair<uint64_t, uint64_t>> lognums;
+    lognums.reserve(memlist.size());
+    for (auto it = memlist.begin(); it != memlist.end(); it++) {
+      MemTable* mem = *it;
+      lognums.emplace_back(mem->GetID(), mem->GetNextLogNumber());
+    }
+    return lognums;
+  }
+
  private:
   friend Status InstallMemtableAtomicFlushResults(
       const autovector<MemTableList*>* imm_lists,

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -391,7 +391,8 @@ class MemTableList {
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
 
-  // Return all the next_log_num and replication_sequence in unflushed memtables
+  // @return vector of <memtable id, next_log_num, replication_sequence> in
+  // unflushed memtables
   std::vector<std::tuple<uint64_t, uint64_t, std::string>>
   TEST_GetNextLogNumAndReplSeq() const {
     const auto& memlist = current_->memlist_;

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -391,15 +391,19 @@ class MemTableList {
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
 
-  std::vector<std::pair<uint64_t, uint64_t>> TEST_GetNextLogNumbers() const {
+  // Return all the next_log_num and replication_sequence in unflushed memtables
+  std::vector<std::tuple<uint64_t, uint64_t, std::string>>
+  TEST_GetNextLogNumAndReplSeq() const {
     const auto& memlist = current_->memlist_;
-    std::vector<std::pair<uint64_t, uint64_t>> lognums;
-    lognums.reserve(memlist.size());
+    std::vector<std::tuple<uint64_t, uint64_t, std::string>>
+        lognums_and_repl_seqs;
+    lognums_and_repl_seqs.reserve(memlist.size());
     for (auto it = memlist.begin(); it != memlist.end(); it++) {
       MemTable* mem = *it;
-      lognums.emplace_back(mem->GetID(), mem->GetNextLogNumber());
+      lognums_and_repl_seqs.emplace_back(mem->GetID(), mem->GetNextLogNumber(),
+                                         mem->GetReplicationSequence());
     }
-    return lognums;
+    return lognums_and_repl_seqs;
   }
 
  private:

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1232,6 +1232,7 @@ class DB {
   // REQUIRES: info needs to be provided, can't be nullptr.
   virtual Status ApplyReplicationLogRecord(
       ReplicationLogRecord record,
+      std::string replication_sequence,
       ApplyReplicationLogRecordInfo* info) = 0;
   // Returns the latest replication log sequence number (returned by
   // ReplicationLogListener::OnReplicationLogRecord()) that is persisted in the

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -475,6 +475,33 @@ class ReplicationLogListener {
   // the database needs to re-apply all replication log records since
   // DB::GetPersistedReplicationSequence() (non-inclusive).
   virtual std::string OnReplicationLogRecord(ReplicationLogRecord record) = 0;
+
+  // Unlike the other log event, kMemtableSwitch needs to be split into two
+  // phases:
+
+  // Phase1): Get the replication sequence and assign it to all the
+  // switched memtablesx
+  // Phase2): Write the kMemtableSwitch event to log (with the
+  // replication sequence)
+  //
+  // TODO(wei): note that there is race condition with current implementation!
+  // It's possible to have concurrent kMemtableSwitch and kManifiestWrite. So
+  // it's possible to have another kManifestWrite(with bigger replication
+  // sequence) happens after Phase1 and before Phase2. One solution for this
+  // issue is to split the `kMemtableSwitch` event into two:
+  //
+  // a) `kMemtableSwitchPrepare`, we assign the replication sequence generated
+  // in this step to switched memtables and write log.
+  // b) `kMemtableSwitchCommit`, we log the replication sequence generated in
+  // Prepare phase and all the next_log_number for memtables.
+
+  // When server recovers based on manifest and replication log, it will find
+  // the last flushed `kMemtableSwitchPrepare`, apply all the logs after that
+  // EXCEPT `kManifestWrite` already committed and the first
+  // `kMemtableSwitchCommit` after it.
+  virtual std::string NewReplicationSequence() = 0;
+  virtual bool OnReplicationLogRecord(Slice replication_sequence,
+                                      ReplicationLogRecord record) = 0;
 };
 
 struct DBOptions {

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -475,12 +475,6 @@ class ReplicationLogListener {
   // the database needs to re-apply all replication log records since
   // DB::GetPersistedReplicationSequence() (non-inclusive).
   virtual std::string OnReplicationLogRecord(ReplicationLogRecord record) = 0;
-
-  // Generate a new replication sequence. Used when we need a replication
-  // sequence before sending the log record to listender
-  // 
-  // Similar to OnReplicationLogRecord, this function needs to be thread safe
-  virtual std::string NewReplicationSequence() = 0;
 };
 
 struct DBOptions {

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -479,8 +479,9 @@ class StackableDB : public DB {
 
   Status ApplyReplicationLogRecord(
       ReplicationLogRecord record,
+      std::string replication_sequence,
       ApplyReplicationLogRecordInfo* info) override {
-    return db_->ApplyReplicationLogRecord(record, info);
+    return db_->ApplyReplicationLogRecord(record, replication_sequence, info);
   }
   Status GetPersistedReplicationSequence(std::string* out) override {
     return db_->GetPersistedReplicationSequence(out);

--- a/src.mk
+++ b/src.mk
@@ -61,6 +61,7 @@ LIB_SOURCES =                                                   \
   db/db_impl/db_impl_remote_compaction.cc                       \
   db/db_impl/db_impl_secondary.cc                               \
   db/db_impl/db_impl_write.cc                                   \
+  db/db_impl/replication_codec.cc                               \
   db/db_info_dumper.cc                                          \
   db/db_iter.cc                                                 \
   db/dbformat.cc                                                \


### PR DESCRIPTION
Fixed multiple bugs related to memtable switch replication:

1. We don't use WAL, so all the switched memtables have the same next_log_num set. This can be an issue with physical replication.
2. We should pass `replication_sequence` and `next_log_num` with `kMemtableSwitch`. Detailed reason described in #SYS-2546
3. For our case, there is no need to create WAL when bumping `next_log_num`. removing that as well