### PR TITLE
cookie as suffix of cloud manifest file

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1783,7 +1783,7 @@ Status CloudEnvImpl::CreateCloudManifest(const std::string& local_dbname) {
 // REQ: This is an existing database.
 Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
   assert(cloud_env_options.roll_cloud_manifest_on_open);
-  auto oldEpoch = GetCloudManifest()->GetCurrentEpoch().ToString();
+  auto oldEpoch = GetCurrentEpoch().ToString();
   // Find next file number. We use dummy MANIFEST filename, which should get
   // remapped into the correct MANIFEST filename through CloudManifest.
   // After this call we should also have a local file named
@@ -1797,8 +1797,8 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
   }
   // roll new epoch
   auto newEpoch = generateNewEpochId();
-  GetCloudManifest()->AddEpoch(maxFileNumber, newEpoch);
-  GetCloudManifest()->Finalize();
+  cloud_manifest_->AddEpoch(maxFileNumber, newEpoch);
+  cloud_manifest_->Finalize();
   Log(InfoLogLevel::INFO_LEVEL, info_log_,
       "Rolling new CLOUDMANIFEST from file number %lu, renaming MANIFEST-%s to "
       "MANIFEST-%s",
@@ -1815,7 +1815,7 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
   if (!st.ok()) {
     return st;
   }
-  st = writeCloudManifest(GetCloudManifest(), CloudManifestFile(local_dbname));
+  st = writeCloudManifest(cloud_manifest_.get(), CloudManifestFile(local_dbname));
   if (!st.ok()) {
     return st;
   }

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -237,7 +237,6 @@ class CloudEnvImpl : public CloudEnv {
     return base_env_->GetFreeSpace(path, diskfree);
   }
 
-  CloudManifest* GetCloudManifest() { return cloud_manifest_.get(); }
   void TEST_InitEmptyCloudManifest();
   void TEST_DisableCloudManifest() { test_disable_cloud_manifest_ = true; }
 
@@ -265,6 +264,15 @@ class CloudEnvImpl : public CloudEnv {
   void FileCachePurge();
   uint64_t FileCacheGetCharge();
   uint64_t FileCacheGetNumItems();
+  bool IsCloudManifestLoaded() const {
+    return cloud_manifest_.get() != nullptr;
+  }
+
+  // Get current epoch from the cloud manifest
+  // REQUIRES: cloud_manifest_ set
+  Slice GetCurrentEpoch() const {
+    return cloud_manifest_->GetCurrentEpoch();
+  }
 
  protected:
   Status CheckValidity() const;

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -185,11 +185,6 @@ class CloudEnvImpl : public CloudEnv {
   // Load CLOUDMANIFEST if exists in local disk to current env.
   Status LoadLocalCloudManifest(const std::string& dbname);
 
-  // Local CLOUDMANIFEST from `base_env` into `cloud_manifest`.
-  static Status LoadLocalCloudManifest(
-      const std::string& dbname, Env* base_env,
-      std::unique_ptr<CloudManifest>* cloud_manifest);
-
   Status CreateCloudManifest(const std::string& local_dbname);
 
   // Transfers the filename from RocksDB's domain to the physical domain, based
@@ -273,6 +268,8 @@ class CloudEnvImpl : public CloudEnv {
   Slice GetCurrentEpoch() const {
     return cloud_manifest_->GetCurrentEpoch();
   }
+
+  std::string CloudManifestFile(const std::string& dbname) const;
 
  protected:
   Status CheckValidity() const;
@@ -364,6 +361,9 @@ class CloudEnvImpl : public CloudEnv {
            const std::string& msg);
   Status writeCloudManifest(CloudManifest* manifest, const std::string& fname);
   std::string generateNewEpochId();
+
+  // TODO(wei): support switching cloud_manifest_ and cookie without reopening
+  // db. We need to protect these two with a shared mutex.
   std::unique_ptr<CloudManifest> cloud_manifest_;
   // This runs only in tests when we want to disable cloud manifest
   // functionality

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -123,7 +123,7 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
   bool new_db = false;
   // If cloud manifest is already loaded, this means the directory has been
   // sanitized (possibly by the call to ListColumnFamilies())
-  if (cenv->GetCloudManifest() == nullptr) {
+  if (!cenv->IsCloudManifestLoaded()) {
     st = cenv->SanitizeDirectory(options, local_dbname, read_only);
 
     if (st.ok()) {
@@ -343,7 +343,7 @@ Status DBCloudImpl::DoCheckpointToCloud(
   files_to_copy.emplace_back(IdentityFileName(""), IdentityFileName(""));
 
   // MANIFEST file
-  auto current_epoch = cenv->GetCloudManifest()->GetCurrentEpoch().ToString();
+  auto current_epoch = cenv->GetCurrentEpoch().ToString();
   auto manifest_fname = ManifestFileWithEpoch("", current_epoch);
   auto tmp_manifest_fname = manifest_fname + ".tmp";
   auto fs = base_env->GetFileSystem();

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -192,8 +192,8 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
     // was already uploaded. It is at this point we consider the database
     // committed in the cloud.
     st = cenv->GetStorageProvider()->PutCloudObject(
-        CloudManifestFile(local_dbname), cenv->GetDestBucketName(),
-        CloudManifestFile(cenv->GetDestObjectPath()));
+        cenv->CloudManifestFile(local_dbname), cenv->GetDestBucketName(),
+        cenv->CloudManifestFile(cenv->GetDestObjectPath()));
   }
 
   // now that the database is opened, all file sizes have been verified and we
@@ -357,7 +357,7 @@ Status DBCloudImpl::DoCheckpointToCloud(
   files_to_copy.emplace_back(tmp_manifest_fname, std::move(manifest_fname));
 
   // CLOUDMANIFEST file
-  files_to_copy.emplace_back(CloudManifestFile(""), CloudManifestFile(""));
+  files_to_copy.emplace_back(cenv->CloudManifestFile(""), cenv->CloudManifestFile(""));
 
   std::atomic<size_t> next_file_to_copy{0};
   int thread_count = std::max(1, options.thread_count);

--- a/cloud/filename.h
+++ b/cloud/filename.h
@@ -79,10 +79,6 @@ inline bool ends_with(std::string const& value, std::string const& ending) {
   return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
-inline std::string CloudManifestFile(const std::string& dbname) {
-  return dbname + "/CLOUDMANIFEST";
-}
-
 inline std::string ManifestFileWithEpoch(const std::string& dbname,
                                          const std::string& epoch) {
   return epoch.empty() ? (dbname + "/MANIFEST")

--- a/cloud/manifest_reader.cc
+++ b/cloud/manifest_reader.cc
@@ -31,7 +31,8 @@ Status ManifestReader::GetLiveFilesAndCloudManifest(
   Status s;
   {
     std::unique_ptr<SequentialFile> file;
-    auto cloudManifestFile = CloudManifestFile(bucket_path);
+    auto cenv_impl = static_cast<CloudEnvImpl*>(cenv_);
+    auto cloudManifestFile = cenv_impl->CloudManifestFile(bucket_path);
     s = cenv_->NewSequentialFileCloud(bucket_prefix_, cloudManifestFile, &file,
                                       EnvOptions());
     if (!s.ok()) {

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -351,6 +351,13 @@ class CloudEnvOptions {
   // Default: true
   bool roll_cloud_manifest_on_open;
 
+  // Cookie determines which CLOUDMANIFEST file we read. The value will
+  // be changed when there is leader election(set as leader's epoch)
+  // If 0, cookie won't be used. So we are expecting that valid epoch of leader
+  // should always be > 0
+  // Default: 0
+  uint64_t cookie;
+
   CloudEnvOptions(
       CloudType _cloud_type = CloudType::kCloudAws,
       LogType _log_type = LogType::kLogKafka,
@@ -368,7 +375,8 @@ class CloudEnvOptions {
       bool _skip_cloud_files_in_getchildren = false,
       bool _use_direct_io_for_cloud_download = false,
       std::shared_ptr<Cache> _sst_file_cache = nullptr,
-      bool _roll_cloud_manifest_on_open = true)
+      bool _roll_cloud_manifest_on_open = true,
+      uint64_t _cookie = 0)
       : log_type(_log_type),
         sst_file_cache(_sst_file_cache),
         keep_local_sst_files(_keep_local_sst_files),
@@ -390,7 +398,8 @@ class CloudEnvOptions {
             _constant_sst_file_size_in_sst_file_manager),
         skip_cloud_files_in_getchildren(_skip_cloud_files_in_getchildren),
         use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download),
-        roll_cloud_manifest_on_open(_roll_cloud_manifest_on_open) {
+        roll_cloud_manifest_on_open(_roll_cloud_manifest_on_open),
+        cookie(_cookie) {
     (void) _cloud_type;
   }
 


### PR DESCRIPTION
Refactored `CloudEnv` and `CloudManifest` to prepare for cloud manifest switch change:

1) Made cookie suffix of the cloud manifest file name. To make sure this is backwards compatible, I use cookie=0 as special value. So I'm assuming that valid leader epoch should always start from 1.  Cookie is associated with an object of `CloudEnv` (specified in `CloudEnvOption` when opening the db and updated when there is leader election). Therefore, we can only get name of `CloudManifestFile` from an object of `CloudEnv`
2) Removed public access of `cloud_manifest_` within `CloudEnv` object. We will protect access to `cloud_manifest_` (and cookie as well) with shared lock when switching cloud manifest. So this is necessary to prevent accidentally accessing `cloud_manifest_` without lock.

- [x] Tested with `db_cloud_test` 