### PR TITLE
Revert "Disable user_key_comparison_count stat"

### DIFF
--- a/util/user_comparator_wrapper.h
+++ b/util/user_comparator_wrapper.h
@@ -8,11 +8,13 @@
 
 #pragma once
 
+#include "monitoring/perf_context_imp.h"
 #include "rocksdb/comparator.h"
 
 namespace ROCKSDB_NAMESPACE {
 
-// Wrapper of user comparator
+// Wrapper of user comparator, with auto increment to
+// perf_context.user_key_comparison_count.
 class UserComparatorWrapper final : public Comparator {
  public:
   // `UserComparatorWrapper`s constructed with the default constructor are not
@@ -27,10 +29,12 @@ class UserComparatorWrapper final : public Comparator {
   const Comparator* user_comparator() const { return user_comparator_; }
 
   int Compare(const Slice& a, const Slice& b) const override {
+    PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->Compare(a, b);
   }
 
   bool Equal(const Slice& a, const Slice& b) const override {
+    PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->Equal(a, b);
   }
 
@@ -65,6 +69,7 @@ class UserComparatorWrapper final : public Comparator {
   using Comparator::CompareWithoutTimestamp;
   int CompareWithoutTimestamp(const Slice& a, bool a_has_ts, const Slice& b,
                               bool b_has_ts) const override {
+    PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->CompareWithoutTimestamp(a, a_has_ts, b, b_has_ts);
   }
 


### PR DESCRIPTION
This reverts commit 719ea519749788b9782b033fa8f60ac215756d73.

I saw a few compilation errors with the commit:
```
In file included from ./db/arena_wrapped_db_iter.h:14,
                 from db/arena_wrapped_db_iter.cc:10:
./db/db_iter.h: In member function 'void rocksdb::DBIter::LocalStatistics::BumpGlobalStatistics(rocksdb::Statistics*)':
./db/db_iter.h:97:24: error: 'iter_read_bytes' was not declared in this scope
   97 |       PERF_COUNTER_ADD(iter_read_bytes, bytes_read_);
      |                        ^~~~~~~~~~~~~~~
./db/db_iter.h:97:7: error: 'PERF_COUNTER_ADD' was not declared in this scope
   97 |       PERF_COUNTER_ADD(iter_read_bytes, bytes_read_);
      |       ^~~~~~~~~~~~~~~~
```

Also, I'll update the branch protection rules for this repo.