### PR TITLE
Disable user_key_comparison_count stat

### DIFF
--- a/util/user_comparator_wrapper.h
+++ b/util/user_comparator_wrapper.h
@@ -29,12 +29,10 @@ class UserComparatorWrapper final : public Comparator {
   const Comparator* user_comparator() const { return user_comparator_; }
 
   int Compare(const Slice& a, const Slice& b) const override {
-    PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->Compare(a, b);
   }
 
   bool Equal(const Slice& a, const Slice& b) const override {
-    PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->Equal(a, b);
   }
 
@@ -69,7 +67,6 @@ class UserComparatorWrapper final : public Comparator {
   using Comparator::CompareWithoutTimestamp;
   int CompareWithoutTimestamp(const Slice& a, bool a_has_ts, const Slice& b,
                               bool b_has_ts) const override {
-    PERF_COUNTER_ADD(user_key_comparison_count, 1);
     return user_comparator_->CompareWithoutTimestamp(a, a_has_ts, b, b_has_ts);
   }
 


### PR DESCRIPTION
We don't use the stat, and accessing thread local storage is expensive

Kicking off a new rockset build against this commit to make sure everything compiles: https://buildkite.com/rockset/build-everything/builds/59433