### PR TITLE
Expose ManifestUpdateSequence in public DB API

### DIFF
--- a/cloud/replication_test.cc
+++ b/cloud/replication_test.cc
@@ -474,6 +474,13 @@ TEST_F(ReplicationTest, Simple) {
   EXPECT_EQ(catchUpFollower(), 2);
   ASSERT_OK(follower->Get(ReadOptions(), "key7", &val));
   EXPECT_EQ(val, "val7");
+
+  uint64_t followerManifestUpdateSeq;
+  uint64_t leaderManifestUpdateSeq;
+  follower->GetManifestUpdateSequence(&followerManifestUpdateSeq);
+  leader->GetManifestUpdateSequence(&leaderManifestUpdateSeq);
+  EXPECT_EQ(followerManifestUpdateSeq, 14);
+  EXPECT_EQ(leaderManifestUpdateSeq, 14);
 }
 
 TEST_F(ReplicationTest, MultiColumnFamily) {

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1273,6 +1273,12 @@ Status DBImpl::GetPersistedReplicationSequence(std::string* out) {
   return Status::OK();
 }
 
+Status DBImpl::GetManifestUpdateSequence(uint64_t* out) {
+  InstrumentedMutexLock l(&mutex_);
+  *out = versions_->GetManifestUpdateSequence();
+  return Status::OK();
+}
+
 Status DBImpl::SetOptions(
     ColumnFamilyHandle* column_family,
     const std::unordered_map<std::string, std::string>& options_map) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -336,6 +336,7 @@ class DBImpl : public DB {
       std::string replication_sequence,
       ApplyReplicationLogRecordInfo* info) override;
   Status GetPersistedReplicationSequence(std::string* out) override;
+  Status GetManifestUpdateSequence(uint64_t* out) override;
 
   using DB::SetOptions;
   Status SetOptions(

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1244,6 +1244,8 @@ class DB {
   // manifest writes mantain their own versioning and the persisted ones will be
   // correctly ignored by ApplyReplicationLogRecord().
   virtual Status GetPersistedReplicationSequence(std::string* out) = 0;
+  // Returns latest ManifestUpdateSequence.
+  virtual Status GetManifestUpdateSequence(uint64_t* out) = 0;
 
   // TODO: documentation needed
   // NOTE: SetOptions is intended only for expert users, and does not apply the

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -486,6 +486,9 @@ class StackableDB : public DB {
   Status GetPersistedReplicationSequence(std::string* out) override {
     return db_->GetPersistedReplicationSequence(out);
   }
+  Status GetManifestUpdateSequence(uint64_t* out) override {
+    return db_->GetManifestUpdateSequence(out);
+  }
 
   using DB::SetOptions;
   virtual Status SetOptions(ColumnFamilyHandle* column_family_handle,


### PR DESCRIPTION
We need this information in leader-follower protocol. Followers need to know if
the manifest they have locally is recent enough or if they need to fetch a new
one from the cloud.

