### PR TITLE
Find live files based on local manifest files

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -2054,40 +2054,6 @@ Status CloudEnvImpl::CheckValidity() const {
   }
 }
 
-Status CloudEnvImpl::FetchCurrentManifest(const std::string& local_dbname) const {
-  assert(cloud_manifest_);
-  auto current_epoch = cloud_manifest_->GetCurrentEpoch().ToString();
-  if (HasDestBucket()) {
-    Status st = GetStorageProvider()->GetCloudObject(
-      GetDestBucketName(), ManifestFileWithEpoch(GetDestObjectPath(), current_epoch),
-      ManifestFileWithEpoch(local_dbname, current_epoch));
-    if (!st.ok() && !st.IsPathNotFound()) {
-      return st;
-    }
-
-    if (st.ok()) {
-      return st;
-    }
-  }
-
-  // we couldn't get cloud manifest from dest, need to try from src
-  if (HasSrcBucket() && !SrcMatchesDest()) {
-    Status st = GetStorageProvider()->GetCloudObject(
-      GetSrcBucketName(), ManifestFileWithEpoch(GetSrcObjectPath(), current_epoch),
-      ManifestFileWithEpoch(local_dbname, current_epoch));
-    if (!st.ok() && !st.IsPathNotFound()) {
-      return st;
-    }
-
-    if (st.ok()) {
-      return st;
-    }
-  }
-
-  return Status::NotFound("Manifest file with epoch: " + current_epoch +
-                          " is not found in s3");
-}
-
 Status CloudEnvImpl::FindAllLiveFiles(const std::string& local_dbname,
                                       std::vector<std::string>* live_sst_files,
                                       std::string* manifest_file) {

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -869,7 +869,8 @@ Status CloudEnvImpl::LoadLocalCloudManifest(
   return s;
 }
 
-std::string RemapFilenameWithCloudManifest(const std::string& logical_path, CloudManifest* cloud_manifest) {
+std::string RemapFilenameWithCloudManifest(const std::string& logical_path,
+                                           CloudManifest* cloud_manifest) {
   auto file_name = basename(logical_path);
   uint64_t fileNumber;
   FileType type;
@@ -2053,27 +2054,60 @@ Status CloudEnvImpl::CheckValidity() const {
   }
 }
 
-Status CloudEnvImpl::FindAllLiveFiles(const std::string& bucket,
-                                      const std::string& object_path,
+Status CloudEnvImpl::FetchCurrentManifest(const std::string& local_dbname) const {
+  assert(cloud_manifest_);
+  auto current_epoch = cloud_manifest_->GetCurrentEpoch().ToString();
+  if (HasDestBucket()) {
+    Status st = GetStorageProvider()->GetCloudObject(
+      GetDestBucketName(), ManifestFileWithEpoch(GetDestObjectPath(), current_epoch),
+      ManifestFileWithEpoch(local_dbname, current_epoch));
+    if (!st.ok() && !st.IsPathNotFound()) {
+      return st;
+    }
+
+    if (st.ok()) {
+      return st;
+    }
+  }
+
+  // we couldn't get cloud manifest from dest, need to try from src
+  if (HasSrcBucket() && !SrcMatchesDest()) {
+    Status st = GetStorageProvider()->GetCloudObject(
+      GetSrcBucketName(), ManifestFileWithEpoch(GetSrcObjectPath(), current_epoch),
+      ManifestFileWithEpoch(local_dbname, current_epoch));
+    if (!st.ok() && !st.IsPathNotFound()) {
+      return st;
+    }
+
+    if (st.ok()) {
+      return st;
+    }
+  }
+
+  return Status::NotFound("Manifest file with epoch: " + current_epoch +
+                          " is not found in s3");
+}
+
+Status CloudEnvImpl::FindAllLiveFiles(const std::string& local_dbname,
                                       std::vector<std::string>* live_sst_files,
                                       std::string* manifest_file) {
-  std::unique_ptr<ManifestReader> extractor(
-      new ManifestReader(info_log_, this, bucket));
+  std::unique_ptr<LocalManifestReader> extractor(
+      new LocalManifestReader(info_log_, this));
   std::set<uint64_t> file_nums;
-  std::unique_ptr<CloudManifest> cloud_manifest;
-  auto st = extractor->GetLiveFilesAndCloudManifest(object_path, &file_nums,
-                                                    &cloud_manifest);
+  auto st = extractor->GetLiveFilesLocally(local_dbname, &file_nums);
   if (!st.ok()) {
     return st;
   }
-  std::string current_epoch = cloud_manifest->GetCurrentEpoch().ToString();
+
   live_sst_files->resize(file_nums.size());
-  *manifest_file = ManifestFileWithEpoch(object_path, current_epoch);
+
+  // filename will be remapped correctly based on current_epoch of cloud_manifest
+  *manifest_file =
+      RemapFilename(ManifestFileWithEpoch("" /* dbname */, "" /* epoch */));
   size_t idx = 0;
   for (auto num : file_nums) {
-    std::string logical_path = MakeTableFileName(object_path, num);
-    (*live_sst_files)[idx] =
-        RemapFilenameWithCloudManifest(logical_path, cloud_manifest.get());
+    std::string logical_path = MakeTableFileName("" /* path */, num);
+    (*live_sst_files)[idx] = RemapFilename(logical_path);
     idx++;
   }
   return Status::OK();

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -173,10 +173,15 @@ class CloudEnvImpl : public CloudEnv {
                            std::vector<std::string>* pathnames);
   Status FindObsoleteDbid(const std::string& bucket_name_prefix,
                           std::vector<std::string>* dbids);
-  Status FindAllLiveFiles(const std::string& bucket,
-                          const std::string& object_path,
+  Status FetchCurrentManifest(const std::string& local_dbname) const override;
+
+  // Find all live files based on cloud_manifest_ and local MANIFEST FILE
+  // 
+  // NOTE: we assume that cloud_manifest_ is not changed when calling FindAllLiveFiles
+  Status FindAllLiveFiles(const std::string& local_dbname,
                           std::vector<std::string>* live_sst_files,
                           std::string* manifest_file) override;
+
   Status extractParents(const std::string& bucket_name_prefix,
                         const DbidList& dbid_list, DbidParents* parents);
   Status PreloadCloudManifest(const std::string& local_dbname) override;

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -173,11 +173,12 @@ class CloudEnvImpl : public CloudEnv {
                            std::vector<std::string>* pathnames);
   Status FindObsoleteDbid(const std::string& bucket_name_prefix,
                           std::vector<std::string>* dbids);
-  Status FetchCurrentManifest(const std::string& local_dbname) const override;
 
   // Find all live files based on cloud_manifest_ and local MANIFEST FILE
+  // If local MANIFEST file doesn't exist, it will pull from cloud
   // 
-  // NOTE: we assume that cloud_manifest_ is not changed when calling FindAllLiveFiles
+  // REQUIRES: cloud_manifest_ is loaded
+  // REQUIRES: cloud_manifest_ is not updated when calling this function
   Status FindAllLiveFiles(const std::string& local_dbname,
                           std::vector<std::string>* live_sst_files,
                           std::string* manifest_file) override;

--- a/cloud/cloud_env_wrapper.h
+++ b/cloud/cloud_env_wrapper.h
@@ -297,8 +297,7 @@ class MockCloudEnv : public CloudEnv {
     return notsup_;
   }
 
-  Status FindAllLiveFiles(const std::string& /* bucket */,
-                          const std::string& /* object_path */,
+  Status FindAllLiveFiles(const std::string& /* local_dbname */,
                           std::vector<std::string>* /* live_sst_files */,
                           std::string* /* manifest_file */) override {
     return notsup_;

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -1864,7 +1864,7 @@ TEST_F(CloudTest, FileCacheOnDemand) {
   CloseDB();
 }
 
-TEST_F(CloudTest, FetchCurrentManifestTest) {
+TEST_F(CloudTest, FindLiveFilesFetchManifestTest) {
   OpenDB();
   ASSERT_OK(db_->Put({}, "a", "1"));
   ASSERT_OK(db_->Flush({}));
@@ -1881,13 +1881,7 @@ TEST_F(CloudTest, FetchCurrentManifestTest) {
   // fetch and load CloudManifest
   ASSERT_OK(aenv_->PreloadCloudManifest(dbname_));
 
-  // there is no local Manifest file, so find live files will fail
-  EXPECT_TRUE(aenv_->FindAllLiveFiles(dbname_, &live_sst_files, &manifest_file)
-                  .IsNotFound());
-
-  // fetch the current manifest
-  ASSERT_OK(aenv_->FetchCurrentManifest(dbname_));
-
+  // manifest file will be fetched to local db
   ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &live_sst_files, &manifest_file));
   EXPECT_EQ(live_sst_files.size(), 1);
 }

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -1,13 +1,8 @@
 // Copyright (c) 2017 Rockset
 
-#include <gtest/gtest.h>
-#include "cloud/cloud_env_impl.h"
-#include "rocksdb/cloud/cloud_env_options.h"
 #ifndef ROCKSDB_LITE
 
 #ifdef USE_AWS
-
-#include "rocksdb/cloud/db_cloud.h"
 
 #include <algorithm>
 #include <chrono>
@@ -20,6 +15,7 @@
 #include "logging/logging.h"
 #include "rocksdb/cloud/cloud_storage_provider.h"
 #include "rocksdb/options.h"
+#include "rocksdb/cloud/db_cloud.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
 #include "db/db_impl/db_impl.h"
@@ -382,27 +378,30 @@ TEST_F(CloudTest, FindAllLiveFilesTest) {
   ASSERT_OK(db_->Put(WriteOptions(), "Hello", "World"));
   ASSERT_OK(db_->Flush(FlushOptions()));
 
-  CloseDB();
-  DestroyDir(dbname_);
-  OpenDB();
+  // wait until files are persisted into s3
+  GetDBImpl()->TEST_WaitForBackgroundWork();
 
   std::vector<std::string> tablefiles;
   std::string manifest;
-  aenv_->FindAllLiveFiles(aenv_->GetSrcBucketName(), aenv_->GetSrcObjectPath(),
-                          &tablefiles, &manifest);
+  ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &tablefiles, &manifest));
   EXPECT_EQ(tablefiles.size(), 1);
   for (auto name: tablefiles) {
     EXPECT_EQ(GetFileType(name), RocksDBFileType::kSstFile);
-    // verify that the sst file indeed exists
-    EXPECT_TRUE(aenv_->GetStorageProvider()
-                    ->ExistsCloudObject(aenv_->GetSrcBucketName(), name)
-                    .ok());
+    // verify that the sst file indeed exists in cloud
+    EXPECT_TRUE(
+        aenv_->GetStorageProvider()
+            ->ExistsCloudObject(aenv_->GetSrcBucketName(),
+                                aenv_->GetSrcObjectPath() + pathsep + name)
+            .ok());
   }
 
   EXPECT_EQ(GetFileType(manifest), RocksDBFileType::kManifestFile);
-  EXPECT_TRUE(aenv_->GetStorageProvider()
-                  ->ExistsCloudObject(aenv_->GetSrcBucketName(), manifest)
-                  .ok());
+  // verify that manifest file indeed exists in cloud
+  EXPECT_TRUE(
+      aenv_->GetStorageProvider()
+          ->ExistsCloudObject(aenv_->GetSrcBucketName(),
+                              aenv_->GetSrcObjectPath() + pathsep + manifest)
+          .ok());
 }
 
 // Files of dropped CF should not be included in live files
@@ -412,36 +411,25 @@ TEST_F(CloudTest, LiveFilesOfDroppedCFTest) {
 
   std::vector<std::string> tablefiles;
   std::string manifest;
-  ASSERT_OK(aenv_->FindAllLiveFiles(aenv_->GetSrcBucketName(),
-                                    aenv_->GetSrcObjectPath(), &tablefiles,
-                                    &manifest));
+  ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &tablefiles, &manifest));
 
   EXPECT_TRUE(tablefiles.empty());
   CreateColumnFamilies({"cf1"}, &handles);
-  auto db_impl = GetDBImpl();
 
   // write to CF
   ASSERT_OK(db_->Put(WriteOptions(), handles[1], "hello", "world"));
   // flush cf1
   ASSERT_OK(db_->Flush({}, handles[1]));
 
-  // wait until background flush job is done, so that the Manifest updates are
-  // synced to s3
-  db_impl->TEST_WaitForBackgroundWork();
-
   tablefiles.clear();
-  ASSERT_OK(aenv_->FindAllLiveFiles(aenv_->GetSrcBucketName(),
-                                    aenv_->GetSrcObjectPath(), &tablefiles,
-                                    &manifest));
+  ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &tablefiles, &manifest));
   EXPECT_TRUE(tablefiles.size() == 1);
 
   // Drop the CF
   ASSERT_OK(db_->DropColumnFamily(handles[1]));
   tablefiles.clear();
   // make sure that files are not listed as live for dropped CF
-  ASSERT_OK(aenv_->FindAllLiveFiles(aenv_->GetSrcBucketName(),
-                                    aenv_->GetSrcObjectPath(), &tablefiles,
-                                    &manifest));
+  ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &tablefiles, &manifest));
   EXPECT_TRUE(tablefiles.empty());
   CloseDB(&handles);
 }
@@ -456,13 +444,10 @@ TEST_F(CloudTest, LiveFilesAfterChangingLevelTest) {
   ASSERT_OK(db_->Flush({}));
   auto db_impl = GetDBImpl();
 
-  ASSERT_OK(db_impl->TEST_WaitForBackgroundWork());
-
   std::vector<std::string> tablefiles_before_move;
   std::string manifest;
-  ASSERT_OK(aenv_->FindAllLiveFiles(aenv_->GetSrcBucketName(),
-                                    aenv_->GetSrcObjectPath(),
-                                    &tablefiles_before_move, &manifest));
+  ASSERT_OK(
+      aenv_->FindAllLiveFiles(dbname_, &tablefiles_before_move, &manifest));
   EXPECT_EQ(tablefiles_before_move.size(), 1);
 
   CompactRangeOptions cro;
@@ -474,9 +459,8 @@ TEST_F(CloudTest, LiveFilesAfterChangingLevelTest) {
   ASSERT_OK(db_impl->TEST_WaitForBackgroundWork());
 
   std::vector<std::string> tablefiles_after_move;
-  ASSERT_OK(aenv_->FindAllLiveFiles(aenv_->GetSrcBucketName(),
-                                    aenv_->GetSrcObjectPath(),
-                                    &tablefiles_after_move, &manifest));
+  ASSERT_OK(
+      aenv_->FindAllLiveFiles(dbname_, &tablefiles_after_move, &manifest));
   EXPECT_EQ(tablefiles_before_move, tablefiles_after_move);
 }
 
@@ -1878,6 +1862,34 @@ TEST_F(CloudTest, FileCacheOnDemand) {
   EXPECT_EQ(local_files.size(), 2);
 
   CloseDB();
+}
+
+TEST_F(CloudTest, FetchCurrentManifestTest) {
+  OpenDB();
+  ASSERT_OK(db_->Put({}, "a", "1"));
+  ASSERT_OK(db_->Flush({}));
+  CloseDB();
+
+  DestroyDir(dbname_);
+
+  // recreate cloud env, which points to the same bucket and objectpath
+  CreateCloudEnv();
+
+  std::vector<std::string> live_sst_files;
+  std::string manifest_file;
+
+  // fetch and load CloudManifest
+  ASSERT_OK(aenv_->PreloadCloudManifest(dbname_));
+
+  // there is no local Manifest file, so find live files will fail
+  EXPECT_TRUE(aenv_->FindAllLiveFiles(dbname_, &live_sst_files, &manifest_file)
+                  .IsNotFound());
+
+  // fetch the current manifest
+  ASSERT_OK(aenv_->FetchCurrentManifest(dbname_));
+
+  ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &live_sst_files, &manifest_file));
+  EXPECT_EQ(live_sst_files.size(), 1);
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/cloud/manifest_reader.cc
+++ b/cloud/manifest_reader.cc
@@ -32,17 +32,12 @@ Status LocalManifestReader::GetLiveFilesLocally(const std::string& local_dbname,
   std::unique_ptr<SequentialFileReader> manifest_file_reader;
   Status s;
   {
-    // file name here doesn't matter, 
-    auto manifest_file = ManifestFileWithEpoch(local_dbname, current_epoch);
-    // Check local file existence to return IsNotFound error if it doesn't exist.
-    // NewSequentialFile directly will return IOError
-    s = cenv_impl->GetBaseEnv()->FileExists(manifest_file);
-    if (!s.ok()) {
-      return s;
-    }
+    // file name here doesn't matter, it will always be mapped to the correct Manifest file
+    // use empty epoch here so that it will be recognized as manifest file type
+    auto manifest_file = ManifestFileWithEpoch(local_dbname, "" /* epoch */);
 
     std::unique_ptr<SequentialFile> file;
-    s = cenv_impl->GetBaseEnv()->NewSequentialFile(manifest_file, &file, EnvOptions());
+    s = cenv_impl->NewSequentialFile(manifest_file, &file, EnvOptions());
     if (!s.ok()) {
       return s;
     }

--- a/cloud/manifest_reader.h
+++ b/cloud/manifest_reader.h
@@ -13,33 +13,44 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+// Operates on MANIFEST files stored locally
+class LocalManifestReader {
+ public:
+  LocalManifestReader(std::shared_ptr<Logger> info_log, CloudEnv* cenv);
+
+  // Retrive all live files by reading manifest files locally.
+  // REQUIRES: there are CLOUDMANIFEST and MANIFEST files in local_dbname
+  // REQUIRES: cenv_ should have cloud_manifest_ set, and it should have the
+  // same content as the CLOUDMANIFEST file stored locally
+  Status GetLiveFilesLocally(const std::string& local_dbname,
+                             std::set<uint64_t>* list) const;
+
+ protected:
+  // Get all the live sst file number by reading version_edit records from file_reader
+  Status GetLiveFilesFromFileReader(
+      std::unique_ptr<SequentialFileReader> file_reader,
+      std::set<uint64_t>* list) const;
+
+  std::shared_ptr<Logger> info_log_;
+  CloudEnv* cenv_;
+};
+
 //
-// Operates on MANIFEST files stored in the cloud bucket
+// Operates on MANIFEST files stored in the cloud bucket directly
 //
-class ManifestReader {
+class ManifestReader: public LocalManifestReader {
  public:
   ManifestReader(std::shared_ptr<Logger> info_log, CloudEnv* cenv,
                  const std::string& bucket_prefix);
 
-  virtual ~ManifestReader();
-
   // Retrieve all live files referred to by this bucket path
-  Status GetLiveFiles(const std::string bucket_path, std::set<uint64_t>* list) {
-    std::unique_ptr<CloudManifest> cloud_manifest;
-    return GetLiveFilesAndCloudManifest(bucket_path, list, &cloud_manifest);
-  }
-
-  // Retrive all live files and cloud_manifest
-  Status GetLiveFilesAndCloudManifest(
-      const std::string bucket_path, std::set<uint64_t>* list,
-      std::unique_ptr<CloudManifest>* cloud_manifest);
+  // It will read from CLOUDMANIFEST and MANIFEST file in s3 directly
+  Status GetLiveFiles(const std::string& bucket_path,
+                      std::set<uint64_t>* list) const;
 
   static Status GetMaxFileNumberFromManifest(Env* env, const std::string& fname,
                                              uint64_t* maxFileNumber);
-
  private:
-  std::shared_ptr<Logger> info_log_;
-  CloudEnv* cenv_;
   std::string bucket_prefix_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/cloud/manifest_reader.h
+++ b/cloud/manifest_reader.h
@@ -19,9 +19,11 @@ class LocalManifestReader {
   LocalManifestReader(std::shared_ptr<Logger> info_log, CloudEnv* cenv);
 
   // Retrive all live files by reading manifest files locally.
-  // REQUIRES: there are CLOUDMANIFEST and MANIFEST files in local_dbname
+  // If Manifest file doesn't exist, it will be pulled from s3
+  //
   // REQUIRES: cenv_ should have cloud_manifest_ set, and it should have the
-  // same content as the CLOUDMANIFEST file stored locally
+  // same content as the CLOUDMANIFEST file stored locally. cloud_manifest_ is
+  // not updated when calling the function
   Status GetLiveFilesLocally(const std::string& local_dbname,
                              std::set<uint64_t>* list) const;
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1373,6 +1373,7 @@ class VersionSet {
   friend class DumpManifestHandler;
   friend class DBImpl;
   friend class DBImplReadOnly;
+  friend class LocalManifestReader;
   friend class ManifestReader;
 
   struct LogReporter : public log::Reader::Reporter {

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -530,9 +530,14 @@ class CloudEnv : public Env {
   // Files both in S3 and in the local directory have this [epoch] suffix.
   virtual std::string RemapFilename(const std::string& logical_name) const = 0;
 
-  // return the list of live files under bucket/object path
-  virtual Status FindAllLiveFiles(const std::string& bucket,
-                                  const std::string& object_path,
+  // Fetch current Manifest file into local
+  virtual Status FetchCurrentManifest(const std::string& local_dbname) const = 0;
+  // Find the list of live files based on CloudManifest and Manifest in local db
+  //
+  // For the returned filepath in `live_sst_files` and `manifest_file`, we only
+  // include the basename of the filepath but not the directory prefix to the
+  // file
+  virtual Status FindAllLiveFiles(const std::string& local_dbname,
                                   std::vector<std::string>* live_sst_files,
                                   std::string* manifest_file) = 0;
 

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -530,8 +530,6 @@ class CloudEnv : public Env {
   // Files both in S3 and in the local directory have this [epoch] suffix.
   virtual std::string RemapFilename(const std::string& logical_name) const = 0;
 
-  // Fetch current Manifest file into local
-  virtual Status FetchCurrentManifest(const std::string& local_dbname) const = 0;
   // Find the list of live files based on CloudManifest and Manifest in local db
   //
   // For the returned filepath in `live_sst_files` and `manifest_file`, we only


### PR DESCRIPTION
We changed the API of finding live files based on cloud manifest. 

##### Before the change
We need to specify the bucket from which to find live files. It read the cloud manifest and manifest from s3 directly with the range call api.

But this can be slow for large manifest files.

##### After the change
`FindLiveFiles` will pull manifest from s3 directly if not exists locally.

Now to list all live files for cloudmanifest in s3, we need to:

```
cloud_env->PreloadCloudManifest(local_dbname);  // fetch cloud manifest to local and load it into cloud_env
cloud_env->FindLiveFiles(local_dbname, &file_nums, &manifest); // find live files based on local manifest(which is fetched from s3 if not exists)
```

Of course, it assumes that `cloud_manifest` is not updated after loading. 

