### PR TITLE
Fix flaky test CloudTest.FileCacheOnDemand

### DIFF
--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -1824,7 +1824,7 @@ TEST_F(CloudTest, FileCacheLarge) {
 // Cache will have a few files only.
 TEST_F(CloudTest, FileCacheOnDemand) {
   size_t capacity = 3000;
-  int num_shard_bits = 1;
+  int num_shard_bits = 0; // 1 shard
   bool strict_capacity_limit = false;
   double high_pri_pool_ratio = 0;
 
@@ -1853,11 +1853,11 @@ TEST_F(CloudTest, FileCacheOnDemand) {
   db_->GetLiveFilesMetaData(&flist);
   EXPECT_EQ(flist.size(), 4);
 
-  // verify that there are only twp entries in the cache
+  // verify that there are only two entries in the cache
   EXPECT_EQ(cimpl->FileCacheGetNumItems(), 2);
   EXPECT_EQ(cimpl->FileCacheGetCharge(), cache->GetUsage());
 
-  // Theere should be only two local sst files.
+  // There should be only two local sst files.
   auto local_files = GetSSTFiles(dbname_);
   EXPECT_EQ(local_files.size(), 2);
 


### PR DESCRIPTION
The `CloudTest.FileCacheOnDemand` test is flaky. We created 2 shards for the lrucache, and total capacity = 3000 bytes. So each shard got 1500 capacity. In the most unlucky case, all 4 sst files might fall into one shard, and each sst file ~ 887bytes, so we ended up with only 1 sst file locally(one shard has 1500 capacity, so it can only hold one sst file). The fix is easy, we only allocated 1 shard for the lrucache. 


- [x] Tested locally by repeating the test multiple times.