### PR TITLE
Return manifest file version when finding live files

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -2057,10 +2057,19 @@ Status CloudEnvImpl::CheckValidity() const {
 Status CloudEnvImpl::FindAllLiveFiles(const std::string& local_dbname,
                                       std::vector<std::string>* live_sst_files,
                                       std::string* manifest_file) {
+  return FindAllLiveFilesAndFetchManifest(local_dbname, live_sst_files,
+                                          manifest_file,
+                                          nullptr /* manifest_file_version */);
+}
+
+Status CloudEnvImpl::FindAllLiveFilesAndFetchManifest(
+    const std::string& local_dbname, std::vector<std::string>* live_sst_files,
+    std::string* manifest_file, std::string* manifest_file_version) {
   std::unique_ptr<LocalManifestReader> extractor(
       new LocalManifestReader(info_log_, this));
   std::set<uint64_t> file_nums;
-  auto st = extractor->GetLiveFilesLocally(local_dbname, &file_nums);
+  auto st = extractor->GetLiveFilesLocally(local_dbname, &file_nums,
+                                           manifest_file_version);
   if (!st.ok()) {
     return st;
   }

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -182,6 +182,9 @@ class CloudEnvImpl : public CloudEnv {
   Status FindAllLiveFiles(const std::string& local_dbname,
                           std::vector<std::string>* live_sst_files,
                           std::string* manifest_file) override;
+  Status FindAllLiveFilesAndFetchManifest(
+      const std::string& local_dbname, std::vector<std::string>* live_sst_files,
+      std::string* manifest_file, std::string* manifest_file_version) override;
 
   Status extractParents(const std::string& bucket_name_prefix,
                         const DbidList& dbid_list, DbidParents* parents);

--- a/cloud/cloud_env_wrapper.h
+++ b/cloud/cloud_env_wrapper.h
@@ -303,6 +303,14 @@ class MockCloudEnv : public CloudEnv {
     return notsup_;
   }
 
+  Status FindAllLiveFilesAndFetchManifest(
+      const std::string& /* local_dbname */,
+      std::vector<std::string>* /* live_sst_files */,
+      std::string* /* manifest_file */,
+      std::string* /* manifest_file_version */) override {
+    return notsup_;
+  }
+
  private:
   Status notsup_;
   std::string empty_;

--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -302,13 +302,20 @@ Status CloudStorageProviderImpl::NewCloudReadableFile(
 Status CloudStorageProviderImpl::GetCloudObject(
     const std::string& bucket_name, const std::string& object_path,
     const std::string& local_destination) {
+  return GetCloudObjectAndVersion(bucket_name, object_path, local_destination,
+                                  nullptr /* version */);
+}
+
+Status CloudStorageProviderImpl::GetCloudObjectAndVersion(
+    const std::string& bucket_name, const std::string& object_path,
+    const std::string& local_destination, std::string* version) {
   Env* localenv = env_->GetBaseEnv();
   std::string tmp_destination =
       local_destination + ".tmp-" + std::to_string(rng_.Next());
 
   uint64_t remote_size;
-  Status s =
-      DoGetCloudObject(bucket_name, object_path, tmp_destination, &remote_size);
+  Status s = DoGetCloudObject(bucket_name, object_path, tmp_destination,
+                              &remote_size, version);
   if (!s.ok()) {
     localenv->DeleteFile(tmp_destination);
     return s;
@@ -335,6 +342,7 @@ Status CloudStorageProviderImpl::GetCloudObject(
       "[%s] GetCloudObject %s/%s size %" PRIu64 ". %s", bucket_name.c_str(),
       Name(), object_path.c_str(), local_size, s.ToString().c_str());
   return s;
+
 }
 
 Status CloudStorageProviderImpl::PutCloudObject(

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -5,6 +5,7 @@
 #ifndef ROCKSDB_LITE
 #include "rocksdb/cloud/cloud_storage_provider.h"
 #include "util/random.h"
+#include <optional>
 
 namespace ROCKSDB_NAMESPACE {
 class CloudStorageReadableFileImpl : public CloudStorageReadableFile {
@@ -109,6 +110,14 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
   Status GetCloudObject(const std::string& bucket_name,
                         const std::string& object_path,
                         const std::string& local_destination) override;
+  virtual Status GetCloudObjectAndVersion(const std::string& bucket_name,
+                                          const std::string& object_path,
+                                          const std::string& local_destination,
+                                          std::string* version);
+  // check that a version of cloud object exists. Only used in tests
+  virtual Status TEST_ExistsCloudObject(const std::string& bucket_name,
+                                        const std::string& object_path,
+                                        const std::string& version) = 0;
   Status PutCloudObject(const std::string& local_file,
                         const std::string& bucket_name,
                         const std::string& object_path) override;
@@ -130,7 +139,8 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
   virtual Status DoGetCloudObject(const std::string& bucket_name,
                                   const std::string& object_path,
                                   const std::string& local_path,
-                                  uint64_t* remote_size) = 0;
+                                  uint64_t* remote_size,
+                                  std::string* version) = 0;
   virtual Status DoPutCloudObject(const std::string& local_file,
                                   const std::string& object_path,
                                   const std::string& bucket_name,

--- a/cloud/manifest_reader.h
+++ b/cloud/manifest_reader.h
@@ -21,11 +21,19 @@ class LocalManifestReader {
   // Retrive all live files by reading manifest files locally.
   // If Manifest file doesn't exist, it will be pulled from s3
   //
+  // If manifest_file_version is not null, it will fetch latest Manifest file
+  // from s3 first before reading it(be careful with this since it will override
+  // the manfiest file in local_dbname). manifest_file_version will be set as
+  // the version we read from s3.
+  //
   // REQUIRES: cenv_ should have cloud_manifest_ set, and it should have the
   // same content as the CLOUDMANIFEST file stored locally. cloud_manifest_ is
   // not updated when calling the function
+  // REQUIRES: cloud storage has versioning enabled if manifest_file_version !=
+  // nullptr
   Status GetLiveFilesLocally(const std::string& local_dbname,
-                             std::set<uint64_t>* list) const;
+                             std::set<uint64_t>* list,
+                             std::string* manifest_file_version = nullptr) const;
 
  protected:
   // Get all the live sst file number by reading version_edit records from file_reader

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -538,6 +538,19 @@ class CloudEnv : public Env {
   virtual Status FindAllLiveFiles(const std::string& local_dbname,
                                   std::vector<std::string>* live_sst_files,
                                   std::string* manifest_file) = 0;
+  // Find the list of live files based on CloudManifest and Manifest in local
+  // db. Also, fetch the current Manifest file before reading.
+  //
+  // Besides returning live file paths, it also return the version of the fetched
+  // manfiest file, if the cloud storage has versioning enabled
+  //
+  // NOTE: be careful with using this function since it will override the local
+  // Manifest file in `local_dbname`!
+  // 
+  // REQUIRES: cloud storage has versioning enabled
+  virtual Status FindAllLiveFilesAndFetchManifest(
+      const std::string& local_dbname, std::vector<std::string>* live_sst_files,
+      std::string* manifest_file, std::string* manifest_file_version) = 0;
 
   // Create a new AWS env.
   // src_bucket_name: bucket name suffix where db data is read from


### PR DESCRIPTION
When finding all the live files based on manifest files, we would like to get the version(in s3) of the Manifest file we read from. Motivation behind this is, if a compaction happened after listing live files and before data copy, the version of Manifest file we read when copying the files would be inconsistent with the list of live sst files.

The way we achieve that is, if we ask for the manifest file version, we fetch the latest manfiest file from s3 and manifest file version. I added a separate API: `FindAllLiveFilesAndFetchManifest` in `CloudEnv` for this, since if we mistakenly called this function with a running db, it would override the local Manifest file with latest Manifest file in s3, which could potentially cause issue. Added a separate API here to make sure the user of this function is aware of it.

- [x] Tested with existing tests.