### PR TITLE
Fix the bug of not returning the correct file modification time

### DIFF
--- a/cloud/manifest_reader.cc
+++ b/cloud/manifest_reader.cc
@@ -1,7 +1,4 @@
 // Copyright (c) 2017 Rockset.
-#include <memory>
-#include "cloud/cloud_storage_provider_impl.h"
-#include "rocksdb/cloud/cloud_storage_provider.h"
 #ifndef ROCKSDB_LITE
 
 #include <unordered_map>
@@ -10,6 +7,7 @@
 #include "cloud/cloud_manifest.h"
 #include "cloud/db_cloud_impl.h"
 #include "cloud/filename.h"
+#include "cloud/cloud_storage_provider_impl.h"
 #include "db/version_set.h"
 #include "env/composite_env_wrapper.h"
 #include "rocksdb/db.h"


### PR DESCRIPTION
This [PR](https://github.com/rockset/rocksdb-cloud/pull/178) introduced a bug when returning the file modification time.

Root cause is [this line](https://github.com/rockset/rocksdb-cloud/blob/51a1cab/cloud/aws/aws_s3.cc#L704), in which we forgot to change the `HeadObject` call accordingly when updating the signature. It caused the `time` argument to be treated as `filesize` in `HeadObject`. 

Made following changes:
* There were so many default values for args of this `HeadObject` function that it's easy to cause bugs like this. So I updated the function signature as well to make sure we can catch similar issue with compiler
* Added test for the `GetFileModificationTime` function as well. Surprised that there is no test for it. It's used in a lot of places in rocksdb.