### PR TITLE
Remap logical_file to <local_file, remote_file>

### DIFF
--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -203,10 +203,17 @@ class CloudEnvImpl : public CloudEnv {
 
   // Transfers the filename from RocksDB's domain to the physical domain, based
   // on information stored in CLOUDMANIFEST.
-  // For example, it will map 00010.sst to 00010.sst-[epoch] where [epoch] is
-  // an epoch during which that file was created.
-  // Files both in S3 and in the local directory have this [epoch] suffix.
-  std::string RemapFilename(const std::string& logical_path) const override;
+  //
+  // After remapping, it's possible that local fname != remote fname
+  //
+  // For example,
+  // - For sst file, it will map 00010.sst to 00010.sst-[epoch](both locally and
+  // remotely) where [epoch] is an epoch during which that file was created.
+  // - For manifest file, when `include_epoch_in_manifest_filename=false`,
+  // "MANIFEST-NUM" file will be mapped to MANIFEST locally and MANIFEST-epoch
+  // remotely.
+  RemappedFilenames RemapFilename(
+      const std::string& logical_path) const override;
 
   // This will delete all files in dest bucket and locally whose epochs are
   // invalid. For example, if we find 00010.sst-[epochX], but the real mapping
@@ -289,7 +296,8 @@ class CloudEnvImpl : public CloudEnv {
   Status ExistsCloudObject(const std::string& fname);
 
   // Gets the cloud object fname from the dest or src bucket
-  Status GetCloudObject(const std::string& fname);
+  Status GetCloudObject(const std::string& remote_fname,
+                        const std::string& local_fname);
 
   // Gets the size of the named cloud object from the dest or src bucket
   Status GetCloudObjectSize(const std::string& fname, uint64_t* remote_size);

--- a/cloud/cloud_env_options.cc
+++ b/cloud/cloud_env_options.cc
@@ -41,6 +41,8 @@ void CloudEnvOptions::Dump(Logger* log) const {
          use_direct_io_for_cloud_download);
   Header(log, "        COptions.roll_cloud_manifest_on_open: %d",
          roll_cloud_manifest_on_open);
+  Header(log, "    COptions.local_manifest_has_epoch_suffix: %d",
+         local_manifest_has_epoch_suffix);
   if (sst_file_cache != nullptr) {
     Header(log, "           COptions.sst_file_cache size: %ld bytes",
            sst_file_cache->GetCapacity());

--- a/cloud/manifest_reader.cc
+++ b/cloud/manifest_reader.cc
@@ -41,16 +41,16 @@ Status LocalManifestReader::GetLiveFilesLocally(
     assert(cloud_storage_provider);
     // file name here doesn't matter, it will always be mapped to the correct Manifest file.
     // use empty epoch here so that it will be recognized as manifest file type
-    auto local_manifest_file = cenv_impl->RemapFilename(
+    auto [local_manifest_file, remote_manifest_file] = cenv_impl->RemapFilename(
         ManifestFileWithEpoch(local_dbname, "" /* epoch */));
 
     if (manifest_file_version != nullptr) {
       // Only fetch the latest Manifest file from cloud when we ask for the version number.
-      auto remote_manifest_file =
-          cenv_impl->GetSrcObjectPath() + "/" + basename(local_manifest_file);
+      auto remote_manifest_full_path =
+          cenv_impl->GetSrcObjectPath() + "/" + basename(remote_manifest_file);
 
       s = cloud_storage_provider->GetCloudObjectAndVersion(
-          cenv_impl->GetSrcBucketName(), remote_manifest_file,
+          cenv_impl->GetSrcBucketName(), remote_manifest_full_path,
           local_manifest_file, manifest_file_version);
       if (!s.ok()) {
         return s;


### PR DESCRIPTION
There are two major changes in this PR:
* supported remapping logical_file to <local_file, remote_file> so that local_file could be different from remote_file. Currently, this is only used to remap `MANIFEST` file to `MANIFEST` locally and `MANIFEST-epoch` remotely when `local_manifest_has_epoch_suffix = false`.  Motivation behind this change is to support switching `CLOUDMANIFEST` and `MANIFEST` without reopening db. Switching `MANIFEST` on a running db by copying to a new file is tricky. But it's much easier to achieve that if local `MANIFEST` file is always named as `MANIFEST`.
* When `resync_on_open=true` and `local_manifest_has_epoch_suffix=false`, we deleted local manifest files on db open. This helps maintain the invariant that `MANIFEST` file locally is always at local `CLOUDMANIFEST's current epoch` when local `MANIFEST` file doesn't have epoch suffix.

- [x] Tested locally 


