### PR TITLE
Remove version number from serialized mem switch record

### DIFF
--- a/db/db_impl/replication_codec.cc
+++ b/db/db_impl/replication_codec.cc
@@ -5,15 +5,10 @@
 namespace ROCKSDB_NAMESPACE {
 
 Status SerializeMemTableSwitchRecord(std::string* dst, const MemTableSwitchRecord &record) {
-  PutFixed16(dst, 1); // version
   PutVarint64(dst, record.next_log_num);
   return Status::OK();
 }
 Status DeserializeMemTableSwitchRecord(Slice* src, MemTableSwitchRecord* record) {
-  uint16_t version;
-  if (!GetFixed16(src, &version)) {
-    return Status::Corruption("Unable to decode memtable switch record version");
-  }
   uint64_t next_log_num;
   if (!GetVarint64(src, &next_log_num)) {
     return Status::Corruption("Unable to decode memtable switch next_log_num");


### PR DESCRIPTION
There is no need to include the version number here. If we want to change the format while maintaining backwards compatibility, we can always add another record type.