### PR TITLE
CLOUDMANIFEST dumper

### DIFF
--- a/cloud/cloud_manifest.cc
+++ b/cloud/cloud_manifest.cc
@@ -193,13 +193,15 @@ Slice CloudManifest::GetEpoch(uint64_t fileNumber) const {
   return Slice(itr->second);
 }
 
-std::string CloudManifest::ToString() const {
+std::string CloudManifest::ToString(bool include_past_epochs) const {
   std::ostringstream oss;
-  oss << "Past Epochs: [ ";
-  for (auto& pe : pastEpochs_) {
-    oss << "(" << pe.first << ", " << pe.second << "), ";
+  if (include_past_epochs) {
+    oss << "Past Epochs: [\n";
+    for (auto& pe : pastEpochs_) {
+      oss << "\t(" << pe.first << ", " << pe.second << "), \n";
+    }
+    oss << "]\n";
   }
-  oss << "] ";
   oss << "Current Epoch: " << currentEpoch_;
   return oss.str();
 }

--- a/cloud/cloud_manifest.h
+++ b/cloud/cloud_manifest.h
@@ -50,7 +50,7 @@ class CloudManifest {
   void Finalize();
   Slice GetEpoch(uint64_t fileNumber) const;
   Slice GetCurrentEpoch() const { return Slice(currentEpoch_); }
-  std::string ToString() const;
+  std::string ToString(bool include_past_epochs=false) const;
 
  private:
   CloudManifest(std::vector<std::pair<uint64_t, std::string>> pastEpochs,

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -740,4 +740,26 @@ class UnsafeRemoveSstFileCommand : public LDBCommand {
   uint64_t sst_file_number_;
 };
 
+// A command to dump cloud manifest
+class CloudManifestDumpCommand : public LDBCommand {
+  public:
+   static std::string Name() { return "cloud_manifest_dump"; }
+
+   CloudManifestDumpCommand(const std::vector<std::string>& params,
+                            const std::map<std::string, std::string>& options,
+                            const std::vector<std::string>& flags);
+   static void Help(std::string& ret);
+
+   virtual void DoCommand() override;
+
+   virtual bool NoDBOpen() override { return true; }
+  private:
+   // If true, will print past epochs as well
+   bool verbose_{false};
+   std::string path_;
+
+   static const std::string ARG_PATH;
+   static const std::string ARG_VERBOSE;
+};
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/tools/ldb_tool.cc
+++ b/tools/ldb_tool.cc
@@ -124,6 +124,7 @@ void LDBCommandRunner::PrintHelp(const LDBOptions& ldb_options,
   WriteExternalSstFilesCommand::Help(ret);
   IngestExternalSstFilesCommand::Help(ret);
   UnsafeRemoveSstFileCommand::Help(ret);
+  CloudManifestDumpCommand::Help(ret);
 
   fprintf(to_stderr ? stderr : stdout, "%s\n", ret.c_str());
 }


### PR DESCRIPTION
Made ldb to support dumping CLOUDMANIFEST

Example:

```
> ldb cloud_manifest_dump --path=CLOUDMANIFEST --verbose
Past Epochs: [
        (6, b4646dd83efb0cca),
        (12, 475afd2ff65ef56d),
        (16, d4490aa2f445463f),
        (21, b519e29a1bc838ed),
 ...
        (3265, 3643e39f9255b8d1),
        (3268, 9540f3f4009ae956),
        (3271, 85de60a55896cf47),
        (3275, bf4f896b7e402052),
]
Current Epoch: e8ab9866fb2973f2
```
