### PR TITLE
Reduce severity levels of some misleading logs

### DIFF
--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -1025,13 +1025,17 @@ Status S3StorageProvider::DoGetCloudObject(const std::string& bucket_name,
       } else {
         const auto& error = outcome.GetError();
         std::string errmsg(error.GetMessage().c_str(), error.GetMessage().size());
-        Log(InfoLogLevel::ERROR_LEVEL, env_->GetLogger(),
+        if (IsNotFound(error.GetErrorType())) {
+          Log(InfoLogLevel::ERROR_LEVEL, env_->GetLogger(),
             "[s3] GetObject %s/%s error %s.", bucket_name.c_str(),
             object_path.c_str(), errmsg.c_str());
-        if (IsNotFound(error.GetErrorType())) {
           return Status::NotFound(std::move(errmsg));
+        } else {
+          Log(InfoLogLevel::INFO_LEVEL, env_->GetLogger(),
+            "[s3] GetObject %s/%s error %s.", bucket_name.c_str(),
+            object_path.c_str(), errmsg.c_str());
+          return Status::IOError(std::move(errmsg));
         }
-        return Status::IOError(std::move(errmsg));
       }
     }
 

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1114,7 +1114,7 @@ Status CloudEnvImpl::NeedsReinitialization(const std::string& local_dir,
   // Check if CURRENT file exists
   st = env->FileExists(CurrentFileName(local_dir));
   if (!st.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+    Log(InfoLogLevel::INFO_LEVEL, info_log_,
         "[cloud_env_impl] NeedsReinitialization: "
         "failed to find CURRENT file %s: %s",
         CurrentFileName(local_dir).c_str(), st.ToString().c_str());
@@ -1124,7 +1124,7 @@ Status CloudEnvImpl::NeedsReinitialization(const std::string& local_dir,
   // Check if CLOUDMANIFEST file exists
   st = env->FileExists(CloudManifestFile(local_dir));
   if (!st.ok()) {
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+    Log(InfoLogLevel::INFO_LEVEL, info_log_,
         "[cloud_env_impl] NeedsReinitialization: "
         "failed to find CLOUDMANIFEST file %s: %s",
         CloudManifestFile(local_dir).c_str(), st.ToString().c_str());
@@ -1679,7 +1679,7 @@ Status CloudEnvImpl::SanitizeDirectory(const DBOptions& options,
   if (!got_identity_from_src && !got_identity_from_dest) {
     // There isn't a valid db in either the src or dest bucket.
     // Return with a success code so that a new DB can be created.
-    Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+    Log(InfoLogLevel::INFO_LEVEL, info_log_,
         "[cloud_env_impl] No valid dbs in src bucket %s src path %s "
         "or dest bucket %s dest path %s",
         GetSrcBucketName().c_str(), GetSrcObjectPath().c_str(),


### PR DESCRIPTION
I believe each of these are situation which would be an error with plain old rocksdb, but rocksdb treats it as a case where we need to reinitialize our local directory. Let's not spam the logs with scary red and yellow stuff when this is perfectly benign.