### PR TITLE
Making checkpoint to cloud upload MANIFEST and CLOUDMANIFEST only after uploading all SST files

### DIFF
--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -341,28 +341,18 @@ Status DBCloudImpl::DoCheckpointToCloud(
   dbid = rtrim_if(trim(dbid), '\n');
   files_to_copy.emplace_back(IdentityFileName(""), IdentityFileName(""));
 
-  // MANIFEST file
-  auto current_epoch = cenv->GetCloudManifest()->GetCurrentEpoch();
-  auto manifest_fname = ManifestFileWithEpoch("", current_epoch);
-  auto tmp_manifest_fname = manifest_fname + ".tmp";
-  auto fs = base_env->GetFileSystem();
-  st =
-      CopyFile(fs.get(), GetName() + "/" + manifest_fname,
-               GetName() + "/" + tmp_manifest_fname, manifest_file_size, false,
-               nullptr, Temperature::kUnknown);
-  if (!st.ok()) {
-    return st;
-  }
-  files_to_copy.emplace_back(tmp_manifest_fname, std::move(manifest_fname));
-
-  // CLOUDMANIFEST file
-  files_to_copy.emplace_back(cenv->CloudManifestFile(""), cenv->CloudManifestFile(""));
-
   std::atomic<size_t> next_file_to_copy{0};
   int thread_count = std::max(1, options.thread_count);
   std::vector<Status> thread_statuses;
   thread_statuses.resize(thread_count);
 
+  auto upload_file = [&](const std::shared_ptr<CloudStorageProvider>& provider,
+                         const std::string& localName,
+                         const std::string& destName) {
+    return provider->PutCloudObject(
+        GetName() + "/" + localName, destination.GetBucketName(),
+        destination.GetObjectPath() + "/" + destName);
+  };
   auto do_copy = [&](size_t threadId) {
     auto provider = cenv->GetStorageProvider();
     while (true) {
@@ -372,9 +362,7 @@ Status DBCloudImpl::DoCheckpointToCloud(
       }
 
       auto& f = files_to_copy[idx];
-      auto copy_st = provider->PutCloudObject(
-          GetName() + "/" + f.first, destination.GetBucketName(),
-          destination.GetObjectPath() + "/" + f.second);
+      auto copy_st = upload_file(provider, f.first, f.second);
       if (!copy_st.ok()) {
         thread_statuses[threadId] = std::move(copy_st);
         break;
@@ -401,6 +389,34 @@ Status DBCloudImpl::DoCheckpointToCloud(
     }
   }
 
+  if (!st.ok()) {
+    return st;
+  }
+
+  // Copy MANIFEST and CLOUDMANIFEST sequentially only after copying all data
+  // files
+
+  // MANIFEST file
+  auto current_epoch = cenv->GetCloudManifest()->GetCurrentEpoch();
+  auto manifest_fname = ManifestFileWithEpoch("", current_epoch);
+  auto tmp_manifest_fname = manifest_fname + ".tmp";
+  auto fs = base_env->GetFileSystem();
+  st = CopyFile(fs.get(), GetName() + "/" + manifest_fname,
+                GetName() + "/" + tmp_manifest_fname, manifest_file_size, false,
+                nullptr, Temperature::kUnknown);
+  if (!st.ok()) {
+    return st;
+  }
+
+  st = upload_file(cenv->GetStorageProvider(), tmp_manifest_fname,
+                   manifest_fname);
+  if (!st.ok()) {
+    return st;
+  }
+
+  // CLOUDMANIFEST file
+  st = upload_file(cenv->GetStorageProvider(), cenv->CloudManifestFile(""),
+                   cenv->CloudManifestFile(""));
   if (!st.ok()) {
     return st;
   }


### PR DESCRIPTION
With the current implementation it is possible that the MANIFEST and CLOUDMANIFEST are uploaded to s3 before all sst files. 