### PR TITLE
[SYS-2941] Added FlushSwitch to allow turning on flush if disabled initially

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1281,6 +1281,10 @@ Status DBImpl::GetManifestUpdateSequence(uint64_t* out) {
   return Status::OK();
 }
 
+Status DBImpl::TurnOnFlush() {
+  return immutable_db_options_.flush_switch->TurnOn();
+}
+
 Status DBImpl::SetOptions(
     ColumnFamilyHandle* column_family,
     const std::unordered_map<std::string, std::string>& options_map) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -337,6 +337,7 @@ class DBImpl : public DB {
       ApplyReplicationLogRecordInfo* info) override;
   Status GetPersistedReplicationSequence(std::string* out) override;
   Status GetManifestUpdateSequence(uint64_t* out) override;
+  Status TurnOnFlush() override;
 
   using DB::SetOptions;
   Status SetOptions(

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3247,6 +3247,9 @@ class ModelDB : public DB {
   Status GetManifestUpdateSequence(uint64_t* /*out*/) override {
     return Status::NotSupported("Not supported in Model DB");
   }
+  Status TurnOnFlush() override {
+    return Status::NotSupported("Not supported in Model DB");
+  }
 
  private:
   class ModelIter : public Iterator {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -58,6 +58,7 @@ struct ImmutableMemTableOptions {
   MergeOperator* merge_operator;
   Logger* info_log;
   bool allow_data_in_errors;
+  std::shared_ptr<FlushSwitch> flush_switch;
 };
 
 // Batched counters to updated when inserting keys in one write batch.

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1276,6 +1276,12 @@ class DB {
   virtual Status GetPersistedReplicationSequence(std::string* out) = 0;
   // Returns latest ManifestUpdateSequence.
   virtual Status GetManifestUpdateSequence(uint64_t* out) = 0;
+  // Enable flush if it's disabled. Both automatic flush and manual flush will
+  // be affected
+  //
+  // REQUIRES: flush is disabled before enabling. Otherwise, error status will
+  // be returned
+  virtual Status TurnOnFlush() = 0;
 
   // Dynamically change column family options or table factory options in a
   // running DB, for the specified column family. Only options internally

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -489,6 +489,9 @@ class StackableDB : public DB {
   Status GetManifestUpdateSequence(uint64_t* out) override {
     return db_->GetManifestUpdateSequence(out);
   }
+  Status TurnOnFlush() override {
+    return db_->TurnOnFlush();
+  }
 
   using DB::SetOptions;
   virtual Status SetOptions(ColumnFamilyHandle* column_family_handle,

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -772,7 +772,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       checksum_handoff_file_types(options.checksum_handoff_file_types),
       lowest_used_cache_tier(options.lowest_used_cache_tier),
       compaction_service(options.compaction_service),
-      enforce_single_del_contracts(options.enforce_single_del_contracts) {
+      enforce_single_del_contracts(options.enforce_single_del_contracts),
+      flush_switch(options.flush_switch) {
   fs = env->GetFileSystem();
   clock = env->GetSystemClock().get();
   logger = info_log.get();

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -110,6 +110,7 @@ struct ImmutableDBOptions {
   Logger* logger;
   std::shared_ptr<CompactionService> compaction_service;
   bool enforce_single_del_contracts;
+  std::shared_ptr<FlushSwitch> flush_switch;
 
   bool IsWalDirSameAsDBPath() const;
   bool IsWalDirSameAsDBPath(const std::string& path) const;


### PR DESCRIPTION
Flush could be triggered in following scenarios:
1. Single memtable exceeds `write_buffer_size` limit.  The memtable will be put into the flush scheduler queue, and flush is scheduled on next write.
2. All memtables exceed `db_write_buffer_size` limit. Memtables will be flushed right away
3. WAL size exceeds `max_total_wal_size`. Memtables will be flushed right away.
4. Manual flush

`FlushSwitch` allows us to enable flush if flush is disabled when opening db. All above four cases will be included (even though we only need 1 and 4)

I didn't support disabling flush on running db intentionally, since we don't need that right now. In leader/follower, db by default opens in follower mode with flush disabled. When follower tries to take over, it will enable flush. When a leader tries to become follower, it will reopen DB with flush disabled.

- [x] Tested by running added tests locally