### PR TITLE
Switch CLOUDMANIFEST on db open

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -851,11 +851,15 @@ void CloudEnvImpl::StopPurger() {
 }
 
 Status CloudEnvImpl::LoadLocalCloudManifest(const std::string& dbname) {
+  return LoadLocalCloudManifest(dbname, cloud_env_options.cookie_on_open);
+}
+
+Status CloudEnvImpl::LoadLocalCloudManifest(const std::string& dbname, const std::string& cookie) {
   if (cloud_manifest_) {
     cloud_manifest_.reset();
   }
   return CloudEnvImpl::LoadLocalCloudManifest(
-      dbname, GetBaseEnv(), cloud_env_options.cookie_on_open, &cloud_manifest_);
+      dbname, GetBaseEnv(), cookie, &cloud_manifest_);
 }
 
 Status CloudEnvImpl::LoadLocalCloudManifest(
@@ -1788,12 +1792,16 @@ Status CloudEnvImpl::FetchCloudManifest(const std::string& local_dbname, const s
 }
 
 Status CloudEnvImpl::CreateCloudManifest(const std::string& local_dbname) {
+  return CreateCloudManifest(local_dbname, cloud_env_options.cookie_on_open);
+}
+
+Status CloudEnvImpl::CreateCloudManifest(const std::string& local_dbname, const std::string& cookie) {
   // No cloud manifest, create an empty one
   std::unique_ptr<CloudManifest> manifest;
   CloudManifest::CreateForEmptyDatabase(generateNewEpochId(), &manifest);
-  auto st = writeCloudManifest(manifest.get(), CloudManifestFile(local_dbname));
+  auto st = writeCloudManifest(manifest.get(), MakeCloudManifestFile(local_dbname, cookie));
   if (st.ok()) {
-    st = LoadLocalCloudManifest(local_dbname);
+    st = LoadLocalCloudManifest(local_dbname, cookie);
   }
   return st;
 }

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1880,17 +1880,6 @@ Status CloudEnvImpl::UploadLocalCloudManifest(const std::string& local_dbname,
     return st;
   }
 
-  // Uploaded as CLOUDMANIFEST to s3 to make sure we can quickly rollback
-  if (!cookie.empty() &&
-      cloud_env_options.upload_cloud_manifest_without_cookie_suffix) {
-    st = GetStorageProvider()->PutCloudObject(
-        MakeCloudManifestFile(local_dbname, cookie), GetDestBucketName(),
-        MakeCloudManifestFile(GetDestObjectPath(), "" /* cookie */));
-    if (!st.ok()) {
-      return st;
-    }
-  }
-
   return st;
 }
 

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1816,7 +1816,7 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
   auto newEpoch = generateNewEpochId();
   // To make sure `RollNewEpoch` is backwards compatible, we don't change
   // the cookie when applying CM delta
-  auto newCookie = cloud_env_options.cookie_on_open;
+  auto newCookie = cloud_env_options.new_cookie_on_open;
 
   st = ApplyLocalCloudManifestDelta(
       local_dbname,
@@ -1902,8 +1902,9 @@ Status CloudEnvImpl::ApplyLocalCloudManifestDelta(const std::string& local_dbnam
   const auto& fs = GetBaseEnv()->GetFileSystem();
   Log(InfoLogLevel::INFO_LEVEL, info_log_,
       "Rolling new CLOUDMANIFEST from file number %lu, renaming MANIFEST-%s to "
-      "MANIFEST-%s",
-      delta.file_num, old_epoch.c_str(), delta.epoch.c_str());
+      "MANIFEST-%s, new cookie: %s",
+      delta.file_num, old_epoch.c_str(), delta.epoch.c_str(),
+      new_cookie.c_str());
   // ManifestFileWithEpoch(local_dbname, oldEpoch) should exist locally.
   // We have to move our old manifest to the new filename.
   // However, we don't move here, we copy. If we moved and crashed immediately

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -195,6 +195,10 @@ class CloudEnvImpl : public CloudEnv {
 
   // Load CLOUDMANIFEST if exists in local disk to current env.
   Status LoadLocalCloudManifest(const std::string& dbname);
+  // TODO(wei): this function is used to temporarily support open db and switch
+  // cookie. Remove it once that's not needed
+  Status LoadLocalCloudManifest(const std::string& dbname,
+                                const std::string& cookie);
 
   // Local CLOUDMANIFEST from `base_env` into `cloud_manifest`.
   static Status LoadLocalCloudManifest(
@@ -202,6 +206,10 @@ class CloudEnvImpl : public CloudEnv {
       std::unique_ptr<CloudManifest>* cloud_manifest);
 
   Status CreateCloudManifest(const std::string& local_dbname);
+  // TODO(wei): this function is used to temporarily support open db and switch
+  // cookie. Remove it once that's not needed
+  Status CreateCloudManifest(const std::string& local_dbname,
+                             const std::string& cookie);
 
   // Transfers the filename from RocksDB's domain to the physical domain, based
   // on information stored in CLOUDMANIFEST.

--- a/cloud/cloud_env_options.cc
+++ b/cloud/cloud_env_options.cc
@@ -41,6 +41,10 @@ void CloudEnvOptions::Dump(Logger* log) const {
          use_direct_io_for_cloud_download);
   Header(log, "        COptions.roll_cloud_manifest_on_open: %d",
          roll_cloud_manifest_on_open);
+  Header(log, "                     COptions.cookie_on_open: %s",
+         cookie_on_open.c_str());
+  Header(log, "                 COptions.new_cookie_on_open: %s",
+         new_cookie_on_open.c_str());
   if (sst_file_cache != nullptr) {
     Header(log, "           COptions.sst_file_cache size: %ld bytes",
            sst_file_cache->GetCapacity());

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -143,13 +143,8 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
     if (read_only) {
       return Status::NotFound("CLOUDMANIFEST not found and read_only is set.");
     }
-    if (cenv->GetCloudEnvOptions().cookie_on_open !=
-        cenv->GetCloudEnvOptions().new_cookie_on_open) {
-      Log(InfoLogLevel::WARN_LEVEL, options.info_log,
-          "Switch CLOUDMANIFEST is not supported when opening new db. Only "
-          "cookie_on_open will be used");
-    }
-    st = cenv->CreateCloudManifest(local_dbname);
+    st = cenv->CreateCloudManifest(
+        local_dbname, cenv->GetCloudEnvOptions().new_cookie_on_open);
     if (!st.ok()) {
       return st;
     }
@@ -198,7 +193,7 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
     // was already uploaded. It is at this point we consider the database
     // committed in the cloud.
     st = cenv->UploadLocalCloudManifest(
-        local_dbname, cenv->GetCloudEnvOptions().cookie_on_open);
+        local_dbname, cenv->GetCloudEnvOptions().new_cookie_on_open);
   }
 
   // now that the database is opened, all file sizes have been verified and we

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -143,6 +143,12 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
     if (read_only) {
       return Status::NotFound("CLOUDMANIFEST not found and read_only is set.");
     }
+    if (cenv->GetCloudEnvOptions().cookie_on_open !=
+        cenv->GetCloudEnvOptions().new_cookie_on_open) {
+      Log(InfoLogLevel::WARN_LEVEL, options.info_log,
+          "Switch CLOUDMANIFEST is not supported when opening new db. Only "
+          "cookie_on_open will be used");
+    }
     st = cenv->CreateCloudManifest(local_dbname);
     if (!st.ok()) {
       return st;

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -364,8 +364,8 @@ class CloudEnvOptions {
   // Experimental option!
   // The cookie we will switch to when we open the db and roll the new epoch.
   //
-  // NOTE: This option will only take effect when db exists (i.e., not new db).
-  // If it's a new db, CLOUDMANIFEST file will be created with `cookie_on_open`.
+  // NOTE: when opening a new db, CLOUDMANIFEST file will only be created with
+  // new_cookie_on_open
   //
   // TODO(wei): This is a temporarly option to unblock leader/follower rollout,
   // so that we can support follower taking over as new leader and having two

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -361,15 +361,6 @@ class CloudEnvOptions {
   // CLOUDMANIFEST)
   std::string cookie_on_open;
 
-  // If true, and cookie is not empty, besides uploading CLOUDMANIFEST-cookie to
-  // s3, we also upload CLOUDMANIFEST (no cookie suffix) to s3. This makes sure
-  // that we can quickly rollback if something unexpected happens.
-  //
-  // TODO(wei): This is a temporary option. Once we gain more confidence about cookie we
-  // should remove it
-  // Default: true
-  bool upload_cloud_manifest_without_cookie_suffix;
-
   // Experimental option!
   // The cookie we will switch to when we open the db and roll the new epoch.
   //
@@ -403,7 +394,6 @@ class CloudEnvOptions {
       std::shared_ptr<Cache> _sst_file_cache = nullptr,
       bool _roll_cloud_manifest_on_open = true,
       std::string _cookie_on_open = "",
-      bool _upload_cloud_manifest_without_cookie_suffix = true,
       std::string _new_cookie_on_open = "")
       : log_type(_log_type),
         sst_file_cache(_sst_file_cache),
@@ -428,8 +418,6 @@ class CloudEnvOptions {
         use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download),
         roll_cloud_manifest_on_open(_roll_cloud_manifest_on_open),
         cookie_on_open(std::move(_cookie_on_open)),
-        upload_cloud_manifest_without_cookie_suffix(
-            _upload_cloud_manifest_without_cookie_suffix),
         new_cookie_on_open(_new_cookie_on_open) {
     (void) _cloud_type;
   }

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -370,6 +370,20 @@ class CloudEnvOptions {
   // Default: true
   bool upload_cloud_manifest_without_cookie_suffix;
 
+  // Experimental option!
+  // The cookie we will switch to when we open the db and roll the new epoch.
+  //
+  // NOTE: This option will only take effect when db exists (i.e., not new db).
+  // If it's a new db, CLOUDMANIFEST file will be created with `cookie_on_open`.
+  //
+  // TODO(wei): This is a temporarly option to unblock leader/follower rollout,
+  // so that we can support follower taking over as new leader and having two
+  // leader running for short period of time. Remove it once leader/follower is
+  // ready
+  //
+  // Default: "", means new cloud manifest file won't have cookie suffix
+  std::string new_cookie_on_open;
+
   CloudEnvOptions(
       CloudType _cloud_type = CloudType::kCloudAws,
       LogType _log_type = LogType::kLogKafka,
@@ -389,7 +403,8 @@ class CloudEnvOptions {
       std::shared_ptr<Cache> _sst_file_cache = nullptr,
       bool _roll_cloud_manifest_on_open = true,
       std::string _cookie_on_open = "",
-      bool _upload_cloud_manifest_without_cookie_suffix = true)
+      bool _upload_cloud_manifest_without_cookie_suffix = true,
+      std::string _new_cookie_on_open = "")
       : log_type(_log_type),
         sst_file_cache(_sst_file_cache),
         keep_local_sst_files(_keep_local_sst_files),
@@ -413,7 +428,9 @@ class CloudEnvOptions {
         use_direct_io_for_cloud_download(_use_direct_io_for_cloud_download),
         roll_cloud_manifest_on_open(_roll_cloud_manifest_on_open),
         cookie_on_open(std::move(_cookie_on_open)),
-        upload_cloud_manifest_without_cookie_suffix(_upload_cloud_manifest_without_cookie_suffix) {
+        upload_cloud_manifest_without_cookie_suffix(
+            _upload_cloud_manifest_without_cookie_suffix),
+        new_cookie_on_open(_new_cookie_on_open) {
     (void) _cloud_type;
   }
 


### PR DESCRIPTION
Added `new_cookie_on_open` option in cloud_env, so that we can switch to new cookie when we open db and roll new epoch. This is a temporary option so that we can roll out stage 1 of leader follower.

Also, removed option: `upload_cloud_manifest_without_cookie_suffix`, which was originally used to make sure we can roll back to empty cookie. But `new_cookie_on_open` can achieve similar things.

- [x] Tested by running db_cloud_test locally