### PR TITLE
[SYS-2143] Fix race between LocalCloudScheduler destruction and job rase after execution

### DIFF
--- a/cloud/cloud_scheduler.cc
+++ b/cloud/cloud_scheduler.cc
@@ -67,14 +67,12 @@ class CloudSchedulerImpl : public CloudScheduler {
 
   std::unique_ptr<std::thread> thread_;
 };
-
 // Implementation of a CloudScheduler that keeps track of the jobs
 // it scheduled.  Only cleans up those jobs on exit or cancel.
 class LocalCloudScheduler : public CloudScheduler,
                             std::enable_shared_from_this<LocalCloudScheduler> {
-  struct PrivateTag {
-    PrivateTag() = default;
-  };
+  struct PrivateTag {};
+
  public:
   static std::shared_ptr<CloudScheduler> Create(
       const std::shared_ptr<CloudScheduler>& scheduler, long local_id) {
@@ -88,15 +86,16 @@ class LocalCloudScheduler : public CloudScheduler,
                       const std::shared_ptr<CloudScheduler>& scheduler,
                       long local_id)
       : scheduler_(scheduler),
-        next_local_id_(local_id),
-        shutting_down_(false) {}
+        next_local_id_(local_id) {}
   ~LocalCloudScheduler() override {
     TEST_SYNC_POINT(
         "LocalCloudScheduler::~LocalCloudScheduler:BeforeCancelJobs1");
     TEST_SYNC_POINT(
         "LocalCloudScheduler::~LocalCloudScheduler:BeforeCancelJobs2");
-    std::lock_guard<std::mutex> lk(job_mutex_);
-    shutting_down_ = true;
+    // NOTE: there is no need to lock job_mutex_ here. LocalCloudScheduler can
+    // only be accessed through shared_ptr. If destructor is called, there is no
+    // way to schedule new jobs. Also, we lock the weak_ptr in the schedule job
+    // callback to make sure it won't race with the destructor
     for (const auto& job : jobs_) {
       scheduler_->CancelJob(job.second);
     }
@@ -105,9 +104,6 @@ class LocalCloudScheduler : public CloudScheduler,
 
   long ScheduleJob(std::chrono::microseconds when,
                    std::function<void(void*)> callback, void* arg) override {
-    if (shutting_down_) {
-      return -1;
-    }
     std::lock_guard<std::mutex> lk(job_mutex_);
     long local_id = next_local_id_++;
     auto wp = this->weak_from_this();
@@ -131,9 +127,6 @@ class LocalCloudScheduler : public CloudScheduler,
                             std::chrono::microseconds frequency,
                             std::function<void(void*)> callback,
                             void* arg) override {
-    if (shutting_down_) {
-      return -1;
-    }
     auto job = scheduler_->ScheduleRecurringJob(when, frequency, callback, arg);
     std::lock_guard<std::mutex> lk(job_mutex_);
     long local_id = next_local_id_++;
@@ -142,23 +135,19 @@ class LocalCloudScheduler : public CloudScheduler,
   }
 
   bool IsScheduled(long handle) override {
-    if (shutting_down_) {
+    std::lock_guard<std::mutex> lk(job_mutex_);
+    const auto& it = jobs_.find(handle);
+    if (it == jobs_.end()) {
+      // We do not have the job in our queue.  Return false
       return false;
+    } else if (scheduler_->IsScheduled(it->second)) {
+      // The job is still scheduled.  Return false
+      return true;
     } else {
-      std::lock_guard<std::mutex> lk(job_mutex_);
-      const auto& it = jobs_.find(handle);
-      if (it == jobs_.end()) {
-        // We do not have the job in our queue.  Return false
-        return false;
-      } else if (scheduler_->IsScheduled(it->second)) {
-        // The job is still scheduled.  Return false
-        return true;
-      } else {
-        // We have the job in our queue but it has already
-        // completed.  Erase from our queue and return false
-        jobs_.erase(it);
-        return false;
-      }
+      // We have the job in our queue but it has already
+      // completed.  Erase from our queue and return false
+      jobs_.erase(it);
+      return false;
     }
   }
 
@@ -184,7 +173,6 @@ class LocalCloudScheduler : public CloudScheduler,
   std::mutex job_mutex_;
   std::shared_ptr<CloudScheduler> scheduler_;
   long next_local_id_;
-  bool shutting_down_;
   std::unordered_map<long, long> jobs_;
 
   void DoEraseJob(long local_id) {

--- a/cloud/cloud_scheduler_test.cc
+++ b/cloud/cloud_scheduler_test.cc
@@ -8,12 +8,11 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <iostream>
 #include <mutex>
 #include <thread>
 #include <unordered_set>
 
-#include "test_util/testharness.h"
+#include "test_util/sync_point.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -23,7 +22,7 @@ class CloudSchedulerTest : public testing::Test {
   ~CloudSchedulerTest() {}
 
   std::shared_ptr<CloudScheduler> scheduler_;
-  void WaitForJobs(const std::vector<long> &jobs, uint32_t delay) {
+  void WaitForJobs(const std::vector<long> &jobs, uint32_t delaySeconds) {
     bool running = true;
     while (running) {
       running = false;
@@ -34,7 +33,7 @@ class CloudSchedulerTest : public testing::Test {
         }
       }
       if (running) {
-        usleep(delay);
+        usleep(delaySeconds);
       }
     }
   }
@@ -172,6 +171,42 @@ TEST_F(CloudSchedulerTest, TestLongRunningJobCancel) {
 
   scheduler_->CancelJob(handle);
   ASSERT_EQ(status.load(), JobStatus::FINISHED);
+}
+
+class CloudSchedulerRaceTest: public testing::Test {
+};
+
+// Once cloud scheduler is destructed, jobs shouldn't be erased after it's scheduled
+TEST_F(CloudSchedulerRaceTest, SkipJobEraseOnceDestructedTest) {
+  // Verify that cloud scheduler can handle the race between LocalCloudScheduler destruction
+  // and job cleanup after execution. 
+  // Use SyncPoint to define related execution order:
+  // - Destructor called
+  // - job scheduled to execute
+  // - job execution is done, job erased
+  // - Destruction is still ongoing
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"LocalCloudScheduler::~LocalCloudScheduler:BeforeCancelJobs1",
+        "LocalCloudScheduler::ScheduleJob:BeforeEraseJob"},
+        {"LocalCloudScheduler::ScheduleJob:AfterEraseJob",
+        "LocalCloudScheduler::~LocalCloudScheduler:BeforeCancelJobs2"
+        }
+        });
+  SyncPoint::GetInstance()->SetCallBack(
+      "LocalCloudScheduler::ScheduleJob::AfterEraseJob", [](void *arg) {
+        ASSERT_NE(nullptr, arg);
+        auto job_erased = *reinterpret_cast<bool *>(arg);
+        EXPECT_FALSE(job_erased);
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  {
+    auto scheduler = CloudScheduler::Get();
+    auto job = [](void *) {};
+    scheduler->ScheduleJob(std::chrono::milliseconds(10), job, nullptr);
+  }
+
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/cloud/cloud_scheduler_test.cc
+++ b/cloud/cloud_scheduler_test.cc
@@ -22,7 +22,7 @@ class CloudSchedulerTest : public testing::Test {
   ~CloudSchedulerTest() {}
 
   std::shared_ptr<CloudScheduler> scheduler_;
-  void WaitForJobs(const std::vector<long> &jobs, uint32_t delaySeconds) {
+  void WaitForJobs(const std::vector<long> &jobs, uint32_t delayMicros) {
     bool running = true;
     while (running) {
       running = false;
@@ -33,7 +33,7 @@ class CloudSchedulerTest : public testing::Test {
         }
       }
       if (running) {
-        usleep(delaySeconds);
+        usleep(delayMicros);
       }
     }
   }
@@ -173,11 +173,8 @@ TEST_F(CloudSchedulerTest, TestLongRunningJobCancel) {
   ASSERT_EQ(status.load(), JobStatus::FINISHED);
 }
 
-class CloudSchedulerRaceTest: public testing::Test {
-};
-
 // Once cloud scheduler is destructed, jobs shouldn't be erased after it's scheduled
-TEST_F(CloudSchedulerRaceTest, SkipJobEraseOnceDestructedTest) {
+TEST(CloudSchedulerRaceTest, SkipJobEraseOnceDestructedTest) {
   // Verify that cloud scheduler can handle the race between LocalCloudScheduler destruction
   // and job cleanup after execution. 
   // Use SyncPoint to define related execution order:


### PR DESCRIPTION
There were multiple races of `LocalCloudScheduler` implementation:
- `job_mutex_` wasn't locked when canceling jobs in `~LocalCloudScheduler`. Therefore, it's possible that right before we started canceling job in destructor, the job was erased when execution is done
- Job execution callback accessed the`jobs_` and `job_mutex_`  even after `~LocalCloudScheduler` is called.

## TEST

- [x] Added extra tests to verify second case. Didn't add test for first case since it's hard to consistently repro the execution order with test after we fix the issue (using sync point will cause deadlock)