### PR TITLE
[SYS-2947] Support turning on replication log listener when follower taking over

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1285,6 +1285,12 @@ Status DBImpl::TurnOnFlush() {
   return immutable_db_options_.flush_switch->TurnOn();
 }
 
+Status DBImpl::TurnOnReplicationLogListener() {
+  // replication log listener should be specified
+  assert(immutable_db_options_.replication_log_listener);
+  return immutable_db_options_.replication_log_listener_switch->TurnOn();
+}
+
 Status DBImpl::SetOptions(
     ColumnFamilyHandle* column_family,
     const std::unordered_map<std::string, std::string>& options_map) {

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -338,6 +338,7 @@ class DBImpl : public DB {
   Status GetPersistedReplicationSequence(std::string* out) override;
   Status GetManifestUpdateSequence(uint64_t* out) override;
   Status TurnOnFlush() override;
+  Status TurnOnReplicationLogListener() override;
 
   using DB::SetOptions;
   Status SetOptions(

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2162,7 +2162,9 @@ Status DBImpl::AtomicFlushMemTables(
     }
     WaitForPendingWrites();
 
-    if (immutable_db_options_.replication_log_listener) {
+    bool replication_log_enabled = immutable_db_options_.IsReplicationLogEnabled();
+
+    if (replication_log_enabled) {
       // If replication_log_listener is installed the only thing we are allowed
       // to do is flush all column families.
       SelectColumnFamiliesForAtomicFlush(&cfds);
@@ -2180,7 +2182,7 @@ Status DBImpl::AtomicFlushMemTables(
 
     MemTableSwitchRecord mem_switch_record;
     std::string replication_sequence;
-    if (immutable_db_options_.replication_log_listener) {
+    if (replication_log_enabled) {
       mem_switch_record.next_log_num = versions_->NewFileNumber();
       replication_sequence = RecordMemTableSwitch(
         immutable_db_options_.replication_log_listener,
@@ -2193,7 +2195,7 @@ Status DBImpl::AtomicFlushMemTables(
         continue;
       }
       cfd->Ref();
-      if (immutable_db_options_.replication_log_listener) {
+      if (replication_log_enabled) {
         s = SwitchMemtableWithoutCreatingWAL(cfd, &context,
                                              mem_switch_record.next_log_num,
                                              replication_sequence);

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -296,6 +296,12 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
         "atomic_flush has to be set if replication_log_listener is set");
   }
 
+  if (db_options.replication_log_listener_switch && !db_options.replication_log_listener) {
+    return Status::InvalidArgument(
+        "replication_log_listener has to be set if "
+        "replication_log_listener_switch is set");
+  }
+
   if (db_options.use_direct_io_for_flush_and_compaction &&
       0 == db_options.writable_file_max_buffer_size) {
     return Status::InvalidArgument(

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3250,6 +3250,9 @@ class ModelDB : public DB {
   Status TurnOnFlush() override {
     return Status::NotSupported("Not supported in Model DB");
   }
+  Status TurnOnReplicationLogListener() override {
+    return Status::NotSupported("Not supported in Model DB");
+  }
 
  private:
   class ModelIter : public Iterator {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1283,6 +1283,22 @@ class DB {
   // be returned
   virtual Status TurnOnFlush() = 0;
 
+  // Enable replication log listener if it's disabled.
+  //
+  // REQUIRES: replication_log_listener is already registered
+  // REQUIRES: there is no ongoing writes
+  // NOTE: there could be gap in the log if there is ongoing writes while
+  // turning replication log listener. For example, suppose there is a memtable
+  // write which will trigger automatic flush,
+  // - receive memtable write, listener disabled
+  // - preprocess memtable write, listener enabled
+  // - memtable switch triggered, memtable switch is logged
+  // - But this memtable write is not logged since listener is disabled when we
+  // receive it
+  // Extra coordination is necessary if there could be ongoing writes
+  // when enabling replication log listener
+  virtual Status TurnOnReplicationLogListener() = 0;
+
   // Dynamically change column family options or table factory options in a
   // running DB, for the specified column family. Only options internally
   // marked as "mutable" can be changed. Options not listed in `opts_map` will

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -493,6 +493,10 @@ class StackableDB : public DB {
     return db_->TurnOnFlush();
   }
 
+  Status TurnOnReplicationLogListener() override {
+    return db_->TurnOnReplicationLogListener();
+  }
+
   using DB::SetOptions;
   virtual Status SetOptions(ColumnFamilyHandle* column_family_handle,
                             const std::unordered_map<std::string, std::string>&

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -773,7 +773,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       lowest_used_cache_tier(options.lowest_used_cache_tier),
       compaction_service(options.compaction_service),
       enforce_single_del_contracts(options.enforce_single_del_contracts),
-      flush_switch(options.flush_switch) {
+      flush_switch(options.flush_switch),
+      replication_log_listener_switch(options.replication_log_listener_switch) {
   fs = env->GetFileSystem();
   clock = env->GetSystemClock().get();
   logger = info_log.get();
@@ -985,6 +986,11 @@ const std::string& ImmutableDBOptions::GetWalDir(
   } else {
     return wal_dir;
   }
+}
+
+bool ImmutableDBOptions::IsReplicationLogEnabled() const {
+  return replication_log_listener && replication_log_listener_switch &&
+         replication_log_listener_switch->IsReplicationLogListenerOn();
 }
 
 MutableDBOptions::MutableDBOptions()

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -111,11 +111,13 @@ struct ImmutableDBOptions {
   std::shared_ptr<CompactionService> compaction_service;
   bool enforce_single_del_contracts;
   std::shared_ptr<FlushSwitch> flush_switch;
+  std::shared_ptr<ReplicationLogListenerSwitch> replication_log_listener_switch;
 
   bool IsWalDirSameAsDBPath() const;
   bool IsWalDirSameAsDBPath(const std::string& path) const;
   const std::string& GetWalDir() const;
   const std::string& GetWalDir(const std::string& path) const;
+  bool IsReplicationLogEnabled() const;
 };
 
 struct MutableDBOptions {


### PR DESCRIPTION
We always register replication log listener. When opening in follower mode, by default replication log listener is disabled. When taking over, we call `db->TurnOnReplicationLogListener` to enable replication log listener.

NOTE when turning on replication log listener, there shouldn't be ongoing writes (that's also the case for us, when follower taking over, it stops tailing from leader and only subscribes from kafka after taking over succeeds). Otherwise, it's possible to have gap in the log (see comments of function: `TurnOnReplicationLogListener` for one case).

If we can't make that assumption, we need to make extra coordination during taking over.

- [x] build & tests pass locally