### PR TITLE
[SYS-3094] clean up old CLOUDMANIFEST files

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -921,8 +921,25 @@ std::string CloudEnvImpl::RemapFilename(const std::string& logical_path) const {
   return RemapFilenameWithCloudManifest(logical_path, cloud_manifest_.get());
 }
 
-Status CloudEnvImpl::DeleteInvisibleFiles(const std::string& dbname) {
+Status CloudEnvImpl::DeleteInvisibleFiles(const std::string& dbname,
+                                          const std::string& cookie) {
   Status s;
+  auto shouldDelete = [&cookie, this](const std::string fname) -> bool {
+    if (IsCloudManifestFile(fname)) { 
+      auto fname_cookie = GetCookie(fname);
+      if (fname_cookie != cookie) {
+        return true;
+      }
+    } else {
+      auto noepoch = RemoveEpoch(fname);
+      if ((IsSstFile(noepoch) || IsManifestFile(noepoch)) &&
+          (RemapFilename(noepoch) != fname)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   if (HasDestBucket()) {
     std::vector<std::string> pathnames;
     s = GetStorageProvider()->ListCloudObjects(GetDestBucketName(),
@@ -932,15 +949,12 @@ Status CloudEnvImpl::DeleteInvisibleFiles(const std::string& dbname) {
     }
 
     for (auto& fname : pathnames) {
-      auto noepoch = RemoveEpoch(fname);
-      if (IsSstFile(noepoch) || IsManifestFile(noepoch)) {
-        if (RemapFilename(noepoch) != fname) {
-          // Ignore returned status on purpose.
-          Log(InfoLogLevel::INFO_LEVEL, info_log_,
-              "DeleteInvisibleFiles deleting %s from destination bucket",
-              fname.c_str());
-          DeleteCloudFileFromDest(fname);
-        }
+      if (shouldDelete(fname)) {
+        // Ignore returned status on purpose.
+        Log(InfoLogLevel::INFO_LEVEL, info_log_,
+            "DeleteInvisibleFiles deleting %s from destination bucket",
+            fname.c_str());
+        DeleteCloudFileFromDest(fname);
       }
     }
   }
@@ -950,15 +964,12 @@ Status CloudEnvImpl::DeleteInvisibleFiles(const std::string& dbname) {
     return s;
   }
   for (auto& fname : children) {
-    auto noepoch = RemoveEpoch(fname);
-    if (IsSstFile(noepoch) || IsManifestFile(noepoch)) {
-      if (RemapFilename(RemoveEpoch(fname)) != fname) {
+    if (shouldDelete(fname)) {
         // Ignore returned status on purpose.
         Log(InfoLogLevel::INFO_LEVEL, info_log_,
             "DeleteInvisibleFiles deleting file %s from local dir",
             fname.c_str());
         GetBaseEnv()->DeleteFile(dbname + "/" + fname);
-      }
     }
   }
   return s;
@@ -1509,6 +1520,21 @@ Status CloudEnvImpl::LoadCloudManifest(const std::string& local_dbname,
     // from the cloud
     st = LoadLocalCloudManifest(local_dbname);
   }
+
+  // Do the cleanup, but don't fail if the cleanup fails.
+  // We only cleanup files which don't belong to cookie_on_open. Also, we do it
+  // before rolling the epoch, so that newly generated CM/M files won't be
+  // cleaned up.
+  if (st.ok() && !read_only) {
+    st = DeleteInvisibleFiles(local_dbname, cloud_env_options.cookie_on_open);
+    if (!st.ok()) {
+      Log(InfoLogLevel::INFO_LEVEL, info_log_,
+          "Failed to delete invisible files: %s", st.ToString().c_str());
+        // Ignore the fail
+      st = Status::OK();
+    }
+  }
+
   if (st.ok() && cloud_env_options.roll_cloud_manifest_on_open) {
     // Rolls the new epoch in CLOUDMANIFEST (only for existing databases)
     st = RollNewEpoch(local_dbname);
@@ -1545,16 +1571,6 @@ Status CloudEnvImpl::LoadCloudManifest(const std::string& local_dbname,
     }
   }
 
-  // Do the cleanup, but don't fail if the cleanup fails.
-  if (!read_only) {
-    st = DeleteInvisibleFiles(local_dbname);
-    if (!st.ok()) {
-      Log(InfoLogLevel::INFO_LEVEL, info_log_,
-          "Failed to delete invisible files: %s", st.ToString().c_str());
-        // Ignore the fail
-      st = Status::OK();
-    }
-  }
   return st;
 }
 

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -960,6 +960,7 @@ Status CloudEnvImpl::DeleteInvisibleFiles(const std::string& dbname,
   }
   std::vector<std::string> children;
   s = GetBaseEnv()->GetChildren(dbname, &children);
+  TEST_SYNC_POINT_CALLBACK("CloudEnvImpl::DeleteInvisibleFiles:AfterListLocalFiles", &s);
   if (!s.ok()) {
     return s;
   }

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -218,13 +218,22 @@ class CloudEnvImpl : public CloudEnv {
   // Files both in S3 and in the local directory have this [epoch] suffix.
   std::string RemapFilename(const std::string& logical_path) const override;
 
-  // This will delete all files in dest bucket and locally whose epochs are
-  // invalid. For example, if we find 00010.sst-[epochX], but the real mapping
-  // for 00010.sst is [epochY], in this function we will delete
-  // 00010.sst-[epochX]. Note that local files are deleted immediately, while
-  // cloud files are deleted with a delay of one hour (just to prevent issues
-  // from two RocksDB databases running on the same bucket for a short time).
-  Status DeleteInvisibleFiles(const std::string& dbname);
+  // This will delete all files in dest bucket and locally, which don't belong
+  // to CLOUDMANIFEST-cookie.
+  // - If cookie is empty, only MANIFEST file and sst
+  // files will be deleted.
+  // - If cookie is not empty, CLOUDMANIFEST files with
+  // different cookie will be deleted as well
+  //
+  // MANIFEST file and sst files will be deleted if their epoch is not current
+  // epoch of CLOUDMANIFEST-cookie. For example, if we find 00010.sst-[epochX],
+  // but the real mapping for 00010.sst is [epochY], in this function we will
+  // delete 00010.sst-[epochX].
+
+  // Note that local files are deleted immediately, while cloud files are
+  // deleted with a delay of one hour (just to prevent issues from two RocksDB
+  // databases running on the same bucket for a short time).
+  Status DeleteInvisibleFiles(const std::string& dbname, const std::string& cookie);
 
   EnvOptions OptimizeForLogRead(const EnvOptions& env_options) const override {
     return base_env_->OptimizeForLogRead(env_options);

--- a/cloud/cloud_scheduler.cc
+++ b/cloud/cloud_scheduler.cc
@@ -296,6 +296,9 @@ bool CloudSchedulerImpl::CancelJob(long id) {
 
 void CloudSchedulerImpl::DoWork() {
   while (true) {
+    // This sync point has to be put before locking mutex_, otherwise
+    // CancelJob won't be able to acquire mutex when called
+    TEST_SYNC_POINT("CloudSchedulerImpl::DoWork:BeforeGetJob");
     std::unique_lock<std::mutex> lk(mutex_);
     if (shutting_down_) {
       break;

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -1184,7 +1184,9 @@ TEST_F(CloudTest, TwoDBsOneBucket) {
 // -- it runs two databases on exact same S3 bucket. The work on CLOUDMANIFEST
 // enables us to run in that configuration for extended amount of time (1 hour
 // by default) without any issues -- the last CLOUDMANIFEST writer wins.
-TEST_F(CloudTest, TwoConcurrentWriters) {
+// This test only applies when cookie is empty. So whenever db is reopened, it
+// always fetches the latest CM/M files from s3
+TEST_F(CloudTest, TwoConcurrentWritersCookieEmpty) {
   cloud_env_options_.resync_on_open = true;
   auto firstDB = dbname_;
   auto secondDB = dbname_ + "-1";
@@ -2215,6 +2217,215 @@ TEST_F(CloudTest, NewCookieOnOpenTest) {
   ASSERT_OK(db_->Get({}, "k2", &value));
   EXPECT_EQ(value, "v2");
   CloseDB();
+}
+
+// When opening db with cookie_on_open, files(including CM/M files) belonging to
+// cookie_on_open won't be deleted, all the other files which don't belong to
+// cookie_on_open will be deleted.
+TEST_F(CloudTest, FileDeletionTest) {
+  std::string cookie1 = "", cookie2 = "-1-1";
+  cloud_env_options_.keep_local_sst_files = true;
+
+  // opening with cookie1
+  OpenDB();
+  ASSERT_OK(db_->Put({}, "k1", "v1"));
+  ASSERT_OK(db_->Flush({}));
+  std::vector<std::string> cookie1_sst_files;
+  std::string cookie1_manifest_file;
+  ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &cookie1_sst_files,
+                                    &cookie1_manifest_file));
+  ASSERT_EQ(cookie1_sst_files.size(), 1);
+  CloseDB();
+
+  // MANIFEST file path of cookie1
+  auto cookie1_manifest_filepath = dbname_ + pathsep + cookie1_manifest_file;
+  // CLOUDMANIFEST file path of cookie1
+  auto cookie1_cm_filepath =
+      MakeCloudManifestFile(dbname_, cloud_env_options_.cookie_on_open);
+  // sst file path of cookie1
+  auto cookie1_sst_filepath = dbname_ + pathsep + cookie1_sst_files[0];
+
+  // opening with cookie1 and switch to cookie2
+  cloud_env_options_.cookie_on_open = cookie1;
+  cloud_env_options_.new_cookie_on_open = cookie2;
+  OpenDB();
+  ASSERT_OK(db_->Put({}, "k2", "v2"));
+  ASSERT_OK(db_->Flush({}));
+  // CM/M/sst files of cookie1 won't be deleted
+  for (auto path :
+       {cookie1_cm_filepath, cookie1_manifest_filepath, cookie1_sst_filepath}) {
+    EXPECT_OK(aenv_->GetBaseEnv()->FileExists(path));
+    EXPECT_OK(aenv_->GetStorageProvider()->ExistsCloudObject(
+        aenv_->GetSrcBucketName(), path));
+  }
+
+  std::vector<std::string> cookie2_sst_files;
+  std::string cookie2_manifest_file;
+  ASSERT_OK(aenv_->FindAllLiveFiles(dbname_, &cookie2_sst_files,
+                                    &cookie2_manifest_file));
+  ASSERT_EQ(cookie2_sst_files.size(), 2);
+  CloseDB();
+
+  // MANIFEST file path of cookie2
+  auto cookie2_manifest_filepath = dbname_ + pathsep + cookie2_manifest_file;
+  // CLOUDMANIFEST file path of cookie2
+  auto cookie2_cm_filepath =
+      MakeCloudManifestFile(dbname_, cloud_env_options_.new_cookie_on_open);
+  // find sst file path of cookie2
+  auto cookie2_sst_filepath = dbname_ + pathsep + cookie2_sst_files[0];
+  if (cookie2_sst_filepath == cookie1_sst_filepath) {
+    cookie2_sst_filepath = dbname_ + pathsep + cookie2_sst_files[1];
+  }
+
+  // Now we reopen db with cookie1 to force deleting all files generated in
+  // cookie2
+
+  // number of file deletion jobs is executed
+  int num_job_executed = 0;
+
+  // Syncpoint callback so that we can check when the files are actually
+  // deleted(which is async)
+  SyncPoint::GetInstance()->SetCallBack(
+      "LocalCloudScheduler::ScheduleJob:AfterEraseJob", [&](void* /*arg*/) {
+        num_job_executed += 1;
+        if (num_job_executed == 3) {
+          // CM/M/SST files of cookie2 are deleted in s3
+          for (auto path : {cookie2_manifest_filepath, cookie2_cm_filepath,
+                            cookie2_sst_filepath}) {
+            EXPECT_NOK(aenv_->GetStorageProvider()->ExistsCloudObject(
+                aenv_->GetSrcBucketName(), path));
+          }
+        }
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // reopen db with cookie1 will force all files generated in cookie2 to be
+  // deleted
+  cloud_env_options_.cookie_on_open = cookie1;
+  cloud_env_options_.new_cookie_on_open = cookie1;
+  OpenDB();
+  // local obsolete CM/M/SST files will be deleted immediately
+  // files in cloud will be deleted later (checked in the callback)
+  for (auto path :
+       {cookie2_cm_filepath, cookie2_manifest_filepath, cookie2_sst_filepath}) {
+    EXPECT_NOK(aenv_->GetBaseEnv()->FileExists(path));
+  }
+  CloseDB();
+
+  SyncPoint::GetInstance()->DisableProcessing();
+}
+
+// verify that two writers with different cookies can write concurrently
+TEST_F(CloudTest, TwoConcurrentWritersCookieNotEmpty) {
+  auto firstDB = dbname_;
+  auto secondDB = dbname_ + "-1";
+
+  DBCloud *db1, *db2;
+  CloudEnv *aenv1, *aenv2;
+
+  auto openDB1 = [&] {
+    dbname_ = firstDB;
+    cloud_env_options_.cookie_on_open = "1";
+    cloud_env_options_.new_cookie_on_open = "2";
+    OpenDB();
+    db1 = db_;
+    db_ = nullptr;
+    aenv1 = aenv_.release();
+  };
+  auto openDB1NoCookieSwitch = [&](const std::string& cookie) {
+    dbname_ = firstDB;
+    // when reopening DB1, we should set cookie_on_open = 2 to make sure
+    // we are opening with the right CM/M files
+    cloud_env_options_.cookie_on_open = cookie;
+    cloud_env_options_.new_cookie_on_open = cookie;
+    OpenDB();
+    db1 = db_;
+    db_ = nullptr;
+    aenv1 = aenv_.release();
+  };
+  auto openDB2 = [&] {
+    dbname_ = secondDB;
+    cloud_env_options_.cookie_on_open = "2";
+    cloud_env_options_.new_cookie_on_open = "3";
+    OpenDB();
+    db2 = db_;
+    db_ = nullptr;
+    aenv2 = aenv_.release();
+  };
+  auto openDB2NoCookieSwitch = [&](const std::string& cookie) {
+    dbname_ = secondDB;
+    // when reopening DB1, we should set cookie_on_open = 3 to make sure
+    // we are opening with the right CM/M files
+    cloud_env_options_.cookie_on_open = cookie;
+    cloud_env_options_.new_cookie_on_open = cookie;
+    OpenDB();
+    db2 = db_;
+    db_ = nullptr;
+    aenv2 = aenv_.release();
+  };
+  auto closeDB1 = [&] {
+    db_ = db1;
+    aenv_.reset(aenv1);
+    CloseDB();
+  };
+  auto closeDB2 = [&] {
+    db_ = db2;
+    aenv_.reset(aenv2);
+    CloseDB();
+  };
+
+  openDB1();
+  db1->Put({}, "k1", "v1");
+  db1->Flush({});
+  closeDB1();
+
+  // cleanup memtable of db1 to make sure k1/v1 indeed exists in sst files
+  DestroyDir(firstDB);
+  openDB1NoCookieSwitch("2" /* cookie */);
+
+  // opening DB2 and running concurrently
+  openDB2();
+
+  db1->Put({}, "k2", "v2");
+  db1->Flush({});
+
+  db2->Put({}, "k3", "v3");
+  db2->Flush({});
+
+  std::string v;
+  ASSERT_OK(db1->Get({}, "k1", &v));
+  EXPECT_EQ(v, "v1");
+  ASSERT_OK(db2->Get({}, "k1", &v));
+  EXPECT_EQ(v, "v1");
+
+  ASSERT_OK(db1->Get({}, "k2", &v));
+  EXPECT_EQ(v, "v2");
+  // k2 is written in db1 after db2 is opened, so it's not visible by db2
+  EXPECT_NOK(db2->Get({}, "k2", &v));
+
+  // k3 is written in db2 after db1 is opened, so it's not visible by db1
+  EXPECT_NOK(db1->Get({}, "k3", &v));
+  ASSERT_OK(db2->Get({}, "k3", &v));
+  EXPECT_EQ(v, "v3");
+
+  closeDB1();
+  closeDB2();
+
+  // cleanup local state to make sure writes indeed exist in sst files
+  DestroyDir(firstDB);
+  DestroyDir(secondDB);
+
+  // We can't reopen db with cookie=2 anymore, since that will remove all the
+  // files for cookie=3. This is guaranteed since whenever we reopen db, we
+  // always get the latest cookie from metadata store.
+  openDB2NoCookieSwitch("3" /* cookie */);
+
+  ASSERT_OK(db2->Get({}, "k1", &v));
+  EXPECT_EQ(v, "v1");
+  EXPECT_NOK(db2->Get({}, "k2", &v));
+  ASSERT_OK(db2->Get({}, "k3", &v));
+  EXPECT_EQ(v, "v3");
+  closeDB2();
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/cloud/filename.h
+++ b/cloud/filename.h
@@ -103,6 +103,18 @@ inline std::string RemoveEpoch(const std::string& path) {
   return path;
 }
 
+// Get the cookie suffix from cloud manifest file path
+inline std::string GetCookie(const std::string& cloud_manifest_file_path) {
+  auto cloud_manifest_fname = basename(cloud_manifest_file_path);
+  auto firstDash = cloud_manifest_fname.find('-');
+  if (firstDash == std::string::npos) {
+    // no cookie suffix in cloud manifest file path
+    return "";
+  }
+
+  return cloud_manifest_fname.substr(firstDash+1);
+}
+
 // pathaname seperator
 const std::string pathsep = "/";
 
@@ -169,6 +181,14 @@ inline bool IsIdentityFile(const std::string& pathname) {
 // A log file has ".log" suffix
 inline bool IsLogFile(const std::string& pathname) {
   return IsWalFile(pathname);
+}
+
+inline bool IsCloudManifestFile(const std::string& pathname) {
+  std::string fname = basename(pathname);
+  if (fname.find("CLOUDMANIFEST") == 0) {
+    return true;
+  }
+  return false;
 }
 
 enum class RocksDBFileType {


### PR DESCRIPTION
There are two major changes in this PR:
* Clean up obsolete CLOUDMANIFEST files when opening db (not readonly, dest bucket set). _Before this PR, only MANIFEST files and sst files are cleaned up._
* Trigger the file deletion jobs before we roll the new epoch and only cleanup `CM/M/SST` files which don't belong to `cookie_on_open`. Therefore, neither the newly generated `CLOUDMANIFEST-new_cookie/MANIFEST-new_epoch` files nor `CLOUDMANIFEST-old_cookie/MANIFEST-old_epoch files` will be deleted. _Before this PR, `MANIFEST-old_epoch` files will be deleted as well_ . This change makes sure that two concurrent writers can keep running without intervening each other. If there are more than two concurrent writers, the latest two can keep running while the other writers' CM/M files will be deleted one hour later.

- [x] build & tests pass locally