### PR TITLE
Fix variable 'job_erased' set but not used error

### DIFF
--- a/cloud/cloud_scheduler.cc
+++ b/cloud/cloud_scheduler.cc
@@ -118,6 +118,8 @@ class LocalCloudScheduler : public CloudScheduler,
       }
       TEST_SYNC_POINT_CALLBACK(
           "LocalCloudScheduler::ScheduleJob:AfterEraseJob", &job_erased);
+      // make sure `job_erased` is not unused variable when compiling in release mode
+      (void)job_erased;
     };
     jobs_[local_id] = scheduler_->ScheduleJob(when, job, arg);
     return local_id;


### PR DESCRIPTION
`TEST_SYNC_POINT_CALLBACK` is empty and optimized away when building in `DEBUG_LEVEL=0`, which causes the `job_erased` variable to be unused. 

- [x] Verified with same build command that we used for rockset