### PR TITLE
Declare cloud manifest switch related functions in class DB

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1895,7 +1895,7 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
 }
 
 Status CloudEnvImpl::UploadLocalCloudManifestAndManifest(
-    const std::string& local_dbname, const std::string& cookie) {
+    const std::string& local_dbname, const std::string& cookie) const {
   if (!HasDestBucket()) {
     return Status::InvalidArgument(
         "Dest bucket has to be specified when uploading manifest files");
@@ -1923,7 +1923,7 @@ Status CloudEnvImpl::UploadLocalCloudManifestAndManifest(
 }
 
 Status CloudEnvImpl::UploadLocalCloudManifest(const std::string& local_dbname,
-                                              const std::string& cookie) {
+                                              const std::string& cookie) const {
   if (!HasDestBucket()) {
     return Status::InvalidArgument(
         "Dest bucket has to be specified when uploading CloudManifest files");
@@ -1938,7 +1938,6 @@ Status CloudEnvImpl::UploadLocalCloudManifest(const std::string& local_dbname,
 
   return st;
 }
-
 
 size_t CloudEnvImpl::TEST_NumScheduledJobs() const {
   return scheduler_->TEST_NumScheduledJobs();

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -279,28 +279,19 @@ class CloudEnvImpl : public CloudEnv {
 
   std::string CloudManifestFile(const std::string& dbname);
 
-  // Apply cloud manifest delta to db locally
-  //
-  // It will:
-  //
-  // - Update in memory cloud manifest
-  // - Persist the changes to disk by writing new CLOUDMANIFEST-new_cookie and
-  // MANIFEST-delta.epoch files
-  Status ApplyLocalCloudManifestDelta(
+  virtual Status ApplyLocalCloudManifestDelta(
     const std::string& local_dbname,
     const std::string& new_cookie,
-    const CloudManifestDelta& delta);
+    const CloudManifestDelta& delta) override;
 
-  // Upload local CLOUDMANIFEST-cookie file and the corresponding
-  // MANIFEST-current_epoch file to cloud
-  //
-  // REQUIRES: the file exists locally
-  Status UploadLocalCloudManifestAndManifest(const std::string& local_dbname,
-                                             const std::string& cookie);
+  virtual Status UploadLocalCloudManifestAndManifest(
+      const std::string& local_dbname,
+      const std::string& cookie) const override;
 
   // Upload local CLOUDMANIFEST-cookie file only. MANIFEST-current_epoch is not uploaded
   // REQURIES: the file exists locally
-  Status UploadLocalCloudManifest(const std::string& local_dbname, const std::string& cookie);
+  Status UploadLocalCloudManifest(const std::string& local_dbname,
+                                  const std::string& cookie) const;
 
   // Get current number of scheduled jobs in cloud scheduler
   // Used for test only

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1007,7 +1007,7 @@ class DBImpl : public DB {
   // is only for the special test of CancelledCompactions
   Status WaitForCompact(bool waitUnscheduled = false);
 
-  void NewManifestOnNextUpdate() {
+  virtual void NewManifestOnNextUpdate() override {
     versions_->NewManifestOnNextUpdate();
   }
 

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -302,6 +302,10 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
         "writes in direct IO require writable_file_max_buffer_size > 0");
   }
 
+  if (db_options.flush_switch == nullptr) {
+    return Status::InvalidArgument("Flush switch is not set");
+  }
+
   return Status::OK();
 }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3251,6 +3251,8 @@ class ModelDB : public DB {
     return Status::NotSupported("Not supported in Model DB");
   }
 
+  void NewManifestOnNextUpdate() override {}
+
  private:
   class ModelIter : public Iterator {
    public:

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -590,6 +590,25 @@ class CloudEnv : public Env {
   virtual Status FindAllLiveFilesAndFetchManifest(
       const std::string& local_dbname, std::vector<std::string>* live_sst_files,
       std::string* manifest_file, std::string* manifest_file_version) = 0;
+    
+  // Apply cloud manifest delta to db locally
+  //
+  // It will:
+  //
+  // - Update in memory cloud manifest
+  // - Persist the changes to disk by writing new CLOUDMANIFEST-new_cookie and
+  // MANIFEST-delta.epoch files
+  virtual Status ApplyLocalCloudManifestDelta(
+    const std::string& local_dbname,
+    const std::string& new_cookie,
+    const CloudManifestDelta& delta) = 0;
+
+  // Upload local CLOUDMANIFEST-cookie file and the corresponding
+  // MANIFEST-current_epoch file to cloud
+  //
+  // REQUIRES: the file exists locally
+  virtual Status UploadLocalCloudManifestAndManifest(
+      const std::string& local_dbname, const std::string& cookie) const = 0;
 
   // Create a new AWS env.
   // src_bucket_name: bucket name suffix where db data is read from

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1816,6 +1816,9 @@ class DB {
 
   // Remove any pluggable compaction
   virtual void UnRegisterPluggableCompactionService() {}
+
+  // Generate new MANIFEST file during next kManifestWrite
+  virtual void NewManifestOnNextUpdate() = 0;
 };
 
 // Overloaded operators for enum class SizeApproximationFlags.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -478,6 +478,7 @@ class ReplicationLogListener {
   virtual std::string OnReplicationLogRecord(ReplicationLogRecord record) = 0;
 };
 
+class DBImpl;
 // FlushSwitch provides a mechanism to enable flush when flush is off. Both
 // automatic flush and manual flush are affected
 //
@@ -486,10 +487,11 @@ class ReplicationLogListener {
 class FlushSwitch {
   public:
     virtual ~FlushSwitch() = default;
-
     virtual bool IsFlushOn() const = 0;
 
+  protected:
     virtual Status TurnOn() = 0;
+    friend class DBImpl;
 };
 
 // Flush is always enabled
@@ -499,6 +501,7 @@ class FlushSwitchAlwaysOn: public FlushSwitch {
       return true;
     }
 
+  protected:
     Status TurnOn() override {
       return Status::Incomplete(
           "Turning on flush for always on flush switch is not expected");
@@ -514,6 +517,7 @@ class FlushSwitchTurnOnOnce: public FlushSwitch {
       return flush_on_.load(std::memory_order_relaxed);
     }
 
+  protected:
     Status TurnOn() override {
       bool prev = flush_on_.exchange(true, std::memory_order_relaxed);
       if (prev) {

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -559,6 +559,10 @@ class StackableDB : public DB {
     db_->UnRegisterPluggableCompactionService();
   }
 
+  virtual void NewManifestOnNextUpdate() override {
+    db_->NewManifestOnNextUpdate();
+  }
+
 #ifndef ROCKSDB_LITE
   Status TryCatchUpWithPrimary() override {
     return db_->TryCatchUpWithPrimary();


### PR DESCRIPTION
Couple of minor refactoring:
- Declare the cloud manifest switch related functions in `DB` since we would need to access them outside of rocksdb (e.g., during taking over)
- Make sure flush can only be turned on through `db->TurnOnFlush` but not through `dboptions.flush_switch`. This doesn't matter quite much for now. But if we want to support disabling flush on running db in the future, we would have to do it through `db`. 
- [x] tested by building and running tests locally