### PR TITLE
[SYS-3153] resync MANIFEST on db open

### DIFF
--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -417,6 +417,7 @@ class CloudEnvImpl : public CloudEnv {
   // Fetch the cloud manifest based on the cookie
   Status FetchCloudManifest(const std::string& local_dbname, const std::string& cookie);
   Status writeCloudManifest(CloudManifest* manifest, const std::string& fname);
+  Status FetchManifest(const std::string& local_dbname, const std::string& epoch);
   std::string generateNewEpochId();
   std::unique_ptr<CloudManifest> cloud_manifest_;
   // This runs only in tests when we want to disable cloud manifest

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -295,6 +295,16 @@ class CloudEnvOptions {
   // Default: false
   bool resync_on_open;
 
+  // Experimental option!
+  // This option only affects how resync_on_open works. If resync_on_open is true,
+  // and resync_manifest_on_open is true, besides fetching CLOUDMANFIEST from s3,
+  // we will fetch latest MANIFEST file as well.
+  // 
+  // This is a temporary option to help quickly rollback the change if something unexpected is wrong.
+  // TODO(wei): remove this option once we are confident about the change.
+  // Default: true
+  bool resync_manifest_on_open;
+
   // If true, we will skip the dbid verification on startup. This is currently
   // only used in tests and is not recommended setting.
   // Default: false
@@ -385,6 +395,7 @@ class CloudEnvOptions {
       bool _server_side_encryption = false, std::string _encryption_key_id = "",
       bool _create_bucket_if_missing = true, uint64_t _request_timeout_ms = 0,
       bool _run_purger = false, bool _resync_on_open = false,
+      bool _resync_manifest_on_open = true,
       bool _skip_dbid_verification = false,
       bool _use_aws_transfer_manager = false,
       int _number_objects_listed_in_one_iteration = 5000,
@@ -393,8 +404,7 @@ class CloudEnvOptions {
       bool _use_direct_io_for_cloud_download = false,
       std::shared_ptr<Cache> _sst_file_cache = nullptr,
       bool _roll_cloud_manifest_on_open = true,
-      std::string _cookie_on_open = "",
-      std::string _new_cookie_on_open = "")
+      std::string _cookie_on_open = "", std::string _new_cookie_on_open = "")
       : log_type(_log_type),
         sst_file_cache(_sst_file_cache),
         keep_local_sst_files(_keep_local_sst_files),
@@ -408,6 +418,7 @@ class CloudEnvOptions {
         request_timeout_ms(_request_timeout_ms),
         run_purger(_run_purger),
         resync_on_open(_resync_on_open),
+        resync_manifest_on_open(_resync_manifest_on_open),
         skip_dbid_verification(_skip_dbid_verification),
         use_aws_transfer_manager(_use_aws_transfer_manager),
         number_objects_listed_in_one_iteration(


### PR DESCRIPTION
Forcing MANIFEST resync when db is opened with `resync_on_open=True`. I added one extra temporary option: `resync_manifest_on_open` so that we can control this with sitevar and quickly rollback if we want to.

Reason why we want to do this now is to avoid following issue:

```
open durable (epoch = 1)
open ephemeral (epoch = 1, new_epoch=?)
durable delete sst-file
reopen ephemeral (epoch = 1, new_epoch=?), it reuses local manifest-1 file which still references the deleted sst-file
```
This happens after my recent file deletion [PR](https://github.com/rockset/rocksdb-cloud/pull/195), which doesn't cleanup `MANIFEST-old_epoch` when db is opened. 

I think we shouldn't rely on the assumption that local db is cleaned up correctly before opening db (e.g., what if the process gets interrupted while we try to delete the old MANIFEST file and durable shard somehow triggers a compaction during that time? ) So if `resync_on_open=True`, we should always fetch latest MANIFEST as well

- [x] built and test locally