### PR TITLE
Enable flush through the SetOptions API

### DIFF
--- a/cloud/replication_test.cc
+++ b/cloud/replication_test.cc
@@ -306,7 +306,10 @@ DB* ReplicationTest::openFollower(Options options) {
 
   options.env = &follower_env_;
   options.disable_auto_compactions = true;
-  options.write_buffer_size = 100 << 20;
+  // write buffer size of follower is much smaller than leader to help verify
+  // that disable_auto_flush works as expected
+  options.write_buffer_size = 10 << 10;
+  options.disable_auto_flush = true;
 
   std::vector<ColumnFamilyDescriptor> column_families;
   for (auto& name : cf_names) {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1293,6 +1293,17 @@ void ColumnFamilyData::InstallSuperVersion(
         mutable_cf_options.write_buffer_size) {
       mem_->UpdateWriteBufferSize(mutable_cf_options.write_buffer_size);
     }
+    if (old_superversion->mutable_cf_options.disable_flush != mutable_cf_options.disable_flush) {
+      // Disabling flush on running db is not supported due to bunch of checks we added to
+      // catch unexpected flush.this t's easy to support it later if we want to
+      if (mutable_cf_options.disable_flush) {
+        ROCKS_LOG_ERROR(ioptions_.info_log,
+                        "Disabling flush on running db is not supported");
+      }
+      assert(!mutable_cf_options.disable_flush);
+      mem_->EnableFlush();
+    }
+
     if (old_superversion->write_stall_condition !=
         new_superversion->write_stall_condition) {
       sv_context->PushWriteStallNotification(

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1293,15 +1293,11 @@ void ColumnFamilyData::InstallSuperVersion(
         mutable_cf_options.write_buffer_size) {
       mem_->UpdateWriteBufferSize(mutable_cf_options.write_buffer_size);
     }
-    if (old_superversion->mutable_cf_options.disable_flush != mutable_cf_options.disable_flush) {
-      // Disabling flush on running db is not supported due to bunch of checks we added to
-      // catch unexpected flush.this t's easy to support it later if we want to
-      if (mutable_cf_options.disable_flush) {
-        ROCKS_LOG_ERROR(ioptions_.info_log,
-                        "Disabling flush on running db is not supported");
-      }
-      assert(!mutable_cf_options.disable_flush);
-      mem_->EnableFlush();
+    if (old_superversion->mutable_cf_options.disable_auto_flush != mutable_cf_options.disable_auto_flush) {
+      assert(!mutable_cf_options.disable_auto_flush);
+      ROCKS_LOG_INFO(ioptions_.info_log, "Enabling auto flush for column family: %s",
+                     GetName().c_str());
+      mem_->EnableAutoFlush();
     }
 
     if (old_superversion->write_stall_condition !=
@@ -1408,6 +1404,15 @@ Status ColumnFamilyData::SetOptions(
                                            &cf_opts);
   if (s.ok()) {
     s = ValidateOptions(db_opts, cf_opts);
+  }
+  if (s.ok()) {
+    // Disabling flush on running db is not supported due to bunch of checks we
+    // added to catch unexpected flush. But it's easy to support it later if we
+    // want to
+    if (!mutable_cf_options_.disable_auto_flush && cf_opts.disable_auto_flush) {
+      s = Status::NotSupported(
+          "Disabling flush on running db is not supported");
+    }
   }
   if (s.ok()) {
     mutable_cf_options_ = MutableCFOptions(cf_opts);

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -2791,13 +2791,13 @@ TEST_P(DBAtomicFlushTest, BgThreadNoWaitAfterManifestError) {
   SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
-TEST_F(DBFlushTest, DisableFlushWhenExceedDBWriteBufferSize) {
-    // case1 : write buffer full
+// Disable auto flush shouldn't affect how WriteBufferManager works
+TEST_F(DBFlushTest, DisableAutoFlushWhenExceedDBWriteBufferSize) {
     Options options;
     options.env = env_;
     options.db_write_buffer_size = 100;
     options.write_buffer_size = 10 << 20;
-    options.disable_flush = true;
+    options.disable_auto_flush = true;
     Reopen(options);
 
     auto versions = dbfull()->GetVersionSet();
@@ -2805,32 +2805,25 @@ TEST_F(DBFlushTest, DisableFlushWhenExceedDBWriteBufferSize) {
 
     // The db_write_buffer_size is so small that each Put will trigger write
     // buffer full handling
+    // 
+    // Flush won't be triggered since memtable is empty
     ASSERT_OK(Put("k1", "v1"));
-    ASSERT_OK(Put("k2", "v2"));
-    PinnableSlice value;
-    ASSERT_OK(Get("k1", &value));
-    EXPECT_EQ(value.ToString(), "v1");
-    ASSERT_OK(Get("k2", &value));
-    EXPECT_EQ(value.ToString(), "v2");
 
-    EXPECT_EQ(mem_id,
-              versions->GetColumnFamilySet()->GetDefault()->mem()->GetID());
-    ASSERT_OK(db_->SetOptions({{"disable_flush", "false"}}));
-    // This write will trigger `HandleWriteBufferManagerFlush`
-    ASSERT_OK(Put("k3", "v3"));
+    // flush triggered this time
+    ASSERT_OK(Put("k2", "v2"));
     EXPECT_NE(mem_id,
               versions->GetColumnFamilySet()->GetDefault()->mem()->GetID());
     Close();
 }
 
-TEST_F(DBFlushTest, DisableFlushWhenSwitchWAL) {
-  // case2 : SwitchWAL
+// When WAL is supported, auto flush should never be disabled
+TEST_F(DBFlushTest, DisableAutoFlushWhenSwitchWAL) {
   Options options;
   options.env = env_;
   options.db_write_buffer_size = 0;
   options.write_buffer_size = 10 << 20;
   options.max_total_wal_size = 1;
-  options.disable_flush = true;
+  options.disable_auto_flush = true;
   Reopen(options);
   // switchWAL will only be triggered with more than 1 CF
   CreateColumnFamilies({"cf1"}, options);
@@ -2854,7 +2847,7 @@ TEST_F(DBFlushTest, DisableFlushWhenSwitchWAL) {
   PinnableSlice value;
   EXPECT_NOK(Get("k2", &value));
 
-  ASSERT_OK(db_->SetOptions({{"disable_flush", "false"}}));
+  ASSERT_OK(db_->SetOptions({{"disable_auto_flush", "false"}}));
 
   // this write will trigger SwitchWAL, but since CF1 still has flush
   // disabled, switchWAL is not triggered
@@ -2863,7 +2856,7 @@ TEST_F(DBFlushTest, DisableFlushWhenSwitchWAL) {
   EXPECT_EQ(mem_table_id, default_cf->mem()->GetID());
 
   // update cf1 disable_flush setting
-  ASSERT_OK(db_->SetOptions(handles_[0], {{"disable_flush", "false"}}));
+  ASSERT_OK(db_->SetOptions(handles_[0], {{"disable_auto_flush", "false"}}));
 
   // this write will trigger SwitchWAL and flush
   EXPECT_OK(Put("k2", "v2"));
@@ -2875,25 +2868,22 @@ TEST_F(DBFlushTest, DisableFlushWhenSwitchWAL) {
   Close();
 }
 
-TEST_F(DBFlushTest, DisableFlushWhenManualFlush) {
-  // case3 : manual flush
+// Manual flush can still be issued when diable_auto_flush = true
+TEST_F(DBFlushTest, DisableAutoFlushWhenManualFlush) {
   Options options;
   options.env = env_;
-  options.disable_flush = true;
+  options.disable_auto_flush = true;
   Reopen(options);
   ASSERT_OK(Put("k1", "v1"));
-  EXPECT_NOK(Flush({}));
-
-  ASSERT_OK(db_->SetOptions({{"disable_flush", "false"}}));
-
   EXPECT_OK(Flush({}));
   Close();
 }
 
-TEST_F(DBFlushTest, DisableFlushWhenExceedWriteBufferSize) {
-  // case4 : single memtable size limit
+// When auto flush disabled, memtables won't be flushed even when
+// the size exceeds write_buffer_size limit
+TEST_F(DBFlushTest, DisableAutoFlushWhenExceedWriteBufferSize) {
   Options options;
-  options.disable_flush = true;
+  options.disable_auto_flush = true;
   options.env = env_;
   // minimum write buffer size we can set is 65536
   options.write_buffer_size = 65536;
@@ -2913,7 +2903,7 @@ TEST_F(DBFlushTest, DisableFlushWhenExceedWriteBufferSize) {
   EXPECT_EQ(mem_table_id, default_cf->mem()->GetID());
 
   // Turn on flush
-  ASSERT_OK(db_->SetOptions({{"disable_flush", "false"}}));
+  ASSERT_OK(db_->SetOptions({{"disable_auto_flush", "false"}}));
 
   // this write should update the flush state and schedule work in flush scheduler
   ASSERT_OK(Put("new_k1", "new_v1"));
@@ -2925,6 +2915,140 @@ TEST_F(DBFlushTest, DisableFlushWhenExceedWriteBufferSize) {
   EXPECT_NE(mem_table_id, default_cf->mem()->GetID());
 
   Close();
+}
+
+// Test the case of disable auto flush when there are multiple CFs and
+// atomic_flush=true
+TEST_F(DBFlushTest, DisableAutoFlushMultiCFAndAtomicFlush) {
+  auto triggerRandomWrites = [this](uint32_t handle_idx, size_t num_keys) {
+    for (size_t i = 0; i < num_keys; i++) {
+      ASSERT_OK(Put(handle_idx, "k" + std::to_string(i), "v" + std::to_string(i)));
+    }
+  };
+
+  Options options;
+  options.disable_auto_flush = true;
+  options.env = env_;
+
+  options.write_buffer_size = 65536;
+  options.atomic_flush = true;
+  Reopen(options);
+  CreateColumnFamilies({"cf1", "cf2"}, options);
+  auto versions = dbfull()->GetVersionSet();
+  auto cf1 = versions->GetColumnFamilySet()->GetColumnFamily("cf1");
+  auto cf2 = versions->GetColumnFamilySet()->GetColumnFamily("cf2");
+
+  auto getCurrentMemtableIds = [cf1, cf2]() {
+    return std::make_pair<>(cf1->mem()->GetID(), cf2->mem()->GetID());
+  };
+  auto memtable_ids = getCurrentMemtableIds();
+  triggerRandomWrites(0 /* cf1 */, 2000);
+  triggerRandomWrites(1 /* cf2 */, 2000);
+
+  // Double check memtables are not switched
+  EXPECT_EQ(memtable_ids, getCurrentMemtableIds());
+
+  // Turn on flush for default_cf and cf1
+  ASSERT_OK(db_->SetOptions({{"disable_auto_flush", "false"}}));
+  ASSERT_OK(db_->SetOptions(handles_[0], {{"disable_auto_flush", "false"}}));
+
+  // this write should update the flush state for cf1 and schedule work in flush scheduler
+  ASSERT_OK(Put(0 /* cf1 */, "new_k1", "new_v1"));
+
+  // this write will trigger `ScheduleFlushes`, but since cf2 has flush disabled,
+  // atomic flush still won't be triggered
+  ASSERT_OK(Put(0 /* cf1 */, "new_k2", "new_v2"));
+
+  // cf1 has been put into flush_scheduler queue, so the flush state has been
+  // cleared
+  EXPECT_FALSE(cf1->mem()->ShouldScheduleFlush());
+  EXPECT_TRUE(cf1->mem()->ShouldFlushNow());
+  // cf2's flush state is not even updated yet. Of course, it won't be in
+  // flush_scheduler queue
+  EXPECT_FALSE(cf2->mem()->ShouldScheduleFlush());
+  EXPECT_TRUE(cf2->mem()->ShouldFlushNow());
+
+  // enable auto flush for cf2
+  ASSERT_OK(db_->SetOptions(handles_[1], {{"disable_auto_flush", "false"}}));
+
+  // This write will trigger `ScheduleFlushes` again. cf1 is in flush_scheduler,
+  // cf2 is not, but since atomic_flush = true, all non-empty CFs will be flushed
+  ASSERT_OK(Put(0 /* cf1 */, "new_k3", "new_v3"));
+
+  // double check that both CFs are flushed
+  EXPECT_GT(cf1->mem()->GetID(), memtable_ids.first);
+  EXPECT_GT(cf2->mem()->GetID(), memtable_ids.second);
+  EXPECT_FALSE(cf1->mem()->ShouldFlushNow());
+  EXPECT_FALSE(cf2->mem()->ShouldFlushNow());
+
+  Close();
+}
+
+// Test the case of disable auto flush when there are multiple CFs and
+// atomic_flush=false
+TEST_F(DBFlushTest, DisableAutoFlushMultiCF) {
+  auto triggerRandomWrites = [this](uint32_t handle_idx, size_t num_keys) {
+    for (size_t i = 0; i < num_keys; i++) {
+      ASSERT_OK(Put(handle_idx, "k" + std::to_string(i), "v" + std::to_string(i)));
+    }
+  };
+
+  Options options;
+  options.disable_auto_flush = true;
+  options.env = env_;
+
+  options.write_buffer_size = 65536;
+  options.atomic_flush = false;
+  Reopen(options);
+  CreateColumnFamilies({"cf1", "cf2"}, options);
+  auto versions = dbfull()->GetVersionSet();
+  auto cf1 = versions->GetColumnFamilySet()->GetColumnFamily("cf1");
+  auto cf2 = versions->GetColumnFamilySet()->GetColumnFamily("cf2");
+
+  auto getCurrentMemtableIds = [cf1, cf2]() {
+    return std::make_pair<>(cf1->mem()->GetID(), cf2->mem()->GetID());
+  };
+  auto memtable_ids = getCurrentMemtableIds();
+  triggerRandomWrites(0 /* cf1 */, 2000);
+  triggerRandomWrites(1 /* cf2 */, 2000);
+
+  // Double check memtables are not switched
+  EXPECT_EQ(memtable_ids, getCurrentMemtableIds());
+
+  // Turn on flush for default_cf and cf1
+  ASSERT_OK(db_->SetOptions({{"disable_auto_flush", "false"}}));
+  ASSERT_OK(db_->SetOptions(handles_[0], {{"disable_auto_flush", "false"}}));
+
+  // this write should update the flush state for cf1 and schedule work in flush scheduler
+  ASSERT_OK(Put(0 /* cf1 */, "new_k1", "new_v1"));
+
+  // this write will trigger `ScheduleFlushes` for cf1 so cf1 memtable will be flushed
+  ASSERT_OK(Put(0 /* cf1 */, "new_k2", "new_v2"));
+
+  // double check that cf1 is flushed while cf2 is not
+  EXPECT_GT(cf1->mem()->GetID(), memtable_ids.first);
+  EXPECT_EQ(cf2->mem()->GetID(), memtable_ids.second);
+
+  memtable_ids = getCurrentMemtableIds();
+
+  // enable auto flush for cf2
+  ASSERT_OK(db_->SetOptions(handles_[1], {{"disable_auto_flush", "false"}}));
+
+  // this write should update the flush state for cf2 and schedule work in flush scheduler
+  ASSERT_OK(Put(1 /* cf2 */, "new_k1", "new_v1"));
+
+  // this write will trigger `ScheduleFlushes` for cf2 so cf2 memtable will be flushed
+  ASSERT_OK(Put(1 /* cf2 */, "new_k2", "new_v2"));
+
+  // double check that cf2 is flushed while cf1 is not
+  EXPECT_EQ(cf1->mem()->GetID(), memtable_ids.first);
+  EXPECT_GT(cf2->mem()->GetID(), memtable_ids.second);
+
+  Close();
+}
+
+TEST_F(DBFlushTest, DisableAutoFlushOnRunningDB) {
+  EXPECT_NOK(db_->SetOptions({{"disable_auto_flush", "true"}}));
 }
 
 INSTANTIATE_TEST_CASE_P(DBFlushDirectIOTest, DBFlushDirectIOTest,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -5579,19 +5579,9 @@ Status DBImpl::GetCreationTimeOfOldestFile(uint64_t* creation_time) {
 }
 #endif  // ROCKSDB_LITE
 
-ColumnFamilyData* DBImpl::GetAnyCFWithFlushDisabled() const {
+ColumnFamilyData* DBImpl::GetAnyCFWithAutoFlushDisabled() const {
   for (auto cfd: *versions_->GetColumnFamilySet()) {
-    if (!cfd->IsDropped() && cfd->GetLatestMutableCFOptions()->disable_flush) {
-      return cfd;
-    }
-  }
-  return nullptr;
-}
-
-ColumnFamilyData* DBImpl::GetAnyCFWithFlushDisabled(
-    const autovector<ColumnFamilyData*>& cfds) const {
-  for (auto cfd: cfds) {
-    if (!cfd->IsDropped() && cfd->GetLatestMutableCFOptions()->disable_flush) {
+    if (!cfd->IsDropped() && cfd->GetLatestMutableCFOptions()->disable_auto_flush) {
       return cfd;
     }
   }

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1281,10 +1281,6 @@ Status DBImpl::GetManifestUpdateSequence(uint64_t* out) {
   return Status::OK();
 }
 
-Status DBImpl::TurnOnFlush() {
-  return immutable_db_options_.flush_switch->TurnOn();
-}
-
 Status DBImpl::SetOptions(
     ColumnFamilyHandle* column_family,
     const std::unordered_map<std::string, std::string>& options_map) {
@@ -5582,5 +5578,24 @@ Status DBImpl::GetCreationTimeOfOldestFile(uint64_t* creation_time) {
   }
 }
 #endif  // ROCKSDB_LITE
+
+ColumnFamilyData* DBImpl::GetAnyCFWithFlushDisabled() const {
+  for (auto cfd: *versions_->GetColumnFamilySet()) {
+    if (!cfd->IsDropped() && cfd->GetLatestMutableCFOptions()->disable_flush) {
+      return cfd;
+    }
+  }
+  return nullptr;
+}
+
+ColumnFamilyData* DBImpl::GetAnyCFWithFlushDisabled(
+    const autovector<ColumnFamilyData*>& cfds) const {
+  for (auto cfd: cfds) {
+    if (!cfd->IsDropped() && cfd->GetLatestMutableCFOptions()->disable_flush) {
+      return cfd;
+    }
+  }
+  return nullptr;
+}
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -337,7 +337,6 @@ class DBImpl : public DB {
       ApplyReplicationLogRecordInfo* info) override;
   Status GetPersistedReplicationSequence(std::string* out) override;
   Status GetManifestUpdateSequence(uint64_t* out) override;
-  Status TurnOnFlush() override;
 
   using DB::SetOptions;
   Status SetOptions(
@@ -2169,6 +2168,17 @@ class DBImpl : public DB {
 
   Status IncreaseFullHistoryTsLowImpl(ColumnFamilyData* cfd,
                                       std::string ts_low);
+
+  // Return any column family (not dropped) with flush disabled
+  //
+  // REQUIRES: mutex_ locked
+  ColumnFamilyData* GetAnyCFWithFlushDisabled() const;
+
+  // Return any column family in cfds with flush disabled
+  //
+  // REQUIRES: mutex_ locked
+  ColumnFamilyData* GetAnyCFWithFlushDisabled(
+      const autovector<ColumnFamilyData*>& cfds) const;
 
   // Lock over the persistent DB state.  Non-nullptr iff successfully acquired.
   FileLock* db_lock_;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -2172,13 +2172,7 @@ class DBImpl : public DB {
   // Return any column family (not dropped) with flush disabled
   //
   // REQUIRES: mutex_ locked
-  ColumnFamilyData* GetAnyCFWithFlushDisabled() const;
-
-  // Return any column family in cfds with flush disabled
-  //
-  // REQUIRES: mutex_ locked
-  ColumnFamilyData* GetAnyCFWithFlushDisabled(
-      const autovector<ColumnFamilyData*>& cfds) const;
+  ColumnFamilyData* GetAnyCFWithAutoFlushDisabled() const;
 
   // Lock over the persistent DB state.  Non-nullptr iff successfully acquired.
   FileLock* db_lock_;

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -302,10 +302,6 @@ Status DBImpl::ValidateOptions(const DBOptions& db_options) {
         "writes in direct IO require writable_file_max_buffer_size > 0");
   }
 
-  if (db_options.flush_switch == nullptr) {
-    return Status::InvalidArgument("Flush switch is not set");
-  }
-
   return Status::OK();
 }
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3247,9 +3247,6 @@ class ModelDB : public DB {
   Status GetManifestUpdateSequence(uint64_t* /*out*/) override {
     return Status::NotSupported("Not supported in Model DB");
   }
-  Status TurnOnFlush() override {
-    return Status::NotSupported("Not supported in Model DB");
-  }
 
   void NewManifestOnNextUpdate() override {}
 

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -63,8 +63,7 @@ ImmutableMemTableOptions::ImmutableMemTableOptions(
       statistics(ioptions.stats),
       merge_operator(ioptions.merge_operator.get()),
       info_log(ioptions.logger),
-      allow_data_in_errors(ioptions.allow_data_in_errors),
-      flush_switch(ioptions.flush_switch) {}
+      allow_data_in_errors(ioptions.allow_data_in_errors) {}
 
 MemTable::MemTable(const InternalKeyComparator& cmp,
                    const ImmutableOptions& ioptions,
@@ -112,7 +111,8 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
           ioptions.memtable_insert_with_hint_prefix_extractor.get()),
       oldest_key_time_(std::numeric_limits<uint64_t>::max()),
       atomic_flush_seqno_(kMaxSequenceNumber),
-      approximate_memory_usage_(0) {
+      approximate_memory_usage_(0),
+      disable_flush_(mutable_cf_options.disable_flush) {
   UpdateFlushState();
   // something went wrong if we need to flush before inserting anything
   assert(!ShouldScheduleFlush());
@@ -211,11 +211,20 @@ bool MemTable::ShouldFlushNow() {
   return arena_.AllocatedAndUnused() < kArenaBlockSize / 4;
 }
 
+void MemTable::EnableFlush() {
+  bool flush_previously_disabled =
+      disable_flush_.exchange(false, std::memory_order_relaxed);
+  if (!flush_previously_disabled) {
+    ROCKS_LOG_WARN(moptions_.info_log,
+                   "EnableFlush called when flush is already enabled");
+  }
+}
+
 void MemTable::UpdateFlushState() {
   auto state = flush_state_.load(std::memory_order_relaxed);
   if (state == FLUSH_NOT_REQUESTED && ShouldFlushNow()) {
-    if (!moptions_.flush_switch->IsFlushOn()) {
-      return ;
+    if (disable_flush_) {
+      return;
     }
     // ignore CAS failure, because that means somebody else requested
     // a flush

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -509,8 +509,8 @@ class MemTable {
   // Returns a heuristic flush decision
   bool ShouldFlushNow();
 
-  // Enable flush if it's previously disabled
-  void EnableFlush();
+  // Enable auto flush if it's previously disabled
+  void EnableAutoFlush();
 
  private:
   enum FlushStateEnum { FLUSH_NOT_REQUESTED, FLUSH_REQUESTED, FLUSH_SCHEDULED };
@@ -596,7 +596,7 @@ class MemTable {
   // Gets refreshed inside `ApproximateMemoryUsage()` or `ShouldFlushNow`
   std::atomic<uint64_t> approximate_memory_usage_;
 
-  std::atomic_bool disable_flush_;
+  std::atomic_bool disable_auto_flush_;
 
 #ifndef ROCKSDB_LITE
   // Flush job info of the current memtable.

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -58,7 +58,6 @@ struct ImmutableMemTableOptions {
   MergeOperator* merge_operator;
   Logger* info_log;
   bool allow_data_in_errors;
-  std::shared_ptr<FlushSwitch> flush_switch;
 };
 
 // Batched counters to updated when inserting keys in one write batch.
@@ -510,6 +509,9 @@ class MemTable {
   // Returns a heuristic flush decision
   bool ShouldFlushNow();
 
+  // Enable flush if it's previously disabled
+  void EnableFlush();
+
  private:
   enum FlushStateEnum { FLUSH_NOT_REQUESTED, FLUSH_REQUESTED, FLUSH_SCHEDULED };
 
@@ -593,6 +595,8 @@ class MemTable {
   // keep track of memory usage in table_, arena_, and range_del_table_.
   // Gets refreshed inside `ApproximateMemoryUsage()` or `ShouldFlushNow`
   std::atomic<uint64_t> approximate_memory_usage_;
+
+  std::atomic_bool disable_flush_;
 
 #ifndef ROCKSDB_LITE
   // Flush job info of the current memtable.

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1276,12 +1276,6 @@ class DB {
   virtual Status GetPersistedReplicationSequence(std::string* out) = 0;
   // Returns latest ManifestUpdateSequence.
   virtual Status GetManifestUpdateSequence(uint64_t* out) = 0;
-  // Enable flush if it's disabled. Both automatic flush and manual flush will
-  // be affected
-  //
-  // REQUIRES: flush is disabled before enabling. Otherwise, error status will
-  // be returned
-  virtual Status TurnOnFlush() = 0;
 
   // Dynamically change column family options or table factory options in a
   // running DB, for the specified column family. Only options internally

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -318,11 +318,12 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Default: nullptr
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
 
-  // Disable flush. Both manual and automatic flush will be disabled
+  // Disable automatic flush(exceed `write_buffer_size` limit). Manual flush
+  // (including exceeding `db_write_buffer_size` limit) can still be issued
   //
   // Dynamically changeable through SetOptions() API
-  // Default: false, flush is enabled
-  bool disable_flush = false;
+  // Default: false, auto flush is enabled
+  bool disable_auto_flush = false;
 
   // Create ColumnFamilyOptions with default values for all fields
   ColumnFamilyOptions();

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -318,6 +318,12 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Default: nullptr
   std::shared_ptr<SstPartitionerFactory> sst_partitioner_factory = nullptr;
 
+  // Disable flush. Both manual and automatic flush will be disabled
+  //
+  // Dynamically changeable through SetOptions() API
+  // Default: false, flush is enabled
+  bool disable_flush = false;
+
   // Create ColumnFamilyOptions with default values for all fields
   ColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options
@@ -476,58 +482,6 @@ class ReplicationLogListener {
   // the database needs to re-apply all replication log records since
   // DB::GetPersistedReplicationSequence() (non-inclusive).
   virtual std::string OnReplicationLogRecord(ReplicationLogRecord record) = 0;
-};
-
-class DBImpl;
-// FlushSwitch provides a mechanism to enable flush when flush is off. Both
-// automatic flush and manual flush are affected
-//
-// Once flush is enabled, it can never be disabled, which is guaranteed by the
-// FlushSwitch interface
-class FlushSwitch {
-  public:
-    virtual ~FlushSwitch() = default;
-    virtual bool IsFlushOn() const = 0;
-
-  protected:
-    virtual Status TurnOn() = 0;
-    friend class DBImpl;
-};
-
-// Flush is always enabled
-class FlushSwitchAlwaysOn: public FlushSwitch {
-  public:
-    bool IsFlushOn() const override {
-      return true;
-    }
-
-  protected:
-    Status TurnOn() override {
-      return Status::Incomplete(
-          "Turning on flush for always on flush switch is not expected");
-    }
-};
-
-// A flush switch that's initially off, and can be turned on.
-// But it can never be turned off
-class FlushSwitchTurnOnOnce: public FlushSwitch {
-  public:
-    FlushSwitchTurnOnOnce(): flush_on_(false) {}
-    bool IsFlushOn() const override {
-      return flush_on_.load(std::memory_order_relaxed);
-    }
-
-  protected:
-    Status TurnOn() override {
-      bool prev = flush_on_.exchange(true, std::memory_order_relaxed);
-      if (prev) {
-        return Status::Incomplete("Turning on flush multiple times");
-      } else {
-        return Status::OK();
-      }
-    }
-  private:
-    std::atomic_bool flush_on_;
 };
 
 struct DBOptions {
@@ -1483,13 +1437,6 @@ struct DBOptions {
   // of the contract leads to undefined behaviors with high possibility of data
   // inconsistency, e.g. deleted old data become visible again, etc.
   bool enforce_single_del_contracts = true;
-
-  // FlushSwitch allows turning on flush if it's disabled initially.
-  // Use `FlushSwitchTurnOnOnce` if you want to disable flush when opening db
-  // and then turn it on sometime later.
-  //
-  // Default: flush is always enabled.
-  std::shared_ptr<FlushSwitch> flush_switch = std::make_shared<FlushSwitchAlwaysOn>();
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -489,9 +489,6 @@ class StackableDB : public DB {
   Status GetManifestUpdateSequence(uint64_t* out) override {
     return db_->GetManifestUpdateSequence(out);
   }
-  Status TurnOnFlush() override {
-    return db_->TurnOnFlush();
-  }
 
   using DB::SetOptions;
   virtual Status SetOptions(ColumnFamilyHandle* column_family_handle,

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -500,8 +500,8 @@ static std::unordered_map<std::string, OptionTypeInfo>
                      name, value, addr);
                }
              })},
-        {"disable_flush",
-         {offsetof(struct MutableCFOptions, disable_flush),
+        {"disable_auto_flush",
+         {offsetof(struct MutableCFOptions, disable_auto_flush),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}}
         // End special case properties

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -500,6 +500,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
                      name, value, addr);
                }
              })},
+        {"disable_flush",
+         {offsetof(struct MutableCFOptions, disable_flush),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}}
         // End special case properties
 };
 
@@ -1069,6 +1073,8 @@ void MutableCFOptions::Dump(Logger* log) const {
                  blob_compaction_readahead_size);
 
   ROCKS_LOG_INFO(log, "                   bottommost_temperature: %d",
+                 static_cast<int>(bottommost_temperature));
+  ROCKS_LOG_INFO(log, "                           disable_flush: %d",
                  static_cast<int>(bottommost_temperature));
 }
 

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -154,7 +154,7 @@ struct MutableCFOptions {
         sample_for_compression(
             options.sample_for_compression),  // TODO: is 0 fine here?
         compression_per_level(options.compression_per_level),
-        disable_flush(options.disable_flush) {
+        disable_auto_flush(options.disable_auto_flush) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -198,7 +198,7 @@ struct MutableCFOptions {
         bottommost_compression(kDisableCompressionOption),
         bottommost_temperature(Temperature::kUnknown),
         sample_for_compression(0),
-        disable_flush(false) {}
+        disable_auto_flush(false) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -278,7 +278,7 @@ struct MutableCFOptions {
   // Per-level target file size.
   std::vector<uint64_t> max_file_size;
 
-  bool disable_flush;
+  bool disable_auto_flush;
 };
 
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2);

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -153,7 +153,8 @@ struct MutableCFOptions {
         bottommost_temperature(options.bottommost_temperature),
         sample_for_compression(
             options.sample_for_compression),  // TODO: is 0 fine here?
-        compression_per_level(options.compression_per_level) {
+        compression_per_level(options.compression_per_level),
+        disable_flush(options.disable_flush) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -196,7 +197,8 @@ struct MutableCFOptions {
         compression(Snappy_Supported() ? kSnappyCompression : kNoCompression),
         bottommost_compression(kDisableCompressionOption),
         bottommost_temperature(Temperature::kUnknown),
-        sample_for_compression(0) {}
+        sample_for_compression(0),
+        disable_flush(false) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -275,6 +277,8 @@ struct MutableCFOptions {
   // Derived options
   // Per-level target file size.
   std::vector<uint64_t> max_file_size;
+
+  bool disable_flush;
 };
 
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2);

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -772,8 +772,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       checksum_handoff_file_types(options.checksum_handoff_file_types),
       lowest_used_cache_tier(options.lowest_used_cache_tier),
       compaction_service(options.compaction_service),
-      enforce_single_del_contracts(options.enforce_single_del_contracts),
-      flush_switch(options.flush_switch) {
+      enforce_single_del_contracts(options.enforce_single_del_contracts) {
   fs = env->GetFileSystem();
   clock = env->GetSystemClock().get();
   logger = info_log.get();

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -110,7 +110,6 @@ struct ImmutableDBOptions {
   Logger* logger;
   std::shared_ptr<CompactionService> compaction_service;
   bool enforce_single_del_contracts;
-  std::shared_ptr<FlushSwitch> flush_switch;
 
   bool IsWalDirSameAsDBPath() const;
   bool IsWalDirSameAsDBPath(const std::string& path) const;

--- a/options/options.cc
+++ b/options/options.cc
@@ -415,7 +415,7 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
         log, "         Options.blob_compaction_readahead_size: %" PRIu64,
         blob_compaction_readahead_size);
     ROCKS_LOG_HEADER(log, "                          Options.disable_flush: %d",
-                     disable_flush);
+                     disable_auto_flush);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options.cc
+++ b/options/options.cc
@@ -414,6 +414,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     ROCKS_LOG_HEADER(
         log, "         Options.blob_compaction_readahead_size: %" PRIu64,
         blob_compaction_readahead_size);
+    ROCKS_LOG_HEADER(log, "                          Options.disable_flush: %d",
+                     disable_flush);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -214,6 +214,7 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->max_successive_merges = moptions.max_successive_merges;
   cf_opts->inplace_update_num_locks = moptions.inplace_update_num_locks;
   cf_opts->prefix_extractor = moptions.prefix_extractor;
+  cf_opts->disable_flush = moptions.disable_flush;
 
   // Compaction related options
   cf_opts->disable_auto_compactions = moptions.disable_auto_compactions;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -214,7 +214,7 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->max_successive_merges = moptions.max_successive_merges;
   cf_opts->inplace_update_num_locks = moptions.inplace_update_num_locks;
   cf_opts->prefix_extractor = moptions.prefix_extractor;
-  cf_opts->disable_flush = moptions.disable_flush;
+  cf_opts->disable_auto_flush = moptions.disable_auto_flush;
 
   // Compaction related options
   cf_opts->disable_auto_compactions = moptions.disable_auto_compactions;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -249,7 +249,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.blob_garbage_collection_force_threshold, 0.75);
   ASSERT_EQ(new_cf_opt.blob_compaction_readahead_size, 262144);
   ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
-  ASSERT_EQ(new_cf_opt.disable_flush, false);
+  ASSERT_EQ(new_cf_opt.disable_auto_flush, false);
 
   cf_options_map["write_buffer_size"] = "hello";
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(exact, base_cf_opt, cf_options_map,

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -110,6 +110,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
       {"blob_garbage_collection_force_threshold", "0.75"},
       {"blob_compaction_readahead_size", "256K"},
       {"bottommost_temperature", "kWarm"},
+      {"disable_flush", "false"}
   };
 
   std::unordered_map<std::string, std::string> db_options_map = {
@@ -248,6 +249,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.blob_garbage_collection_force_threshold, 0.75);
   ASSERT_EQ(new_cf_opt.blob_compaction_readahead_size, 262144);
   ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
+  ASSERT_EQ(new_cf_opt.disable_flush, false);
 
   cf_options_map["write_buffer_size"] = "hello";
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(exact, base_cf_opt, cf_options_map,


### PR DESCRIPTION
Enabling/disabling auto flush through the `SetOptions` API and removed `FlushSwitch`. 

Flush could be triggered in following scenarios:
1. Single memtable exceeds `write_buffer_size` limit.  The memtable will be put into the flush scheduler queue, and flush is scheduled on next write.
2. All memtables exceed `db_write_buffer_size` limit. Memtables will be flushed right away. This is controlled through `WriteBufferManager`. 
3. WAL size exceeds `max_total_wal_size`. Memtables will be flushed right away.
4. Manual flush

When auto flush is disabled, 1 and 3 won't be triggered while 2 and 4 can still be issued. 

I didn't support disabling flush on running db intentionally, since we don't need that right now. In leader/follower, db by default opens in follower mode with flush disabled. When follower tries to take over, it will enable flush. When a leader tries to become follower, it will reopen DB with flush disabled. But it's easy to support that if we want to.



