### PR TITLE
Support replicating log record metadata

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1105,7 +1105,8 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
     write_thread_.EnterUnbatched(&w, &mutex_);
 
     switch (record.type) {
-      case ReplicationLogRecord::kMemtableWrite: {
+      case ReplicationLogRecord::kMemtableWrite:
+      case ReplicationLogRecord::kMemtableWriteWithMetadata: {
         mutex_.Unlock();
         WriteBatch batch;
         s = WriteBatchInternal::SetContents(&batch, std::move(record.contents));

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -479,7 +479,8 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
 
       ReplicationLogRecord rlr;
       rlr.contents = WriteBatchInternal::StealContents(&wb);
-      rlr.type = ReplicationLogRecord::kMemtableWrite;
+      rlr.metadata = write_options.repl_record_metadata;
+      rlr.type = ReplicationLogRecord::kMemtableWriteWithMetadata;
       immutable_db_options_.replication_log_listener->OnReplicationLogRecord(
           std::move(rlr));
     }


### PR DESCRIPTION
The `metadata` can be used to replicate extra data passed from the caller of `Write` API. One example usage is to replicate the in-memory cache delta changes. Caller is responsible for the serde and make sure `metadata` is consistent with the `content`.


## TESTS
- [x] existing `replication_test`