### PR TITLE
[SYS-3275] Igore directories and errors during local directory cleaning up

### DIFF
--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3250,6 +3250,8 @@ class ModelDB : public DB {
 
   void NewManifestOnNextUpdate() override {}
 
+  uint64_t GetNextFileNumber() const override { return 0; };
+
  private:
   class ModelIter : public Iterator {
    public:


### PR DESCRIPTION
Local directory cleaning up during sanitization fails if there is directory locally. We changed the behavior here so that:
* Local directories are ignored
* File deletion errors are ignored as well. This is ok since we fetch the latest CM/M from s3 when `resync_on_open=True`

## TESTS
- [x] Added new tests to test `SanitizeDirectory` function