### PR TITLE
Fix logging for disable_auto_flush

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1295,11 +1295,18 @@ void ColumnFamilyData::InstallSuperVersion(
     }
     if (old_superversion->mutable_cf_options.disable_auto_flush != mutable_cf_options.disable_auto_flush) {
       assert(!mutable_cf_options.disable_auto_flush);
-      ROCKS_LOG_INFO(ioptions_.info_log,
-                     "Enabling auto flush for column family: %s; old super "
-                     "version: %" PRIu64 ", new super version: %" PRIu64,
-                     GetName().c_str(), old_superversion->version_number,
-                     new_superversion->version_number);
+      ROCKS_LOG_INFO(
+          ioptions_.info_log,
+          "Enabling auto flush for column family: %s; old super "
+          "version: %" PRIu64
+          ", disable_auto_flush: %d; new super version: %" PRIu64
+          ", disable_auto_flush: %d",
+          GetName().c_str(), old_superversion->version_number,
+          static_cast<int>(
+              old_superversion->mutable_cf_options.disable_auto_flush),
+          new_superversion->version_number,
+          static_cast<int>(
+              new_superversion->mutable_cf_options.disable_auto_flush));
       mem_->EnableAutoFlush();
     }
 

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1295,8 +1295,11 @@ void ColumnFamilyData::InstallSuperVersion(
     }
     if (old_superversion->mutable_cf_options.disable_auto_flush != mutable_cf_options.disable_auto_flush) {
       assert(!mutable_cf_options.disable_auto_flush);
-      ROCKS_LOG_INFO(ioptions_.info_log, "Enabling auto flush for column family: %s",
-                     GetName().c_str());
+      ROCKS_LOG_INFO(ioptions_.info_log,
+                     "Enabling auto flush for column family: %s; old super "
+                     "version: %" PRIu64 ", new super version: %" PRIu64,
+                     GetName().c_str(), old_superversion->version_number,
+                     new_superversion->version_number);
       mem_->EnableAutoFlush();
     }
 

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1074,8 +1074,8 @@ void MutableCFOptions::Dump(Logger* log) const {
 
   ROCKS_LOG_INFO(log, "                   bottommost_temperature: %d",
                  static_cast<int>(bottommost_temperature));
-  ROCKS_LOG_INFO(log, "                           disable_flush: %d",
-                 static_cast<int>(bottommost_temperature));
+  ROCKS_LOG_INFO(log, "                       disable_auto_flush: %d",
+                 static_cast<int>(disable_auto_flush));
 }
 
 MutableCFOptions::MutableCFOptions(const Options& options)

--- a/options/options.cc
+++ b/options/options.cc
@@ -414,7 +414,7 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
     ROCKS_LOG_HEADER(
         log, "         Options.blob_compaction_readahead_size: %" PRIu64,
         blob_compaction_readahead_size);
-    ROCKS_LOG_HEADER(log, "                          Options.disable_flush: %d",
+    ROCKS_LOG_HEADER(log, "                     Options.disable_auto_flush: %d",
                      disable_auto_flush);
 }  // ColumnFamilyOptions::Dump
 


### PR DESCRIPTION
Logged `disable_auto_flush` options on start up correctly. Also, added logging of superversion version to help debug the issue of `EnableAutoFlush` called multiple times.