### PR TITLE
[SYS-3282] InstallSuperVersion with old mutable_cf_options shouldn't trigger EnableAutoFlush

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -220,6 +220,10 @@ void MemTable::EnableAutoFlush() {
   }
 }
 
+bool MemTable::TEST_IsAutoFlushEnabled() const {
+  return !disable_auto_flush_.load(std::memory_order_relaxed);
+}
+
 void MemTable::UpdateFlushState() {
   auto state = flush_state_.load(std::memory_order_relaxed);
   if (state == FLUSH_NOT_REQUESTED && ShouldFlushNow()) {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -511,6 +511,7 @@ class MemTable {
 
   // Enable auto flush if it's previously disabled
   void EnableAutoFlush();
+  bool TEST_IsAutoFlushEnabled() const;
 
  private:
   enum FlushStateEnum { FLUSH_NOT_REQUESTED, FLUSH_REQUESTED, FLUSH_SCHEDULED };


### PR DESCRIPTION
If compaction is started before we enable auto flush and finishes after we enable auto flush, we will hit the issue of trying to set `disable_auto_flush=true` when compaction job tries to install super version with the old mutable_cf_option.

Sequence of steps:
- Compaction starts with own copy of `mutable_cf_options`(`disable_auto_flush=true`)
- `SetOptions()` with `disable_auto_flush=false`
- Compaction finishes and calls `InstallSuperVersion` with `mutable_cf_options`(`disable_auto_flush=true`).

This seems to be a bug of rocksdb in general. A compaction job which is started with old `mutable_cf_options` and before we call `SetOptions` explicitly might install a super version with stale `mutable_cf_options`. I believe we can trigger the same bug for the other options as well. For the other options, this bug might not be a big deal since the next time we install a new superversion, the new superversion will have the right `mutable_cf_options`. 

We get around this issue by only enabling auto flush if previous superversion has `autoflush` disabled. Also, in rockset, we will enable auto flush first before enabling auto compaction.

## TESTS
- [x] Added tests to make sure that InstallSuperVersion with old mutable_cf_options wouldn't trigger EnableAutoFlush