### PR TITLE
Unify the way cloud_env_options are printed

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -2243,26 +2243,8 @@ Status CloudEnvImpl::ValidateOptions(const DBOptions& db_opts,
   if (info_log_ == nullptr) {
     info_log_ = db_opts.info_log;
   }
-  Header(info_log_, "     %s.src_bucket_name: %s", Name(),
-         cloud_env_options.src_bucket.GetBucketName().c_str());
-  Header(info_log_, "     %s.src_object_path: %s", Name(),
-         cloud_env_options.src_bucket.GetObjectPath().c_str());
-  Header(info_log_, "     %s.src_bucket_region: %s", Name(),
-         cloud_env_options.src_bucket.GetRegion().c_str());
-  Header(info_log_, "     %s.dest_bucket_name: %s", Name(),
-         cloud_env_options.dest_bucket.GetBucketName().c_str());
-  Header(info_log_, "     %s.dest_object_path: %s", Name(),
-         cloud_env_options.dest_bucket.GetObjectPath().c_str());
-  Header(info_log_, "     %s.dest_bucket_region: %s", Name(),
-         cloud_env_options.dest_bucket.GetRegion().c_str());
   Status s = CheckValidity();
   if (s.ok()) {
-    Header(info_log_, "     %s.storage_provider: %s", Name(),
-           GetStorageProvider()->Name());
-    if (cloud_env_options.cloud_log_controller) {
-      Header(info_log_, "     %s.log controller: %s", Name(),
-             cloud_env_options.cloud_log_controller->Name());
-    }
     return CloudEnv::ValidateOptions(db_opts, cf_opts);
   } else {
     return s;

--- a/cloud/cloud_env_options.cc
+++ b/cloud/cloud_env_options.cc
@@ -16,6 +16,18 @@ void CloudEnvOptions::Dump(Logger* log) const {
   auto provider = storage_provider.get();
   auto controller = cloud_log_controller.get();
   Header(log, "                         COptions.cloud_type: %s", (provider != nullptr) ? provider->Name() : "Unknown");
+  Header(log, "                    COptions.src_bucket_name: %s",
+         src_bucket.GetBucketName().c_str());
+  Header(log, "                    COptions.src_object_path: %s",
+         src_bucket.GetObjectPath().c_str());
+  Header(log, "                  COptions.src_bucket_region: %s",
+         src_bucket.GetRegion().c_str());
+  Header(log, "                   COptions.dest_bucket_name: %s",
+         dest_bucket.GetBucketName().c_str());
+  Header(log, "                   COptions.dest_object_path: %s",
+         dest_bucket.GetObjectPath().c_str());
+  Header(log, "                 COptions.dest_bucket_region: %s",
+         dest_bucket.GetRegion().c_str());
   Header(log, "                           COptions.log_type: %s", (controller != nullptr) ? controller->Name() : "None");
   Header(log, "               COptions.keep_local_sst_files: %d",
          keep_local_sst_files);


### PR DESCRIPTION
In particular, don't print them in ValidateOptions() as that is invoked once
for every column family and it gets fairly verbose and not very useful.

