### PR TITLE
[SYS-2547] Add replication debug logging to the follower

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1164,16 +1164,18 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
           oss << "Gap in sequence numbers, expected="
               << versions_->LastSequence() + 1
               << " got=" << WriteBatchInternal::Sequence(&batch);
-          return Status::Corruption(oss.str());
+          s = Status::Corruption(oss.str());
         }
 
-        SequenceNumber next_seq;
-        s = WriteBatchInternal::InsertInto(
-            &batch, column_family_memtables_.get(), &flush_scheduler_,
-            &trim_history_scheduler_,
-            true /* ignore_missing_column_families_ */, 0 /* log_number */,
-            this, false /* concurrent_memtable_writes */, &next_seq,
-            nullptr /* has_valid_writes */, seq_per_batch_, batch_per_txn_);
+        SequenceNumber next_seq{0};
+        if (s.ok()) {
+          s = WriteBatchInternal::InsertInto(
+              &batch, column_family_memtables_.get(), &flush_scheduler_,
+              &trim_history_scheduler_,
+              true /* ignore_missing_column_families_ */, 0 /* log_number */,
+              this, false /* concurrent_memtable_writes */, &next_seq,
+              nullptr /* has_valid_writes */, seq_per_batch_, batch_per_txn_);
+        }
         if (s.ok()) {
           versions_->SetLastSequence(next_seq - 1);
         }
@@ -1186,7 +1188,7 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
         Slice contents_slice(record.contents);
         s = DeserializeMemTableSwitchRecord(&contents_slice, &mem_switch_record);
         if (!s.ok()) {
-          return s;
+          break;
         }
         ROCKS_LOG_INFO(immutable_db_options_.info_log,
                        "Applying memtable switch with next log file: %" PRIu64
@@ -1214,9 +1216,9 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
         break;
       }
       case ReplicationLogRecord::kManifestWrite: {
-        Slice src = record.contents;
+        Slice contents_slice(record.contents);
         autovector<VersionEdit> edits;
-        s = DeserializeReplicationLogManifestWrite(&src, &edits);
+        s = DeserializeReplicationLogManifestWrite(&contents_slice, &edits);
         if (!s.ok()) {
             break;
         }
@@ -1235,8 +1237,9 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
         uint64_t latest_applied_update_sequence = 0;
         for (auto& e : edits) {
           if (!e.HasManifestUpdateSequence()) {
-            return Status::InvalidArgument(
+            s = Status::InvalidArgument(
                 "Manifest write doesn't have a ManifestUpdateSequence");
+            break;
           }
           latest_applied_update_sequence = e.GetManifestUpdateSequence();
           if (e.GetManifestUpdateSequence() <= current_update_sequence) {
@@ -1249,7 +1252,8 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
             oss << "Gap in ManifestUpdateSequence, expected="
                 << current_update_sequence
                 << " got=" << e.GetManifestUpdateSequence();
-            return Status::Corruption(oss.str());
+            s = Status::Corruption(oss.str());
+            break;
           }
 
           if (e.HasLogNumber()) {
@@ -1268,7 +1272,6 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
             cfd = versions_->GetColumnFamilySet()->GetColumnFamily(
                 e.GetColumnFamily());
           }
-
           if (e.IsColumnFamilyAdd()) {
             single_column_family_mode_ = false;
             added_column_families.push_back(e.GetColumnFamily());
@@ -1277,7 +1280,6 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
           } else if (e.IsColumnFamilyDrop()) {
             info->deleted_column_families.push_back(e.GetColumnFamily());
           }
-
           cfds.push_back(cfd);
           mutable_cf_options_list.push_back(mutable_options);
           autovector<VersionEdit*> el;
@@ -1287,12 +1289,15 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
           ROCKS_LOG_INFO(immutable_db_options_.info_log, "%s",
                          DescribeVersionEdit(e, cfd).c_str());
         }
+        if (!s.ok()) {
+          break;
+        }
         s = versions_->LogAndApply(cfds, mutable_cf_options_list, edit_lists,
                                    &mutex_, directories_.GetDbDir(),
                                    false /* new_descriptor_log */,
                                    cf_options.get());
         if (!s.ok()) {
-          return s;
+          break;
         }
         for (auto cfd : cfds) {
           if (!cfd) {
@@ -1352,27 +1357,29 @@ Status DBImpl::GetReplicationRecordDebugString(
       Slice contents_slice(record.contents);
       s = DeserializeMemTableSwitchRecord(&contents_slice, &mem_switch_record);
       if (!s.ok()) {
-        return s;
+        break;
       }
       oss << "kMemtableSwitch next_log_num=" << mem_switch_record.next_log_num;
       break;
     }
     case ReplicationLogRecord::kManifestWrite: {
-      Slice src = record.contents;
+      Slice contents_slice(record.contents);
       autovector<VersionEdit> edits;
-      s = DeserializeReplicationLogManifestWrite(&src, &edits);
+      s = DeserializeReplicationLogManifestWrite(&contents_slice, &edits);
       if (!s.ok()) {
-        return s;
+        break;
       }
       oss << "kManifestWrite with " << edits.size() << " updates:\n";
-      for (auto& e : edits) {
+      for (const auto& e : edits) {
         oss << e.DebugString(true);
       }
       break;
     }
   }
 
-  *out = oss.str();
+  if (s.ok()) {
+    *out = oss.str();
+  }
   return s;
 }
 

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -335,6 +335,8 @@ class DBImpl : public DB {
       ReplicationLogRecord record,
       std::string replication_sequence,
       ApplyReplicationLogRecordInfo* info) override;
+  Status GetReplicationRecordDebugString(
+      const ReplicationLogRecord& record, std::string* out) const override;
   Status GetPersistedReplicationSequence(std::string* out) override;
   Status GetManifestUpdateSequence(uint64_t* out) override;
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -586,6 +586,7 @@ class VersionEdit {
   }
 
   bool IsColumnFamilyAdd() const { return is_column_family_add_; }
+  const std::string& GetAddColumnFamily() const { return column_family_name_; }
 
   bool IsColumnFamilyDrop() const { return is_column_family_drop_; }
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1264,6 +1264,8 @@ class DB {
       ReplicationLogRecord record,
       std::string replication_sequence,
       ApplyReplicationLogRecordInfo* info) = 0;
+  virtual Status GetReplicationRecordDebugString(
+      const ReplicationLogRecord& record, std::string* out) const = 0;
   // Returns the latest replication log sequence number (returned by
   // ReplicationLogListener::OnReplicationLogRecord()) that is persisted in the
   // LSM tree. All records after the persisted sequence need to be reapplied

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -483,6 +483,10 @@ class StackableDB : public DB {
       ApplyReplicationLogRecordInfo* info) override {
     return db_->ApplyReplicationLogRecord(record, replication_sequence, info);
   }
+  Status GetReplicationRecordDebugString(const ReplicationLogRecord& record,
+                                         std::string* out) const override {
+    return db_->GetReplicationRecordDebugString(record, out);
+  }
   Status GetPersistedReplicationSequence(std::string* out) override {
     return db_->GetPersistedReplicationSequence(out);
   }


### PR DESCRIPTION
This PR introduces debug logging on the follower. kMemtableSwitch and
kManifestWrite events are logged, which correspond to flush/compaction/column
family deletion and creation. All of those are logged on the leader as well, so
there is no concern of excessive logging.

DB::GetReplicationRecordDebugString is also introduced in the PR, which
provides much more detailed information about each replication event and could
be used when more verbose information is needed.

Log example:
```
2022/10/05-15:46:22.272607 140138908816064 [/db_impl/db_impl.cc:1195] Applying memtable switch with next log file: 1132, replication sequence (hex): 3534333438
2022/10/05-15:46:22.272617 140138908816064 [/db_impl/db_impl_write.cc:2012] [cf0] New memtable created with log file: #1132. Immutable memtables: 0.
2022/10/05-15:46:22.272624 140138908816064 [/db_impl/db_impl_write.cc:2012] [cf1] New memtable created with log file: #1132. Immutable memtables: 0.
2022/10/05-15:46:22.272629 140138908816064 [/db_impl/db_impl_write.cc:2012] [cf2] New memtable created with log file: #1132. Immutable memtables: 0.
2022/10/05-15:46:22.274322 140138908816064 [/db_impl/db_impl.cc:1288] [cf2] Applying manifest update seq=906: New files: [1125, 1126, 1131, 1136] Deleted files: [1112, 939, 940, 945] NextFileNumber: 1137
2022/10/05-15:46:22.277757 140138908816064 [/db_impl/db_impl.cc:1288] [cf0] Applying manifest update seq=907: New files: [1133] NextFileNumber: 1138
2022/10/05-15:46:22.277765 140138908816064 [/db_impl/db_impl.cc:1288] [cf1] Applying manifest update seq=908: New files: [1134] NextFileNumber: 1138
2022/10/05-15:46:22.277768 140138908816064 [/db_impl/db_impl.cc:1288] [cf2] Applying manifest update seq=909: New files: [1135] NextFileNumber: 1138
```
