### PR TITLE
[SYS-3326] The caller should provide CF options for new CF in ApplyReplicationLogRecord

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -332,8 +332,8 @@ class DBImpl : public DB {
   virtual void DisableManualCompaction() override;
 
   Status ApplyReplicationLogRecord(
-      ReplicationLogRecord record,
-      std::string replication_sequence,
+      ReplicationLogRecord record, std::string replication_sequence,
+      CFOptionsFactory cf_options_factory,
       ApplyReplicationLogRecordInfo* info) override;
   Status GetReplicationRecordDebugString(
       const ReplicationLogRecord& record, std::string* out) const override;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3238,6 +3238,7 @@ class ModelDB : public DB {
 
   Status ApplyReplicationLogRecord(
       ReplicationLogRecord /*record*/, std::string /*replication_sequence*/,
+      CFOptionsFactory /* cf_options_factory */,
       ApplyReplicationLogRecordInfo* /*info*/) override {
     return Status::NotSupported("Not supported in Model DB");
   }
@@ -3245,6 +3246,10 @@ class ModelDB : public DB {
     return Status::NotSupported("Not supported in Model DB");
   }
   Status GetManifestUpdateSequence(uint64_t* /*out*/) override {
+    return Status::NotSupported("Not supported in Model DB");
+  }
+  Status GetReplicationRecordDebugString(const ReplicationLogRecord& /* record */,
+                                         std::string* /* out */) const override {
     return Status::NotSupported("Not supported in Model DB");
   }
 

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1258,11 +1258,17 @@ class DB {
   // leader's ReplicationLogListener. Info contains some useful information
   // about the event that was applied.
   //
+  // cf_options_factory is invoked when ApplyReplicationLogRecord contains a
+  // column family creation. Column family name is given as an argument and its
+  // options need to be returned. The function is invoked done outside of the DB
+  // mutex.
+  //
   //
   // REQUIRES: info needs to be provided, can't be nullptr.
+  using CFOptionsFactory = std::function<ColumnFamilyOptions(Slice)>;
   virtual Status ApplyReplicationLogRecord(
-      ReplicationLogRecord record,
-      std::string replication_sequence,
+      ReplicationLogRecord record, std::string replication_sequence,
+      CFOptionsFactory cf_options_factory,
       ApplyReplicationLogRecordInfo* info) = 0;
   virtual Status GetReplicationRecordDebugString(
       const ReplicationLogRecord& record, std::string* out) const = 0;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -478,10 +478,11 @@ class StackableDB : public DB {
   }
 
   Status ApplyReplicationLogRecord(
-      ReplicationLogRecord record,
-      std::string replication_sequence,
+      ReplicationLogRecord record, std::string replication_sequence,
+      CFOptionsFactory cf_options_factory,
       ApplyReplicationLogRecordInfo* info) override {
-    return db_->ApplyReplicationLogRecord(record, replication_sequence, info);
+    return db_->ApplyReplicationLogRecord(record, replication_sequence,
+                                          std::move(cf_options_factory), info);
   }
   Status GetReplicationRecordDebugString(const ReplicationLogRecord& record,
                                          std::string* out) const override {


### PR DESCRIPTION
Until now, we created the ColumnFamilyOptions for a column family created
through ApplyReplicationLogRecord() by copying the default CF's options. This
was good enough for a prototype, but we need the ability on the caller to
provide the custom options. This PR implements the support through a
CFOptionsFactory callback provided to ApplyReplicationLogRecord().
