### PR TITLE
Do not call malloc_usable_size on memory allocated from arenas

### DIFF
--- a/memory/jemalloc_nodump_allocator.h
+++ b/memory/jemalloc_nodump_allocator.h
@@ -69,7 +69,7 @@ class JemallocNodumpAllocator : public BaseMemoryAllocator {
 
   // Get or create tcache. Return flag suitable to use with `mallocx`:
   // either MALLOCX_TCACHE_NONE or MALLOCX_TCACHE(tc).
-  int GetThreadSpecificCache(size_t size);
+  int GetThreadSpecificCache(size_t size) const;
 #endif  // ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
   JemallocAllocatorOptions options_;
 
@@ -85,7 +85,7 @@ class JemallocNodumpAllocator : public BaseMemoryAllocator {
   std::unique_ptr<extent_hooks_t> arena_hooks_;
 
   // Hold thread-local tcache index.
-  ThreadLocalPtr tcache_;
+  mutable ThreadLocalPtr tcache_;
 #endif  // ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
 
   // Arena index.

--- a/memory/memory_allocator.h
+++ b/memory/memory_allocator.h
@@ -17,7 +17,7 @@ struct CustomDeleter {
     if (allocator) {
       allocator->Deallocate(reinterpret_cast<void*>(ptr));
     } else {
-      delete[] ptr;
+      free(reinterpret_cast<void*>(ptr));
     }
   }
 
@@ -32,7 +32,8 @@ inline CacheAllocationPtr AllocateBlock(size_t size,
     auto block = reinterpret_cast<char*>(allocator->Allocate(size));
     return CacheAllocationPtr(block, allocator);
   }
-  return CacheAllocationPtr(new char[size]);
+  void* block = malloc(size);
+  return CacheAllocationPtr(reinterpret_cast<char*>(block));
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memory/memory_allocator.h
+++ b/memory/memory_allocator.h
@@ -17,7 +17,7 @@ struct CustomDeleter {
     if (allocator) {
       allocator->Deallocate(reinterpret_cast<void*>(ptr));
     } else {
-      free(reinterpret_cast<void*>(ptr));
+      delete[] ptr;
     }
   }
 
@@ -32,8 +32,7 @@ inline CacheAllocationPtr AllocateBlock(size_t size,
     auto block = reinterpret_cast<char*>(allocator->Allocate(size));
     return CacheAllocationPtr(block, allocator);
   }
-  void* block = malloc(size);
-  return CacheAllocationPtr(reinterpret_cast<char*>(block));
+  return CacheAllocationPtr(new char[size]);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memory/memory_allocator_test.cc
+++ b/memory/memory_allocator_test.cc
@@ -212,6 +212,18 @@ TEST_F(CreateMemoryAllocatorTest, NewJemallocNodumpAllocator) {
   ASSERT_EQ(opts->limit_tcache_size, jopts.limit_tcache_size);
 }
 
+#ifdef ROCKSDB_JEMALLOC_NODUMP_ALLOCATOR
+TEST(JemallocNodumpAllocatorTest, LimitCacheSize) {
+  std::shared_ptr<MemoryAllocator> allocator;
+  JemallocAllocatorOptions options;
+  options.limit_tcache_size = true;
+  ASSERT_OK(NewJemallocNodumpAllocator(options, &allocator));
+  auto ptr = allocator->Allocate(1024);
+  EXPECT_GE(allocator->UsableSize(ptr, 1024), 1024);
+  allocator->Deallocate(ptr);
+}
+#endif
+
 INSTANTIATE_TEST_CASE_P(DefaultMemoryAllocator, MemoryAllocatorTest,
                         ::testing::Values(std::make_tuple(
                             DefaultMemoryAllocator::kClassName(), true)));


### PR DESCRIPTION
Calling `malloc_usable_size` on memory allocated from jemalloc arenas will cause asan to complain with `AddressSanitizer: attempting to call malloc_usable_size() for pointer which is not owned` error. This PR fixes the issue:
* In `JemallocNodumpAllocator`, uses `sallocx` and `nallocx` to return size for memory allocated from jemalloc.

Related issues:
* https://github.com/facebook/rocksdb/issues/10797

## TESTS
- [x] built with `DEBUG_LEVEL=2 USE_AWS=1 USE_RTTI=1 CFLAGS='-fsanitize=address' LDFLAGS='-fsanitize=address' USE_CLANG=1 CC=clang-14 CXX=clang++-14 make -j 8 memory_allocator_test` and ran `./memory_allocator_test`
