### PR TITLE
Don't create a new manifest twice

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4420,9 +4420,11 @@ Status VersionSet::ProcessManifestWrites(
   }
 
   assert(pending_manifest_file_number_ == 0);
+  auto new_manifest_force =
+      new_manifest_on_next_update_.exchange(false, std::memory_order_relaxed);
   if (!descriptor_log_ ||
       manifest_file_size_ > db_options_->max_manifest_file_size ||
-      new_manifest_on_next_update_.exchange(false, std::memory_order_relaxed)) {
+      new_manifest_force) {
     TEST_SYNC_POINT("VersionSet::ProcessManifestWrites:BeforeNewManifest");
     new_descriptor_log = true;
   } else {


### PR DESCRIPTION
`new_manifest_on_next_update_.exchange()` is not executed if other conditions
for creating new manifest file are satisfied. This is not the behavior we want
- if the new manifest is created for any other reason, we don't need to create
the manifest again.
