### PR TITLE
[SYS-3320] Fix the way NextFileNumbers are handled in ApplyReplicationLogRecord()

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1264,9 +1264,12 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
             // argue: at least one alive_log_files_ and logs_ always needs to be
             // alive and alive means that its log number is greater or equal to
             // the latest log number.
-            versions_->MarkFileNumberUsed(e.GetLogNumber());
             alive_log_files_.begin()->number = e.GetLogNumber();
             logs_.front().number = e.GetLogNumber();
+          }
+
+          if (e.HasNextFile()) {
+              versions_->SetNextFileNumber(e.GetNextFile());
           }
 
           ColumnFamilyData* cfd{nullptr};

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1156,6 +1156,8 @@ class VersionSet {
     return next_file_number_.fetch_add(n);
   }
 
+  void SetNextFileNumber(uint64_t n) { next_file_number_.store(n); }
+
   // Return the last sequence number.
   uint64_t LastSequence() const {
     return last_sequence_.load(std::memory_order_acquire);


### PR DESCRIPTION
The way we handled NextFileNumber propagation in ApplyReplicationLogRecord()
was broken. We only updated `next_file_number_` through
`versions_->MarkFileNumberUsed(e.GetLogNumber());`, when the version edit had the
`GetLogNumber()` present. Version edit's next file number (that was set on the
leader) was reset in follower's VersionSet based on the latest value of
`next_file_number_` here:
https://github.com/rockset/rocksdb-cloud/blob/27dbc089b8952fdda6203c190867526ab28a8a74/db/version_set.cc#L4911

This PR fixes this by setting `next_file_number_` when version edit received
from the leader carries the NextFileNumber. This should keep the
`next_file_number_` on the follower the same as on the leader.

A failing unit test is introduced and fixed in this PR.
