### PR TITLE
[SYS-3469] Don't create a new CLOUDMANIFEST if roll_cloud_manifest_on_open=false

### DIFF
--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -188,7 +188,8 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
     st = DB::Open(options, local_dbname, column_families, handles, &db);
   }
 
-  if (new_db && st.ok() && cenv->HasDestBucket()) {
+  if (new_db && st.ok() && cenv->HasDestBucket() &&
+      cenv->GetCloudEnvOptions().roll_cloud_manifest_on_open) {
     // This is a new database, upload the CLOUDMANIFEST after all MANIFEST file
     // was already uploaded. It is at this point we consider the database
     // committed in the cloud.

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -2499,6 +2499,7 @@ TEST_F(CloudTest, DisableObsoleteFileDeletionOnOpenTest) {
   WriteOptions wo;
   wo.disableWAL = true;
   OpenDB();
+  SwitchToNewCookie("");
   db_->DisableFileDeletions();
 
   std::vector<LiveFileMetaData> files;
@@ -2511,8 +2512,8 @@ TEST_F(CloudTest, DisableObsoleteFileDeletionOnOpenTest) {
   ASSERT_EQ(files.size(), 2);
 
   auto local_files = GetAllLocalFiles();
-  // CM, MANIFEST, CURRENT, IDENTITY, 2 sst files, wal directory
-  EXPECT_EQ(local_files.size(), 7);
+  // CM, MANIFEST1, MANIFEST2, CURRENT, IDENTITY, 2 sst files, wal directory
+  EXPECT_EQ(local_files.size(), 8);
 
   ASSERT_OK(GetDBImpl()->TEST_CompactRange(0, nullptr, nullptr, nullptr, true));
 
@@ -2522,7 +2523,7 @@ TEST_F(CloudTest, DisableObsoleteFileDeletionOnOpenTest) {
 
   local_files = GetAllLocalFiles();
   // obsolete files are not deleted, also one extra sst files generated after compaction
-  EXPECT_EQ(local_files.size(), 8);
+  EXPECT_EQ(local_files.size(), 9);
 
   CloseDB();
 


### PR DESCRIPTION
See internal task for more information. Creating a new CLOUDMANIFEST with the
new cookie on open is equivalent to rolling a new cloud manifest. Therefore, we
shouldn't do it if `roll_cloud_manifest_on_open` is false.

Existing unit tests and internal buildkite tests.
