### PR TITLE
[SYS-3456] fix the race between CloudEnv destruction and file deletion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,7 @@ set(SOURCES
         cloud/cloud_scheduler.cc
         cloud/cloud_storage_provider.cc
         cloud/cloud_file_cache.cc
+        cloud/cloud_file_deletion_scheduler.cc
         db/db_impl/db_impl_remote_compaction.cc
         db/db_impl/replication_codec.cc
         $<TARGET_OBJECTS:build_version>)

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -27,10 +27,82 @@
 
 namespace ROCKSDB_NAMESPACE {
 
+std::shared_ptr<CloudFileDeletionScheduler> CloudFileDeletionScheduler::Create(
+     const std::shared_ptr<CloudScheduler>& scheduler) {
+  return std::make_shared<CloudFileDeletionScheduler>(PrivateTag(), scheduler);
+}
+
+CloudFileDeletionScheduler::~CloudFileDeletionScheduler() {
+  TEST_SYNC_POINT(
+      "CloudFileDeletionScheduler::~CloudFileDeletionScheduler:"
+      "BeforeCancelJobs");
+  for (auto& e : files_to_delete_) {
+    scheduler_->CancelJob(e.second);
+  }
+  files_to_delete_.clear();
+}
+
+void CloudFileDeletionScheduler::UnscheduleFileDeletion(const std::string& filename) {
+  std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+  auto itr = files_to_delete_.find(filename);
+  if (itr != files_to_delete_.end()) {
+    scheduler_->CancelJob(itr->second);
+    files_to_delete_.erase(itr);
+  }
+}
+
+rocksdb::Status CloudFileDeletionScheduler::ScheduleFileDeletion(const std::string& fname, FileDeletionRunnable runnable) {
+  auto wp = this->weak_from_this();
+  auto doDeleteFile = [wp = std::move(wp), fname, runnable = std::move(runnable)](void*) {
+    TEST_SYNC_POINT(
+        "CloudFileDeletionScheduler::ScheduleFileDeletion:BeforeFileDeletion");
+    auto sp = wp.lock();
+    bool file_deleted = false;
+    if (sp) {
+      file_deleted = true;
+      sp->DoDeleteFile(std::move(fname), std::move(runnable));
+    }
+    TEST_SYNC_POINT_CALLBACK(
+        "CloudFileDeletionScheduler::ScheduleFileDeletion:AfterFileDeletion",
+        &file_deleted);
+    (void) file_deleted;
+  };
+
+  {
+    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+    if (files_to_delete_.find(fname) != files_to_delete_.end()) {
+      // already in the queue
+      return Status::OK();
+    }
+
+    auto handle = scheduler_->ScheduleJob(file_deletion_delay_,
+                                          std::move(doDeleteFile), nullptr);
+    files_to_delete_.emplace(fname, std::move(handle));
+  }
+  return Status::OK();
+}
+
+void CloudFileDeletionScheduler::DoDeleteFile(const std::string& fname,
+                                              FileDeletionRunnable runnable) {
+  {
+    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+    auto itr = files_to_delete_.find(fname);
+    if (itr == files_to_delete_.end()) {
+      // File was removed from files_to_delete_, do not delete!
+      return;
+    }
+    files_to_delete_.erase(itr);
+  }
+
+  runnable();
+}
+
 CloudEnvImpl::CloudEnvImpl(const CloudEnvOptions& opts, Env* base,
                            const std::shared_ptr<Logger>& l)
     : CloudEnv(opts, base, l), purger_is_running_(true) {
   scheduler_ = CloudScheduler::Get();
+  cloud_file_deletion_scheduler_ =
+      CloudFileDeletionScheduler::Create(scheduler_);
 }
 
 CloudEnvImpl::~CloudEnvImpl() {
@@ -39,14 +111,6 @@ CloudEnvImpl::~CloudEnvImpl() {
 
   if (cloud_env_options.cloud_log_controller) {
     cloud_env_options.cloud_log_controller->StopTailingStream();
-  }
-  {
-    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-    using std::swap;
-    for (auto& e : files_to_delete_) {
-      scheduler_->CancelJob(e.second);
-    }
-    files_to_delete_.clear();
   }
   StopPurger();
 }
@@ -766,12 +830,7 @@ Status CloudEnvImpl::DeleteFile(const std::string& logical_fname) {
 }
 
 void CloudEnvImpl::RemoveFileFromDeletionQueue(const std::string& filename) {
-  std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-  auto itr = files_to_delete_.find(filename);
-  if (itr != files_to_delete_.end()) {
-    scheduler_->CancelJob(itr->second);
-    files_to_delete_.erase(itr);
-  }
+  cloud_file_deletion_scheduler_->UnscheduleFileDeletion(filename);
 }
 
 Status CloudEnvImpl::CopyLocalFileToDest(const std::string& local_name,
@@ -784,41 +843,28 @@ Status CloudEnvImpl::CopyLocalFileToDest(const std::string& local_name,
 Status CloudEnvImpl::DeleteCloudFileFromDest(const std::string& fname) {
   assert(HasDestBucket());
   auto base = basename(fname);
-  // add the job to delete the file in 1 hour
-  auto doDeleteFile = [this, base](void*) {
-    {
-      std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-      auto itr = files_to_delete_.find(base);
-      if (itr == files_to_delete_.end()) {
-        // File was removed from files_to_delete_, do not delete!
-        return;
-      }
-      files_to_delete_.erase(itr);
-    }
-    auto path = GetDestObjectPath() + "/" + base;
-    // we are ready to delete the file!
-    auto st =
-        GetStorageProvider()->DeleteCloudObject(GetDestBucketName(), path);
-    if (!st.ok() && !st.IsNotFound()) {
-      Log(InfoLogLevel::ERROR_LEVEL, info_log_,
-          "[%s] DeleteFile file %s error %s", Name(), path.c_str(),
-          st.ToString().c_str());
-    }
-  };
-  {
-    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-    if (files_to_delete_.find(base) != files_to_delete_.end()) {
-      // already in the queue
-      return Status::OK();
-    }
-  }
-  {
-    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-    auto handle = scheduler_->ScheduleJob(file_deletion_delay_,
-                                          std::move(doDeleteFile), nullptr);
-    files_to_delete_.emplace(base, std::move(handle));
-  }
-  return Status::OK();
+  auto path = GetDestObjectPath() + pathsep + base;
+  auto bucket = GetDestBucketName();
+  std::weak_ptr<Logger> info_log_wp = info_log_;
+  std::weak_ptr<CloudStorageProvider> storage_provider_wp = GetStorageProvider();
+  auto file_deletion_runnable =
+      [path = std::move(path), bucket = std::move(bucket),
+       info_log_wp = std::move(info_log_wp),
+       storage_provider_wp = std::move(storage_provider_wp)]() {
+        auto storage_provider = storage_provider_wp.lock();
+        auto info_log = info_log_wp.lock();
+        if (!storage_provider || !info_log) {
+          return;
+        }
+        auto st = storage_provider->DeleteCloudObject(bucket, path);
+        if (!st.ok() && !st.IsNotFound()) {
+          Log(InfoLogLevel::ERROR_LEVEL, info_log,
+              "[CloudEnvImpl] DeleteFile file %s error %s", path.c_str(),
+              st.ToString().c_str());
+        }
+      };
+  return cloud_file_deletion_scheduler_->ScheduleFileDeletion(
+      base, std::move(file_deletion_runnable));
 }
 
 // Copy my IDENTITY file to cloud storage. Update dbid registry.

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -17,52 +17,7 @@ namespace ROCKSDB_NAMESPACE {
 class CloudScheduler;
 class CloudStorageReadableFile;
 class ObjectLibrary;
-
-// schedule/unschedule file deletion jobs
-class CloudFileDeletionScheduler
-    : public std::enable_shared_from_this<CloudFileDeletionScheduler> {
-  struct PrivateTag {};
-public:
- static std::shared_ptr<CloudFileDeletionScheduler> Create(
-     const std::shared_ptr<CloudScheduler>& scheduler);
-
- explicit CloudFileDeletionScheduler(
-     PrivateTag, const std::shared_ptr<CloudScheduler>& scheduler)
-     : scheduler_(scheduler) {}
-
- ~CloudFileDeletionScheduler();
-
- void UnscheduleFileDeletion(const std::string& filename);
- using FileDeletionRunnable = std::function<void()>;
- // Schedule the file deletion runnable(which actually delets the file from
- // cloud) to be executed in the future (specified by `file_deletion_delay_`).
- rocksdb::Status ScheduleFileDeletion(const std::string& filename,
-                                      FileDeletionRunnable runnable);
-
- void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
-   std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-   file_deletion_delay_ = delay;
- }
-
- // Return all the files that are scheduled to be deleted(but not deleted yet)
- std::vector<std::string> TEST_FilesToDelete() const {
-   std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-   std::vector<std::string> files;
-   for (auto& [file, handle] : files_to_delete_) {
-     files.push_back(file);
-   }
-  return files;
- }
-
-private:
-  // execute the `FileDeletionRunnable`
- void DoDeleteFile(const std::string& fname, FileDeletionRunnable cb);
- std::shared_ptr<CloudScheduler> scheduler_;
-
- mutable std::mutex files_to_delete_mutex_;
- std::unordered_map<std::string, int> files_to_delete_;
- std::chrono::seconds file_deletion_delay_ = std::chrono::hours(1);
-};
+class CloudFileDeletionScheduler;
 
 //
 // The Cloud environment
@@ -308,9 +263,7 @@ class CloudEnvImpl : public CloudEnv {
 
   void RemoveFileFromDeletionQueue(const std::string& filename);
 
-  void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
-    cloud_file_deletion_scheduler_->TEST_SetFileDeletionDelay(delay);
-  }
+  void TEST_SetFileDeletionDelay(std::chrono::seconds delay);
 
   Status PrepareOptions(const ConfigOptions& config_options) override;
   Status ValidateOptions(const DBOptions& /*db_opts*/,

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -18,6 +18,52 @@ class CloudScheduler;
 class CloudStorageReadableFile;
 class ObjectLibrary;
 
+// schedule/unschedule file deletion jobs
+class CloudFileDeletionScheduler
+    : public std::enable_shared_from_this<CloudFileDeletionScheduler> {
+  struct PrivateTag {};
+public:
+ static std::shared_ptr<CloudFileDeletionScheduler> Create(
+     const std::shared_ptr<CloudScheduler>& scheduler);
+
+ explicit CloudFileDeletionScheduler(
+     PrivateTag, const std::shared_ptr<CloudScheduler>& scheduler)
+     : scheduler_(scheduler) {}
+
+ ~CloudFileDeletionScheduler();
+
+ void UnscheduleFileDeletion(const std::string& filename);
+ using FileDeletionRunnable = std::function<void()>;
+ // Schedule the file deletion runnable(which actually delets the file from
+ // cloud) to be executed in the future (specified by `file_deletion_delay_`).
+ rocksdb::Status ScheduleFileDeletion(const std::string& filename,
+                                      FileDeletionRunnable runnable);
+
+ void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
+   std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+   file_deletion_delay_ = delay;
+ }
+
+ // Return all the files that are scheduled to be deleted(but not deleted yet)
+ std::vector<std::string> TEST_FilesToDelete() const {
+   std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+   std::vector<std::string> files;
+   for (auto& [file, handle] : files_to_delete_) {
+     files.push_back(file);
+   }
+  return files;
+ }
+
+private:
+  // execute the `FileDeletionRunnable`
+ void DoDeleteFile(const std::string& fname, FileDeletionRunnable cb);
+ std::shared_ptr<CloudScheduler> scheduler_;
+
+ mutable std::mutex files_to_delete_mutex_;
+ std::unordered_map<std::string, int> files_to_delete_;
+ std::chrono::seconds file_deletion_delay_ = std::chrono::hours(1);
+};
+
 //
 // The Cloud environment
 //
@@ -263,8 +309,7 @@ class CloudEnvImpl : public CloudEnv {
   void RemoveFileFromDeletionQueue(const std::string& filename);
 
   void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
-    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-    file_deletion_delay_ = delay;
+    cloud_file_deletion_scheduler_->TEST_SetFileDeletionDelay(delay);
   }
 
   Status PrepareOptions(const ConfigOptions& config_options) override;
@@ -421,9 +466,7 @@ class CloudEnvImpl : public CloudEnv {
 
   // scratch space in local dir
   static constexpr const char* SCRATCH_LOCAL_DIR = "/tmp";
-  std::mutex files_to_delete_mutex_;
-  std::chrono::seconds file_deletion_delay_ = std::chrono::hours(1);
-  std::unordered_map<std::string, int> files_to_delete_;
+  std::shared_ptr<CloudFileDeletionScheduler> cloud_file_deletion_scheduler_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/cloud/cloud_file_deletion_scheduler.cc
+++ b/cloud/cloud_file_deletion_scheduler.cc
@@ -1,0 +1,78 @@
+//  Copyright (c) 2016-present, Rockset, Inc.  All rights reserved.
+
+#include "cloud/cloud_file_deletion_scheduler.h"
+
+#include "cloud/cloud_scheduler.h"
+#include "test_util/sync_point.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+std::shared_ptr<CloudFileDeletionScheduler> CloudFileDeletionScheduler::Create(
+     const std::shared_ptr<CloudScheduler>& scheduler) {
+  return std::make_shared<CloudFileDeletionScheduler>(PrivateTag(), scheduler);
+}
+
+CloudFileDeletionScheduler::~CloudFileDeletionScheduler() {
+  TEST_SYNC_POINT(
+      "CloudFileDeletionScheduler::~CloudFileDeletionScheduler:"
+      "BeforeCancelJobs");
+  // NOTE: no need to cancel jobs here. These jobs won't be executed
+  // as longs as `CloudFileDeletionScheduler` is destructed. Also,
+  // `LocalCloudScheduler` will remove the jobs in the queue when destructed
+}
+
+void CloudFileDeletionScheduler::UnscheduleFileDeletion(const std::string& filename) {
+  std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+  auto itr = files_to_delete_.find(filename);
+  if (itr != files_to_delete_.end()) {
+    scheduler_->CancelJob(itr->second);
+    files_to_delete_.erase(itr);
+  }
+}
+
+rocksdb::Status CloudFileDeletionScheduler::ScheduleFileDeletion(const std::string& fname, FileDeletionRunnable runnable) {
+  auto wp = this->weak_from_this();
+  auto doDeleteFile = [wp = std::move(wp), fname, runnable = std::move(runnable)](void*) {
+    TEST_SYNC_POINT(
+        "CloudFileDeletionScheduler::ScheduleFileDeletion:BeforeFileDeletion");
+    auto sp = wp.lock();
+    bool file_deleted = false;
+    if (sp) {
+      file_deleted = true;
+      sp->DoDeleteFile(std::move(fname), std::move(runnable));
+    }
+    TEST_SYNC_POINT_CALLBACK(
+        "CloudFileDeletionScheduler::ScheduleFileDeletion:AfterFileDeletion",
+        &file_deleted);
+    (void) file_deleted;
+  };
+
+  {
+    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+    if (files_to_delete_.find(fname) != files_to_delete_.end()) {
+      // already in the queue
+      return Status::OK();
+    }
+
+    auto handle = scheduler_->ScheduleJob(file_deletion_delay_,
+                                          std::move(doDeleteFile), nullptr);
+    files_to_delete_.emplace(fname, std::move(handle));
+  }
+  return Status::OK();
+}
+
+void CloudFileDeletionScheduler::DoDeleteFile(const std::string& fname,
+                                              FileDeletionRunnable runnable) {
+  {
+    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+    auto itr = files_to_delete_.find(fname);
+    if (itr == files_to_delete_.end()) {
+      // File was removed from files_to_delete_, do not delete!
+      return;
+    }
+    files_to_delete_.erase(itr);
+  }
+
+  runnable();
+}
+}

--- a/cloud/cloud_file_deletion_scheduler.h
+++ b/cloud/cloud_file_deletion_scheduler.h
@@ -1,0 +1,56 @@
+//  Copyright (c) 2016-present, Rockset, Inc.  All rights reserved.
+
+#pragma once
+#include "util/mutexlock.h"
+
+namespace ROCKSDB_NAMESPACE {
+class CloudScheduler;
+
+// schedule/unschedule file deletion jobs
+class CloudFileDeletionScheduler
+    : public std::enable_shared_from_this<CloudFileDeletionScheduler> {
+  struct PrivateTag {};
+
+ public:
+  static std::shared_ptr<CloudFileDeletionScheduler> Create(
+      const std::shared_ptr<CloudScheduler>& scheduler);
+
+  explicit CloudFileDeletionScheduler(
+      PrivateTag, const std::shared_ptr<CloudScheduler>& scheduler)
+      : scheduler_(scheduler) {}
+
+  ~CloudFileDeletionScheduler();
+
+  void UnscheduleFileDeletion(const std::string& filename);
+  using FileDeletionRunnable = std::function<void()>;
+  // Schedule the file deletion runnable(which actually delets the file from
+  // cloud) to be executed in the future (specified by `file_deletion_delay_`).
+  rocksdb::Status ScheduleFileDeletion(const std::string& filename,
+                                       FileDeletionRunnable runnable);
+
+  void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
+    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+    file_deletion_delay_ = delay;
+  }
+
+  // Return all the files that are scheduled to be deleted(but not deleted yet)
+  std::vector<std::string> TEST_FilesToDelete() const {
+    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
+    std::vector<std::string> files;
+    for (auto& [file, handle] : files_to_delete_) {
+      files.push_back(file);
+    }
+    return files;
+  }
+
+ private:
+  // execute the `FileDeletionRunnable`
+  void DoDeleteFile(const std::string& fname, FileDeletionRunnable cb);
+  std::shared_ptr<CloudScheduler> scheduler_;
+
+  mutable std::mutex files_to_delete_mutex_;
+  std::unordered_map<std::string, int> files_to_delete_;
+  std::chrono::seconds file_deletion_delay_ = std::chrono::hours(1);
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -12,11 +12,13 @@
 #include <cinttypes>
 
 #include "cloud/cloud_env_impl.h"
+#include "cloud/cloud_scheduler.h"
 #include "cloud/cloud_storage_provider_impl.h"
 #include "cloud/db_cloud_impl.h"
 #include "cloud/filename.h"
 #include "cloud/manifest_reader.h"
 #include "db/db_impl/db_impl.h"
+#include "db/db_test_util.h"
 #include "file/filename.h"
 #include "logging/logging.h"
 #include "rocksdb/cloud/cloud_env_options.h"
@@ -26,6 +28,7 @@
 #include "rocksdb/table.h"
 #include "test_util/sync_point.h"
 #include "test_util/testharness.h"
+#include "test_util/testutil.h"
 #include "util/random.h"
 #include "util/string_util.h"
 #ifndef OS_WIN
@@ -371,6 +374,38 @@ class CloudTest : public testing::Test {
     std::vector<Env::FileAttributes> local_files;
     assert(base_env_->GetChildrenFileAttributes(dbname_, &local_files).ok());
     return local_files;
+  }
+
+  // Generate a few obsolete sst files on an empty db
+  static void GenerateObsoleteFilesOnEmptyDB(
+      DBImpl* db, CloudEnv* aenv, std::vector<std::string>* obsolete_files) {
+    ASSERT_OK(db->Put({}, "k1", "v1"));
+    ASSERT_OK(db->Flush({}));
+
+    ASSERT_OK(db->Put({}, "k1", "v2"));
+    ASSERT_OK(db->Flush({}));
+
+    std::vector<LiveFileMetaData> sst_files;
+    db->GetLiveFilesMetaData(&sst_files);
+    ASSERT_EQ(sst_files.size(), 2);
+    for (auto& f: sst_files) {
+      obsolete_files->push_back(
+        aenv->RemapFilename(f.relative_filename));
+    }
+
+    // trigger compaction, so previous 2 sst files will be obsolete
+    ASSERT_OK(
+        db->TEST_CompactRange(0, nullptr, nullptr, nullptr, true));
+    sst_files.clear();
+    db->GetLiveFilesMetaData(&sst_files);
+    ASSERT_EQ(sst_files.size(), 1);
+  }
+
+  // check that fname existsin in src bucket/object path
+  rocksdb::Status ExistsCloudObject(const std::string& filename) const {
+    return aenv_->GetStorageProvider()->ExistsCloudObject(
+        aenv_->GetSrcBucketName(),
+        aenv_->GetSrcObjectPath() + pathsep + filename);
   }
 
   std::string test_id_;
@@ -2952,6 +2987,160 @@ TEST_F(CloudTest, SanitizeDirectoryTest) {
       base_env_->DeleteFile(MakeCloudManifestFile(dbname_, "" /* cooke */)));
 
   ASSERT_OK(GetCloudEnvImpl()->SanitizeDirectory(options_, dbname_, false));
+  SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_F(CloudTest, CloudFileDeletionNotTriggeredIfDestBucketNotSet) {
+  std::vector<std::string> files_to_delete;
+
+  // generate invisible MANIFEST file to delete
+  OpenDB();
+  std::string manifest_file = ManifestFileWithEpoch(
+      dbname_, GetCloudEnvImpl()->GetCloudManifest()->GetCurrentEpoch());
+  files_to_delete.push_back(basename(manifest_file));
+  CloseDB();
+
+  // generate obsolete sst files to delete
+  options_.disable_delete_obsolete_files_on_open = true;
+  cloud_env_options_.delete_cloud_invisible_files_on_open = false;
+  OpenDB();
+  GenerateObsoleteFilesOnEmptyDB(GetDBImpl(), aenv_.get(), &files_to_delete);
+  CloseDB();
+
+  options_.disable_delete_obsolete_files_on_open = false;
+  cloud_env_options_.dest_bucket.SetBucketName("");
+  cloud_env_options_.dest_bucket.SetObjectPath("");
+  cloud_env_options_.delete_cloud_invisible_files_on_open = true;
+  OpenDB();
+  WaitUntilNoScheduledJobs();
+  for (auto& fname: files_to_delete) {
+    EXPECT_OK(ExistsCloudObject(fname));
+  }
+  CloseDB();
+
+  cloud_env_options_.dest_bucket = cloud_env_options_.src_bucket;
+  OpenDB();
+  WaitUntilNoScheduledJobs();
+  for (auto& fname: files_to_delete) {
+    EXPECT_NOK(ExistsCloudObject(fname));
+  }
+  CloseDB();
+}
+
+TEST_F(CloudTest, ScheduleFileDeletionTest) {
+  auto scheduler = CloudScheduler::Get();
+  auto deletion_scheduler = CloudFileDeletionScheduler::Create(scheduler);
+  deletion_scheduler->TEST_SetFileDeletionDelay(std::chrono::seconds(0));
+
+  std::atomic_int counter{0};
+  int num_file_deletions = 10;
+  for (int i = 0; i < num_file_deletions; i++) {
+    ASSERT_OK(deletion_scheduler->ScheduleFileDeletion(
+        std::to_string(i) + ".sst", [&counter]() { counter++; }));
+  }
+
+  // wait until no scheduled jobs
+  while (scheduler->TEST_NumScheduledJobs() > 0) {
+    usleep(100);
+  }
+  EXPECT_EQ(counter, num_file_deletions);
+  EXPECT_EQ(deletion_scheduler->TEST_FilesToDelete().size(), 0);
+}
+
+TEST_F(CloudTest, SameFileDeletedMultipleTimesTest) {
+  auto scheduler = CloudScheduler::Get();
+  auto deletion_scheduler = CloudFileDeletionScheduler::Create(scheduler);
+  deletion_scheduler->TEST_SetFileDeletionDelay(std::chrono::hours(1));
+  ASSERT_OK(deletion_scheduler->ScheduleFileDeletion("filename", []() {}));
+  ASSERT_OK(deletion_scheduler->ScheduleFileDeletion("filename", []() {}));
+  EXPECT_EQ(deletion_scheduler->TEST_FilesToDelete().size(), 1);
+}
+
+TEST_F(CloudTest, UnscheduleFileDeletionTest) {
+  auto scheduler = CloudScheduler::Get();
+  auto deletion_scheduler = CloudFileDeletionScheduler::Create(scheduler);
+  deletion_scheduler->TEST_SetFileDeletionDelay(std::chrono::hours(1));
+
+  std::atomic_int counter{0};
+  int num_file_deletions = 10;
+  std::vector<std::string> files_to_delete;
+  for (int i = 0; i < num_file_deletions; i++) {
+    std::string filename = std::to_string(i) + ".sst";
+    files_to_delete.push_back(filename);
+    ASSERT_OK(
+        deletion_scheduler->ScheduleFileDeletion(filename, [&counter]() { counter++; }));
+  }
+  auto actual_files_to_delete = deletion_scheduler->TEST_FilesToDelete();
+  std::sort(actual_files_to_delete.begin(), actual_files_to_delete.end());
+  EXPECT_EQ(actual_files_to_delete, files_to_delete);
+
+  int num_scheduled_jobs = num_file_deletions;
+  for (auto& fname: files_to_delete) {
+    deletion_scheduler->UnscheduleFileDeletion(fname);
+    num_scheduled_jobs -= 1;
+    EXPECT_EQ(scheduler->TEST_NumScheduledJobs(), num_scheduled_jobs);
+  }
+}
+
+TEST_F(CloudTest, UnscheduleUnknownFileTest) {
+  auto scheduler = CloudScheduler::Get();
+  auto deletion_scheduler = CloudFileDeletionScheduler::Create(scheduler);
+  deletion_scheduler->TEST_SetFileDeletionDelay(std::chrono::hours(1));
+  deletion_scheduler->UnscheduleFileDeletion("unknown file");
+}
+
+// Verifies that as long as `CloudFileDeletionScheduler` is destructed, no file
+// deletion job will actually be scheduled
+// This is also a repro of SYS-3456, which is a race between CloudEnvImpl
+// destruction and cloud file deletion
+TEST_F(CloudTest,
+       FileDeletionNotScheduledOnceCloudFileDeletionSchedulerDestructed) {
+  // Generate some invisible files to delete
+  // Disable file deletion to make sure these files are not deleted
+  // automatically
+  options_.disable_delete_obsolete_files_on_open = true;
+  cloud_env_options_.delete_cloud_invisible_files_on_open = false;
+  OpenDB();
+  std::vector<std::string> obsolete_files;
+  GenerateObsoleteFilesOnEmptyDB(GetDBImpl(), aenv_.get(), &obsolete_files);
+  CloseDB();
+
+  // Order of execution:
+  // - scheduled file deletion job starts running (but file not deleted yet)
+  // - destruct CloudFileDeletionScheduler
+  // - file deletion job deletes the file
+  SyncPoint::GetInstance()->LoadDependency({
+    {
+      // `BeforeCancelJobs` happens-after `BeforeFileDeletion`
+      "CloudFileDeletionScheduler::ScheduleFileDeletion:BeforeFileDeletion",
+      "CloudFileDeletionScheduler::~CloudFileDeletionScheduler:BeforeCancelJobs",
+    },
+    {
+      "CloudFileDeletionScheduler::~CloudFileDeletionScheduler:BeforeCancelJobs",
+      "CloudFileDeletionScheduler::ScheduleFileDeletion:AfterFileDeletion"
+    }
+  });
+
+  std::atomic<size_t> num_jobs_finished{0};
+  SyncPoint::GetInstance()->SetCallBack(
+      "CloudFileDeletionScheduler::ScheduleFileDeletion:AfterFileDeletion",
+      [&](void* arg) {
+        ASSERT_NE(nullptr, arg);
+        auto file_deleted = *reinterpret_cast<bool *>(arg);
+        EXPECT_FALSE(file_deleted);
+        num_jobs_finished++;
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  // file not deleted immediately but just scheduled
+  ASSERT_OK(aenv_->DeleteFile(obsolete_files[0]));
+  EXPECT_EQ(GetCloudEnvImpl()->TEST_NumScheduledJobs(), 1);
+  // destruct `CloudEnv`, which will cause `CloudFileDeletionScheduler` to be destructed
+  aenv_.reset();
+  // wait until file deletion job is done
+  while (num_jobs_finished.load() != 1) {
+    usleep(100);
+  }
+  SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->DisableProcessing();
 }
 

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -12,6 +12,7 @@
 #include <cinttypes>
 
 #include "cloud/cloud_env_impl.h"
+#include "cloud/cloud_file_deletion_scheduler.h"
 #include "cloud/cloud_scheduler.h"
 #include "cloud/cloud_storage_provider_impl.h"
 #include "cloud/db_cloud_impl.h"

--- a/src.mk
+++ b/src.mk
@@ -25,6 +25,7 @@ LIB_SOURCES =                                                   \
   cloud/cloud_scheduler.cc                                      \
   cloud/cloud_storage_provider.cc                               \
   cloud/cloud_file_cache.cc                                     \
+  cloud/cloud_file_deletion_scheduler.cc                        \
   db/arena_wrapped_db_iter.cc                                   \
   db/blob/blob_fetcher.cc                                       \
   db/blob/blob_file_addition.cc                                 \


### PR DESCRIPTION
There is a race between `CloudEnv` destruction and cloud file deletion for current implementation:
* When CloudEnvImpl is destructed, it will acquire files_to_delete_mutex_ and  cancel existing jobs.
* While canceling existing jobs, it will wait (condition variable) if the job is still running.
* For the job that deletes files from cloud, it will try to acquire files_to_delete_mutex_ before actually deleting the files, therefore causing deadlock

We shouldn't acquire mutex in destructor. Also, it's possible that when the scheduled jobs are executed, `CloudEnv` might have already been destructed. Fixed above two issues by moving the file deletion scheduling into a separate class: `CloudFileDeletionScheduler` and only allow accessing it through a shared_ptr. In the scheduled jobs, it will try to lock shared ptr first before actually deleting the files. If it's already destructed, then the file deletion job should never be executed.

- [x] Added multiple tests to test `CloudFileDeletionScheduler`
- [x] Added a test to repro the race we found