### PR TITLE
[SYS-3469] cleanup local files if new_db

### DIFF
--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -161,7 +161,9 @@ class CloudEnvImpl : public CloudEnv {
   Status GetDbidList(const std::string& bucket, DbidList* dblist) override;
   Status DeleteDbid(const std::string& bucket,
                     const std::string& dbid) override;
-
+  // delete all local files except `excluded_files`
+  Status DeleteLocalFiles(const std::string& local_dbname,
+        const std::vector<std::string>& excluded_files = {});
   Status SanitizeDirectory(const DBOptions& options,
                            const std::string& clone_name, bool read_only);
   Status LoadCloudManifest(const std::string& local_dbname, bool read_only);

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -2941,7 +2941,7 @@ TEST_F(CloudTest, SanitizeDirectoryTest) {
 
   // inject io errors during cleaning up. The io errors should be ignored
   SyncPoint::GetInstance()->SetCallBack(
-    "CloudEnvImpl::SanitizeDirectory:AfterDeleteFile",
+    "CloudEnvImpl::DeleteLocalFiles:AfterDeleteFile",
     [](void* arg) {
         auto st = reinterpret_cast<Status*>(arg);
         *st = Status::IOError("Inject io error during cleaning up");
@@ -2954,6 +2954,17 @@ TEST_F(CloudTest, SanitizeDirectoryTest) {
 
   ASSERT_OK(GetCloudEnvImpl()->SanitizeDirectory(options_, dbname_, false));
   SyncPoint::GetInstance()->DisableProcessing();
+}
+
+// Verify that when db opens without uploading CM, it can still be reopened.
+TEST_F(CloudTest, ReopenDBWithoutUploadingCM) {
+  // if we don't roll cm, cm won't be uploaded to cloud
+  cloud_env_options_.roll_cloud_manifest_on_open = false;
+  OpenDB();
+  CloseDB();
+
+  OpenDB();
+  CloseDB();
 }
 
 }  //  namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
If db is opened without uploading cm, next time db will still be opened as new db. But there would be some local stale `CURRENT` file, so rocksdb refuses to create new MANIFEST file. Also, local WAL files will cause failures when opening db.

Fixed this issue by always cleaning up local files except cloud manifest if it's a new db.

- [x] Added test to verify the fix works