### PR TITLE
[SYS-3423] Fix memory leak in phyiscal replication

### DIFF
--- a/cloud/cloud_file_deletion_scheduler.h
+++ b/cloud/cloud_file_deletion_scheduler.h
@@ -39,6 +39,7 @@ class CloudFileDeletionScheduler
     std::vector<std::string> files;
     for (auto& [file, handle] : files_to_delete_) {
       files.push_back(file);
+      (void)handle;
     }
     return files;
   }


### PR DESCRIPTION
The bug was that we called InstallSuperVersion() before RemoveOldMemTables(),
which means our newly installed superversion still had a pointer to an old
memtable. This means that each column family held onto exactly 1 memtable more
than it needs to, which explains the increased memory usage on the follower.
This is especially pronounced when most column families latest memtables are
empty.

Also fixed a bug where we forgot to set CF as initialized, which is only ever
used for stats gathering, so it's not as serious.

Added a repro unit test that for both of the problems.