### PR TITLE
[SYS-3633] Make CloudManifest::AddEpoch idempotent

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1997,7 +1997,13 @@ size_t CloudEnvImpl::TEST_NumScheduledJobs() const {
 };
 
 Status CloudEnvImpl::ApplyCloudManifestDelta(const CloudManifestDelta& delta) {
-  cloud_manifest_->AddEpoch(delta.file_num, delta.epoch);
+  if (!cloud_manifest_->AddEpoch(delta.file_num, delta.epoch)) {
+    Log(InfoLogLevel::INFO_LEVEL, info_log_,
+        "[CloudEnvImpl::ApplyCloudManifestDelta] delta: %s has already been "
+        "applied to current cloud "
+        "manifest",
+        delta.ToString().c_str());
+  }
   return Status::OK();
 }
 
@@ -2028,7 +2034,14 @@ Status CloudEnvImpl::RollNewCookie(const std::string& local_dbname,
 
   // TODO(igor): Compact cloud manifest by looking at live files in the database
   // and removing epochs that don't contain any live files.
-  newCloudManifest->AddEpoch(delta.file_num, delta.epoch);
+  if (!newCloudManifest->AddEpoch(delta.file_num, delta.epoch)) {
+    Log(InfoLogLevel::INFO_LEVEL, info_log_,
+        "[CloudEnvImpl::RollNewCookie] delta: %s has already been applied to "
+        "current cloud "
+        "manifest",
+        delta.ToString().c_str());
+    return st;
+  }
 
   TEST_SYNC_POINT_CALLBACK(
       "CloudEnvImpl::RollNewCookie:AfterManifestCopy", &st);

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1998,11 +1998,7 @@ size_t CloudEnvImpl::TEST_NumScheduledJobs() const {
 
 Status CloudEnvImpl::ApplyCloudManifestDelta(const CloudManifestDelta& delta) {
   if (!cloud_manifest_->AddEpoch(delta.file_num, delta.epoch)) {
-    Log(InfoLogLevel::INFO_LEVEL, info_log_,
-        "[CloudEnvImpl::ApplyCloudManifestDelta] delta: %s has already been "
-        "applied to current cloud "
-        "manifest",
-        delta.ToString().c_str());
+    return Status::InvalidArgument("Delta already applied in cloud manifest");
   }
   return Status::OK();
 }
@@ -2013,6 +2009,10 @@ Status CloudEnvImpl::RollNewCookie(const std::string& local_dbname,
   auto newCloudManifest = cloud_manifest_->clone();
   Status st;
   std::string old_epoch = newCloudManifest->GetCurrentEpoch();
+  if (!newCloudManifest->AddEpoch(delta.file_num, delta.epoch)) {
+    return Status::InvalidArgument("Delta already applied in cloud manifest");
+  }
+
   const auto& fs = GetBaseEnv()->GetFileSystem();
   Log(InfoLogLevel::INFO_LEVEL, info_log_,
       "Rolling new CLOUDMANIFEST from file number %lu, renaming MANIFEST-%s to "
@@ -2034,14 +2034,7 @@ Status CloudEnvImpl::RollNewCookie(const std::string& local_dbname,
 
   // TODO(igor): Compact cloud manifest by looking at live files in the database
   // and removing epochs that don't contain any live files.
-  if (!newCloudManifest->AddEpoch(delta.file_num, delta.epoch)) {
-    Log(InfoLogLevel::INFO_LEVEL, info_log_,
-        "[CloudEnvImpl::RollNewCookie] delta: %s has already been applied to "
-        "current cloud "
-        "manifest",
-        delta.ToString().c_str());
-    return st;
-  }
+
 
   TEST_SYNC_POINT_CALLBACK(
       "CloudEnvImpl::RollNewCookie:AfterManifestCopy", &st);

--- a/cloud/cloud_manifest.h
+++ b/cloud/cloud_manifest.h
@@ -47,8 +47,15 @@ class CloudManifest {
 
   // Add an epoch that starts with startFileNumber and is identified by epochId.
   // GetEpoch(startFileNumber) == epochId
-  // Invalid call if finalized_ is false
-  void AddEpoch(uint64_t startFileNumber, std::string epochId);
+  //
+  // AddEpoch is idempotent, which means:
+  // - we can't add an epoch with smaller `startFileNumber`
+  // - we can't add an epoch which equals current epoch and starts at
+  // same file number
+  //
+  // Idempotency is based on the assumption that epochs added don't diverge from
+  // existing epochs(same sequence of <filenumm, epoch> is re-added)
+  bool AddEpoch(uint64_t startFileNumber, std::string epochId);
 
   std::string GetEpoch(uint64_t fileNumber);
 

--- a/cloud/cloud_manifest_test.cc
+++ b/cloud/cloud_manifest_test.cc
@@ -32,9 +32,9 @@ TEST_F(CloudManifestTest, BasicTest) {
   {
     std::unique_ptr<CloudManifest> manifest;
     ASSERT_OK(CloudManifest::CreateForEmptyDatabase("firstEpoch", &manifest));
-    manifest->AddEpoch(10, "secondEpoch");
-    manifest->AddEpoch(10, "thirdEpoch");
-    manifest->AddEpoch(40, "fourthEpoch");
+    EXPECT_TRUE(manifest->AddEpoch(10, "secondEpoch"));
+    EXPECT_TRUE(manifest->AddEpoch(10, "thirdEpoch"));
+    EXPECT_TRUE(manifest->AddEpoch(40, "fourthEpoch"));
 
     for (int iter = 0; iter < 2; ++iter) {
       ASSERT_EQ(manifest->GetEpoch(0), "firstEpoch");
@@ -63,6 +63,18 @@ TEST_F(CloudManifestTest, BasicTest) {
       }
     }
   }
+}
+
+TEST_F(CloudManifestTest, IdempotencyTest) {
+  std::unique_ptr<CloudManifest> manifest;
+  ASSERT_OK(CloudManifest::CreateForEmptyDatabase("epoch1", &manifest));
+  EXPECT_TRUE(manifest->AddEpoch(10, "epoch2"));
+  // file number goes back in time
+  EXPECT_FALSE(manifest->AddEpoch(9, "epoch3"));
+  // same file number, same epoch
+  EXPECT_FALSE(manifest->AddEpoch(10, "epoch2"));
+  // same file number, different epoch
+  EXPECT_TRUE(manifest->AddEpoch(10, "epoch3"));
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -3171,9 +3171,9 @@ TEST_F(CloudTest, UniqueCurrentEpochAcrossDBRestart) {
 
 TEST_F(CloudTest, ReplayCloudManifestDeltaTest) {
   OpenDB();
-  constexpr int numKeys = 3;
+  constexpr int kNumKeys = 3;
   std::vector<CloudManifestDelta> deltas;
-  for (int i = 0; i < numKeys; i++) {
+  for (int i = 0; i < kNumKeys; i++) {
     ASSERT_OK(db_->Put({}, "k" + std::to_string(i), "v" + std::to_string(i)));
     ASSERT_OK(db_->Flush({}));
 
@@ -3194,13 +3194,13 @@ TEST_F(CloudTest, ReplayCloudManifestDeltaTest) {
 
   // replay the deltas one more time
   for (const auto& delta : deltas) {
-    EXPECT_OK(ApplyCMDeltaToCloudDB(delta));
+    EXPECT_TRUE(ApplyCMDeltaToCloudDB(delta).IsInvalidArgument());
     // current epoch not changed
     EXPECT_EQ(GetCloudEnvImpl()->GetCloudManifest()->GetCurrentEpoch(),
               currentEpoch);
   }
 
-  for (int i = 0; i < numKeys; i++) {
+  for (int i = 0; i < kNumKeys; i++) {
     std::string v;
     ASSERT_OK(db_->Get({}, "k" + std::to_string(i), &v));
     EXPECT_EQ(v, "v" + std::to_string(i));

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -349,14 +349,25 @@ class CloudTest : public testing::Test {
     return static_cast<DBImpl*>(db_->GetBaseDB());
   }
 
-  void SwitchToNewCookie(std::string new_cookie) {
+  Status SwitchToNewCookie(std::string new_cookie) {
     CloudManifestDelta delta{
       db_->GetNextFileNumber(),
       new_cookie
     };
-    ASSERT_OK(aenv_->RollNewCookie(dbname_, new_cookie, delta));
-    ASSERT_OK(aenv_->ApplyCloudManifestDelta(delta));
+    return ApplyCMDeltaToCloudDB(delta);
+  }
+
+  Status ApplyCMDeltaToCloudDB(const CloudManifestDelta& delta) {
+    auto st = aenv_->RollNewCookie(dbname_, delta.epoch, delta);
+    if (!st.ok()) {
+      return st;
+    }
+    st = aenv_->ApplyCloudManifestDelta(delta);
+    if (!st.ok()) {
+      return st;
+    }
     db_->NewManifestOnNextUpdate();
+    return st;
   }
 
  protected:
@@ -2467,7 +2478,7 @@ TEST_F(CloudTest, DisableInvisibleFileDeletionOnOpenTest) {
       MakeCloudManifestFile(dbname_, cloud_env_options_.cookie_on_open);
   auto cookie1_sst_filepath = dbname_ + pathsep + cookie1_sst_files[0];
 
-  SwitchToNewCookie(cookie2);
+  ASSERT_OK(SwitchToNewCookie(cookie2));
 
   // generate sst file with cookie2
   ASSERT_OK(db_->Put({}, "k2", "v2"));
@@ -2535,7 +2546,7 @@ TEST_F(CloudTest, DisableObsoleteFileDeletionOnOpenTest) {
   WriteOptions wo;
   wo.disableWAL = true;
   OpenDB();
-  SwitchToNewCookie("");
+  ASSERT_OK(SwitchToNewCookie(""));
   db_->DisableFileDeletions();
 
   std::vector<LiveFileMetaData> files;
@@ -3144,6 +3155,57 @@ TEST_F(CloudTest,
   }
   SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_F(CloudTest, UniqueCurrentEpochAcrossDBRestart) {
+  constexpr int kNumRestarts = 3;
+  std::unordered_set<std::string> epochs;
+  for (int i = 0; i < kNumRestarts; i++) {
+    OpenDB();
+    auto [it, inserted] = epochs.emplace(
+        GetCloudEnvImpl()->GetCloudManifest()->GetCurrentEpoch());
+    EXPECT_TRUE(inserted);
+    CloseDB();
+  }
+}
+
+TEST_F(CloudTest, ReplayCloudManifestDeltaTest) {
+  OpenDB();
+  constexpr int numKeys = 3;
+  std::vector<CloudManifestDelta> deltas;
+  for (int i = 0; i < numKeys; i++) {
+    ASSERT_OK(db_->Put({}, "k" + std::to_string(i), "v" + std::to_string(i)));
+    ASSERT_OK(db_->Flush({}));
+
+    auto cookie1 =  std::to_string(i) + "0";
+    auto filenum1 = db_->GetNextFileNumber();
+    deltas.push_back({filenum1, cookie1});
+    ASSERT_OK(SwitchToNewCookie(cookie1));
+
+    // apply again with same file number but different cookie
+    auto cookie2 = std::to_string(i) + "1";
+    auto filenum2 = db_->GetNextFileNumber();
+    EXPECT_EQ(filenum1, filenum2);
+    deltas.push_back({filenum2, cookie2});
+    ASSERT_OK(SwitchToNewCookie(cookie2));
+  }
+
+  auto currentEpoch = GetCloudEnvImpl()->GetCloudManifest()->GetCurrentEpoch();
+
+  // replay the deltas one more time
+  for (const auto& delta : deltas) {
+    EXPECT_OK(ApplyCMDeltaToCloudDB(delta));
+    // current epoch not changed
+    EXPECT_EQ(GetCloudEnvImpl()->GetCloudManifest()->GetCurrentEpoch(),
+              currentEpoch);
+  }
+
+  for (int i = 0; i < numKeys; i++) {
+    std::string v;
+    ASSERT_OK(db_->Get({}, "k" + std::to_string(i), &v));
+    EXPECT_EQ(v, "v" + std::to_string(i));
+  }
+  CloseDB();
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -481,10 +481,6 @@ typedef std::map<std::string, std::string> DbidList;
 struct CloudManifestDelta {
   uint64_t file_num; // next file number for new epoch
   std::string epoch; // epoch for the new manifest file
-
-  std::string ToString() const {
-    return std::to_string(file_num) + "," + epoch;
-  }
 };
 
 
@@ -621,8 +617,8 @@ class CloudEnv : public Env {
   // Apply cloud manifest delta to in-memory cloud manifest. Does not change the
   // on-disk state.
   //
-  // This function is idempotent. If delta has already been applied, then
-  // nothing will be changed
+  // Return InvalidArgument status if the delta has been applied in current
+  // CloudManfiest
   virtual Status ApplyCloudManifestDelta(const CloudManifestDelta& delta) = 0;
 
   // This function does several things:
@@ -632,8 +628,8 @@ class CloudEnv : public Env {
   // * Uploads both CLOUDMANIFEST-cookie and MANIFEST-delta.epoch into cloud
   // storage (if dest bucket is given).
   //
-  // This function is idempotent. If delta has already been applied, then
-  // nothing will be changed
+  // Return InvalidArgument status if the delta has been applied in current
+  // CloudManfiest
   virtual Status RollNewCookie(const std::string& local_dbname,
                                const std::string& cookie,
                                const CloudManifestDelta& delta) const = 0;

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -618,7 +618,7 @@ class CloudEnv : public Env {
   // on-disk state.
   //
   // Return InvalidArgument status if the delta has been applied in current
-  // CloudManfiest
+  // CloudManifest
   virtual Status ApplyCloudManifestDelta(const CloudManifestDelta& delta) = 0;
 
   // This function does several things:
@@ -629,7 +629,7 @@ class CloudEnv : public Env {
   // storage (if dest bucket is given).
   //
   // Return InvalidArgument status if the delta has been applied in current
-  // CloudManfiest
+  // CloudManifest
   virtual Status RollNewCookie(const std::string& local_dbname,
                                const std::string& cookie,
                                const CloudManifestDelta& delta) const = 0;

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -481,6 +481,10 @@ typedef std::map<std::string, std::string> DbidList;
 struct CloudManifestDelta {
   uint64_t file_num; // next file number for new epoch
   std::string epoch; // epoch for the new manifest file
+
+  std::string ToString() const {
+    return std::to_string(file_num) + "," + epoch;
+  }
 };
 
 
@@ -616,6 +620,9 @@ class CloudEnv : public Env {
 
   // Apply cloud manifest delta to in-memory cloud manifest. Does not change the
   // on-disk state.
+  //
+  // This function is idempotent. If delta has already been applied, then
+  // nothing will be changed
   virtual Status ApplyCloudManifestDelta(const CloudManifestDelta& delta) = 0;
 
   // This function does several things:
@@ -624,6 +631,9 @@ class CloudEnv : public Env {
   // * Copies MANIFEST-epoch into MANIFEST-delta.epoch
   // * Uploads both CLOUDMANIFEST-cookie and MANIFEST-delta.epoch into cloud
   // storage (if dest bucket is given).
+  //
+  // This function is idempotent. If delta has already been applied, then
+  // nothing will be changed
   virtual Status RollNewCookie(const std::string& local_dbname,
                                const std::string& cookie,
                                const CloudManifestDelta& delta) const = 0;


### PR DESCRIPTION
In leader follower world, it's possible to re-apply the old (filenum, epochs). Made `AddEpoch` function to be idempotent to support this case

### TEST
- [x] Added tests to verify the operation is idempotent