### PR TITLE
Make ApplyCloudManifestDelta idempotent for old epoch

### DIFF
--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1954,6 +1954,9 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
     // Apply the delta to our in-memory state, too.
     bool updateApplied = true;
     st = ApplyCloudManifestDelta(cloudManifestDelta, &updateApplied);
+    // We know for sure that <maxFileNumber, newEpoch> hasn't been applied
+    // in current CLOUDMANFIEST yet since maxFileNumber >= filenumber in
+    // CLOUDMANIFEST and epoch is generated randomly
     assert(updateApplied);
   }
 

--- a/cloud/cloud_env_impl.cc
+++ b/cloud/cloud_env_impl.cc
@@ -1952,7 +1952,9 @@ Status CloudEnvImpl::RollNewEpoch(const std::string& local_dbname) {
   st = RollNewCookie(local_dbname, newCookie, cloudManifestDelta);
   if (st.ok()) {
     // Apply the delta to our in-memory state, too.
-    st = ApplyCloudManifestDelta(cloudManifestDelta);
+    bool updateApplied = true;
+    st = ApplyCloudManifestDelta(cloudManifestDelta, &updateApplied);
+    assert(updateApplied);
   }
 
   return st;
@@ -1996,10 +1998,9 @@ size_t CloudEnvImpl::TEST_NumScheduledJobs() const {
   return scheduler_->TEST_NumScheduledJobs();
 };
 
-Status CloudEnvImpl::ApplyCloudManifestDelta(const CloudManifestDelta& delta) {
-  if (!cloud_manifest_->AddEpoch(delta.file_num, delta.epoch)) {
-    return Status::InvalidArgument("Delta already applied in cloud manifest");
-  }
+Status CloudEnvImpl::ApplyCloudManifestDelta(const CloudManifestDelta& delta,
+                                             bool* delta_applied) {
+  *delta_applied = cloud_manifest_->AddEpoch(delta.file_num, delta.epoch);
   return Status::OK();
 }
 

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -279,7 +279,8 @@ class CloudEnvImpl : public CloudEnv {
 
   // Apply cloud manifest delta to in-memory cloud manifest. Does not change the
   // on-disk state.
-  Status ApplyCloudManifestDelta(const CloudManifestDelta& delta) override;
+  Status ApplyCloudManifestDelta(const CloudManifestDelta& delta,
+                                 bool* delta_applied) override;
 
   // See comments in the parent class
   Status RollNewCookie(const std::string& local_dbname,

--- a/cloud/cloud_manifest.cc
+++ b/cloud/cloud_manifest.cc
@@ -194,7 +194,10 @@ bool CloudManifest::AddEpoch(uint64_t startFileNumber, std::string epochId) {
     }
     nxtEpoch = &(rit->second);
   }
-  pastEpochs_.emplace_back(startFileNumber, std::move(currentEpoch_));
+
+  if (pastEpochs_.empty() || pastEpochs_.back().first < startFileNumber) {
+    pastEpochs_.emplace_back(startFileNumber, std::move(currentEpoch_));
+  }
   currentEpoch_ = std::move(epochId);
   return true;
 }
@@ -216,6 +219,12 @@ std::string CloudManifest::GetEpoch(uint64_t fileNumber) {
 std::string CloudManifest::GetCurrentEpoch() {
   ReadLock lck(&mutex_);
   return currentEpoch_;
+}
+
+std::vector<std::pair<uint64_t, std::string>>
+CloudManifest::TEST_GetPastEpochs() const {
+  ReadLock lck(&mutex_);
+  return pastEpochs_;
 }
 
 std::string CloudManifest::ToString(bool include_past_epochs) {

--- a/cloud/cloud_manifest.h
+++ b/cloud/cloud_manifest.h
@@ -43,7 +43,7 @@ class CloudManifest {
 
   std::unique_ptr<CloudManifest> clone() const;
 
-  Status WriteToLog(std::unique_ptr<WritableFileWriter> log);
+  Status WriteToLog(std::unique_ptr<WritableFileWriter> log) const;
 
   // Add an epoch that starts with startFileNumber and is identified by epochId.
   // GetEpoch(startFileNumber) == epochId
@@ -52,10 +52,6 @@ class CloudManifest {
   // - we can't add an epoch with smaller `startFileNumber`
   // - we can't add an epoch which equals current epoch and starts at
   // same file number
-  //
-  // Besides that, we also maintain the invariant that there won't be more than
-  // one epoch with same file number (even if we call `AddEpoch` with same file
-  // number but different epochs multiple times)
   //
   // Idempotency is based on the assumption that epochs added don't diverge from
   // existing epochs(same sequence of <filenumm, epoch> is re-added)

--- a/cloud/cloud_manifest.h
+++ b/cloud/cloud_manifest.h
@@ -53,6 +53,10 @@ class CloudManifest {
   // - we can't add an epoch which equals current epoch and starts at
   // same file number
   //
+  // Besides that, we also maintain the invariant that there won't be more than
+  // one epoch with same file number (even if we call `AddEpoch` with same file
+  // number but different epochs multiple times)
+  //
   // Idempotency is based on the assumption that epochs added don't diverge from
   // existing epochs(same sequence of <filenumm, epoch> is re-added)
   bool AddEpoch(uint64_t startFileNumber, std::string epochId);
@@ -61,6 +65,7 @@ class CloudManifest {
 
   std::string GetCurrentEpoch();
   std::string ToString(bool include_past_epochs=false);
+  std::vector<std::pair<uint64_t, std::string>> TEST_GetPastEpochs() const;
 
  private:
   CloudManifest(std::vector<std::pair<uint64_t, std::string>> pastEpochs,

--- a/cloud/cloud_manifest_test.cc
+++ b/cloud/cloud_manifest_test.cc
@@ -18,6 +18,33 @@ class CloudManifestTest : public testing::Test {
   }
 
  protected:
+  Status DumpToRandomFile(const CloudManifest* manifest, std::string *filepath) {
+    Random rnd(301);
+    std::string filename = "CLOUDMANIFEST" + rnd.RandomString(7);
+    *filepath = tmp_dir_ + "/" + filename;
+    std::unique_ptr<WritableFileWriter> writer;
+    Status st = WritableFileWriter::Create(env_->GetFileSystem(), *filepath,
+                                         FileOptions(), &writer, nullptr);
+    if (!st.ok()) {
+      return st;
+    }
+
+    st = manifest->WriteToLog(std::move(writer));
+    return st;
+  }
+
+  Status LoadFromFile(const std::string& filepath,
+                      std::unique_ptr<CloudManifest>* manifest) {
+    std::unique_ptr<SequentialFileReader> reader;
+    Status st = SequentialFileReader::Create(env_->GetFileSystem(), filepath,
+                                           FileOptions(), &reader, nullptr);
+    if (!st.ok()) {
+      return st;
+    }
+    st = CloudManifest::LoadFromLog(std::move(reader), manifest);
+    return st;
+  }
+
   std::string tmp_dir_;
   Env* env_;
 };
@@ -45,22 +72,10 @@ TEST_F(CloudManifestTest, BasicTest) {
       ASSERT_EQ(manifest->GetEpoch(40), "fourthEpoch");
       ASSERT_EQ(manifest->GetEpoch(41), "fourthEpoch");
 
-      // serialize and deserialize
-      auto tmpfile = tmp_dir_ + "/cloudmanifest";
-      {
-        std::unique_ptr<WritableFileWriter> writer;
-        ASSERT_OK(WritableFileWriter::Create(env_->GetFileSystem(), tmpfile,
-                                             FileOptions(), &writer, nullptr));
-        ASSERT_OK(manifest->WriteToLog(std::move(writer)));
-      }
-
+      std::string filepath;
+      ASSERT_OK(DumpToRandomFile(manifest.get(), &filepath));
       manifest.reset();
-      {
-        std::unique_ptr<SequentialFileReader> reader;
-        ASSERT_OK(SequentialFileReader::Create(
-            env_->GetFileSystem(), tmpfile, FileOptions(), &reader, nullptr));
-        ASSERT_OK(CloudManifest::LoadFromLog(std::move(reader), &manifest));
-      }
+      ASSERT_OK(LoadFromFile(filepath, &manifest));
     }
   }
 }
@@ -78,17 +93,28 @@ TEST_F(CloudManifestTest, IdempotencyTest) {
 
   // same file number, different epoch
   EXPECT_TRUE(manifest->AddEpoch(10, "epoch3"));
+  EXPECT_EQ(manifest->GetCurrentEpoch(), "epoch3");
 
+  // idempotency for old cm delta
+  EXPECT_FALSE(manifest->AddEpoch(10, "epoch2"));
   EXPECT_EQ(manifest->GetCurrentEpoch(), "epoch3");
 
   EXPECT_TRUE(manifest->AddEpoch(11, "epoch4"));
 
   EXPECT_EQ(manifest->GetCurrentEpoch(), "epoch4");
 
-  // NOTE: for file number: 10, there is only one epoch
   std::vector<std::pair<uint64_t, std::string>> pastEpochs{{10, "epoch1"},
+                                                           {10, "epoch2"},
                                                            {11, "epoch3"}};
   EXPECT_EQ(manifest->TEST_GetPastEpochs(), pastEpochs);
+
+  EXPECT_EQ(manifest->GetEpoch(9), "epoch1");
+  EXPECT_EQ(manifest->GetEpoch(10), "epoch3");
+
+  std::string filepath;
+  ASSERT_OK(DumpToRandomFile(manifest.get(), &filepath));
+  manifest.reset();
+  ASSERT_OK(LoadFromFile(filepath, &manifest));
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/cloud/cloud_manifest_test.cc
+++ b/cloud/cloud_manifest_test.cc
@@ -73,8 +73,22 @@ TEST_F(CloudManifestTest, IdempotencyTest) {
   EXPECT_FALSE(manifest->AddEpoch(9, "epoch3"));
   // same file number, same epoch
   EXPECT_FALSE(manifest->AddEpoch(10, "epoch2"));
+
+  EXPECT_EQ(manifest->GetCurrentEpoch(), "epoch2");
+
   // same file number, different epoch
   EXPECT_TRUE(manifest->AddEpoch(10, "epoch3"));
+
+  EXPECT_EQ(manifest->GetCurrentEpoch(), "epoch3");
+
+  EXPECT_TRUE(manifest->AddEpoch(11, "epoch4"));
+
+  EXPECT_EQ(manifest->GetCurrentEpoch(), "epoch4");
+
+  // NOTE: for file number: 10, there is only one epoch
+  std::vector<std::pair<uint64_t, std::string>> pastEpochs{{10, "epoch1"},
+                                                           {11, "epoch3"}};
+  EXPECT_EQ(manifest->TEST_GetPastEpochs(), pastEpochs);
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -47,6 +47,7 @@ class CloudTest : public testing::Test {
 
     base_env_ = Env::Default();
     dbname_ = test::TmpDir() + "/db_cloud-" + test_id_;
+    fprintf(stderr, "dbname: %s\n", dbname_.c_str());
     clone_dir_ = test::TmpDir() + "/ctest-" + test_id_;
     cloud_env_options_.TEST_Initialize("dbcloudtest.", dbname_);
     cloud_env_options_.resync_manifest_on_open = true;

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -47,7 +47,6 @@ class CloudTest : public testing::Test {
 
     base_env_ = Env::Default();
     dbname_ = test::TmpDir() + "/db_cloud-" + test_id_;
-    fprintf(stderr, "dbname: %s\n", dbname_.c_str());
     clone_dir_ = test::TmpDir() + "/ctest-" + test_id_;
     cloud_env_options_.TEST_Initialize("dbcloudtest.", dbname_);
     cloud_env_options_.resync_manifest_on_open = true;

--- a/include/rocksdb/cloud/cloud_env_options.h
+++ b/include/rocksdb/cloud/cloud_env_options.h
@@ -617,9 +617,10 @@ class CloudEnv : public Env {
   // Apply cloud manifest delta to in-memory cloud manifest. Does not change the
   // on-disk state.
   //
-  // Return InvalidArgument status if the delta has been applied in current
-  // CloudManifest
-  virtual Status ApplyCloudManifestDelta(const CloudManifestDelta& delta) = 0;
+  // If delta has already been applied in cloud manifest, delta_applied would be
+  // `false`
+  virtual Status ApplyCloudManifestDelta(const CloudManifestDelta& delta,
+                                         bool* delta_applied) = 0;
 
   // This function does several things:
   // * Writes CLOUDMANIFEST-cookie file based on existing in-memory


### PR DESCRIPTION
Addressed Igor's comments: https://github.com/rockset/rocksdb-cloud/pull/222#discussion_r1022082457

We should return `Status::OK` and return additional information through the `bool* update_applied` argument for `ApplyCloudManifestDelta`.

Also, now that it's possible to have one filenum showing more than once in `CLOUDMANFIEST` with different epochs,  we should only check `filenum` is sorted in ascending order when loading CM from file.

