### PR TITLE
[SRE-2477] Make RocksDB-Cloud work with newer version of AWS SDK

### DIFF
--- a/cloud/aws/aws_s3.cc
+++ b/cloud/aws/aws_s3.cc
@@ -118,7 +118,10 @@ class AwsS3ClientWrapper {
     if (cloud_options.s3_client_factory) {
       client_ = cloud_options.s3_client_factory(creds, config);
     } else if (creds) {
-      client_ = std::make_shared<Aws::S3::S3Client>(creds, config);
+      client_ = std::make_shared<Aws::S3::S3Client>(
+          creds, config,
+          Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+          true /* useVirtualAddressing */);
     } else {
       client_ = std::make_shared<Aws::S3::S3Client>(config);
     }


### PR DESCRIPTION
Summary:
https://github.com/aws/aws-sdk-cpp/commit/3878f0112eb73b9a174b5b7ee21bbea9a693ef4a changed the public API by removing default params from S3Client constructor:
```
         S3Client(const Aws::Auth::AWSCredentials& credentials,
-                 const Aws::Client::ClientConfiguration& clientConfiguration = Aws::Client::ClientConfiguration(),
-                 Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy signPayloads = Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-                 bool useVirtualAddressing = true,
+                 const Aws::Client::ClientConfiguration& clientConfiguration,
+                 Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy signPayloads,
+                 bool useVirtualAddressing,
                  Aws::S3::US_EAST_1_REGIONAL_ENDPOINT_OPTION USEast1RegionalEndPointOption = Aws::S3::US_EAST_1_REGIONAL_ENDPOINT_OPTION::NOT_SET);
```

This PR makes RocksDB-Cloud work with both old and new versions of AWS SDK.

Test Plan: Compiles

Reviewers: