### PR TITLE
Use FileSystem methods to create CloudReadableFiles

### DIFF
--- a/cloud/aws/aws_env.h
+++ b/cloud/aws/aws_env.h
@@ -42,13 +42,16 @@ namespace ROCKSDB_NAMESPACE {
 // is associated with a specific instance of AwsEnv. All AwsEnv internally share
 // Env::Posix() for sharing common resources like background threads, etc.
 //
+// TODO(estalgo): Rename to AwsFileSystem
 class AwsEnv : public CloudEnvImpl {
  public:
   // A factory method for creating S3 envs
-  static Status NewAwsEnv(Env* env, const CloudEnvOptions& env_options,
+  static Status NewAwsEnv(const std::shared_ptr<FileSystem>& fs,
+                          const CloudEnvOptions& env_options,
                           const std::shared_ptr<Logger>& info_log,
                           CloudEnv** cenv);
-  static Status NewAwsEnv(Env* env, std::unique_ptr<CloudEnv>* cenv);
+  static Status NewAwsEnv(const std::shared_ptr<FileSystem>& fs,
+                          std::unique_ptr<CloudEnv>* cenv);
   virtual ~AwsEnv() {}
 
   static const char* kName() { return kAws(); }
@@ -71,7 +74,8 @@ class AwsEnv : public CloudEnvImpl {
   // The AWS credentials are specified to the constructor via
   // access_key_id and secret_key.
   //
-  explicit AwsEnv(Env* underlying_env, const CloudEnvOptions& cloud_options,
+  explicit AwsEnv(const std::shared_ptr<FileSystem>& underlying_fs,
+                  const CloudEnvOptions& cloud_options,
                   const std::shared_ptr<Logger>& info_log = nullptr);
 };
 

--- a/cloud/cloud_env_impl.h
+++ b/cloud/cloud_env_impl.h
@@ -9,7 +9,8 @@
 #include "cloud/cloud_manifest.h"
 #include "port/port_posix.h"
 #include "rocksdb/cloud/cloud_env_options.h"
-#include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
+#include "rocksdb/io_status.h"
 #include "rocksdb/status.h"
 #include "util/mutexlock.h"
 
@@ -28,189 +29,161 @@ class CloudEnvImpl : public CloudEnv {
  public:
   static int RegisterAwsObjects(ObjectLibrary& library, const std::string& arg);
   // Constructor
-  CloudEnvImpl(const CloudEnvOptions& options, Env* base_env,
+  CloudEnvImpl(const CloudEnvOptions& options,
+               const std::shared_ptr<FileSystem>& base_env,
                const std::shared_ptr<Logger>& logger);
 
   virtual ~CloudEnvImpl();
   static const char* kClassName() { return kCloud(); }
   virtual const char* Name() const override { return kClassName(); }
 
-  Status NewSequentialFile(const std::string& fname,
-                           std::unique_ptr<SequentialFile>* result,
-                           const EnvOptions& options) override;
-  Status NewSequentialFileCloud(const std::string& bucket,
-                                const std::string& fname,
-                                std::unique_ptr<SequentialFile>* result,
-                                const EnvOptions& options) override;
+  IOStatus NewSequentialFile(const std::string& fname,
+                             const FileOptions& file_opts,
+                             std::unique_ptr<FSSequentialFile>* result,
+                             IODebugContext* dbg) override;
 
-  Status NewRandomAccessFile(const std::string& fname,
-                             std::unique_ptr<RandomAccessFile>* result,
-                             const EnvOptions& options) override;
+  IOStatus NewSequentialFileCloud(const std::string& bucket_prefix,
+                                  const std::string& fname,
+                                  const FileOptions& file_opts,
+                                  std::unique_ptr<FSSequentialFile>* result,
+                                  IODebugContext* dbg) override;
 
-  Status NewWritableFile(const std::string& fname,
-                         std::unique_ptr<WritableFile>* result,
-                         const EnvOptions& options) override;
+  IOStatus NewRandomAccessFile(const std::string& fname,
+                               const FileOptions& file_opts,
+                               std::unique_ptr<FSRandomAccessFile>* result,
+                               IODebugContext* dbg) override;
 
-  Status ReopenWritableFile(const std::string& /*fname*/,
-                            std::unique_ptr<WritableFile>* /*result*/,
-                            const EnvOptions& /*options*/) override;
+  IOStatus NewWritableFile(const std::string& fname,
+                           const FileOptions& file_opts,
+                           std::unique_ptr<FSWritableFile>* result,
+                           IODebugContext* dbg) override;
 
-  Status RenameFile(const std::string& src, const std::string& target) override;
+  IOStatus ReopenWritableFile(const std::string& fname,
+                              const FileOptions& options,
+                              std::unique_ptr<FSWritableFile>* result,
+                              IODebugContext* dbg) override;
 
-  Status LinkFile(const std::string& src, const std::string& target) override;
+  IOStatus RenameFile(const std::string& src, const std::string& target,
+                      const IOOptions& options, IODebugContext* dbg) override;
 
-  Status FileExists(const std::string& fname) override;
+  IOStatus LinkFile(const std::string& src, const std::string& target,
+                    const IOOptions& options, IODebugContext* dbg) override;
 
-  Status GetChildren(const std::string& path,
-                     std::vector<std::string>* result) override;
+  IOStatus FileExists(const std::string& fname, const IOOptions& options,
+                      IODebugContext* dbg) override;
 
-  Status GetFileSize(const std::string& fname, uint64_t* size) override;
+  IOStatus GetChildren(const std::string& dir, const IOOptions& options,
+                       std::vector<std::string>* result,
+                       IODebugContext* dbg) override;
 
-  Status GetFileModificationTime(const std::string& fname,
-                                 uint64_t* file_mtime) override;
+  IOStatus GetFileSize(const std::string& fname, const IOOptions& options,
+                       uint64_t* file_size, IODebugContext* dbg) override;
 
-  Status NewDirectory(const std::string& name,
-                      std::unique_ptr<Directory>* result) override;
+  IOStatus GetFileModificationTime(const std::string& fname,
+                                   const IOOptions& options,
+                                   uint64_t* file_mtime,
+                                   IODebugContext* dbg) override;
 
-  Status CreateDir(const std::string& name) override;
+  IOStatus NewDirectory(const std::string& name, const IOOptions& io_opts,
+                        std::unique_ptr<FSDirectory>* result,
+                        IODebugContext* dbg) override;
 
-  Status CreateDirIfMissing(const std::string& name) override;
+  IOStatus CreateDir(const std::string& dirname, const IOOptions& options,
+                     IODebugContext* dbg) override;
 
-  Status DeleteDir(const std::string& name) override;
+  IOStatus CreateDirIfMissing(const std::string& dirname,
+                              const IOOptions& options,
+                              IODebugContext* dbg) override;
 
-  Status DeleteFile(const std::string& fname) override;
+  IOStatus DeleteDir(const std::string& dirname, const IOOptions& options,
+                     IODebugContext* dbg) override;
 
-  Status NewLogger(const std::string& fname,
-                   std::shared_ptr<Logger>* result) override {
-    return base_env_->NewLogger(fname, result);
+  IOStatus DeleteFile(const std::string& fname, const IOOptions& options,
+                      IODebugContext* dbg) override;
+
+  IOStatus NewLogger(const std::string& fname, const IOOptions& io_opts,
+                     std::shared_ptr<Logger>* result,
+                     IODebugContext* dbg) override {
+    return base_env_->NewLogger(fname, io_opts, result, dbg);
   }
 
-  virtual void Schedule(void (*function)(void* arg), void* arg,
-                        Priority pri = LOW, void* tag = nullptr,
-                        void (*unschedFunction)(void* arg) = 0) override {
-    base_env_->Schedule(function, arg, pri, tag, unschedFunction);
+  IOStatus GetTestDirectory(const IOOptions& options, std::string* path,
+                            IODebugContext* dbg) override {
+    return base_env_->GetTestDirectory(options, path, dbg);
   }
 
-  virtual int UnSchedule(void* tag, Priority pri) override {
-    return base_env_->UnSchedule(tag, pri);
+  IOStatus GetAbsolutePath(const std::string& db_path, const IOOptions& options,
+                           std::string* output_path,
+                           IODebugContext* dbg) override {
+    return base_env_->GetAbsolutePath(db_path, options, output_path, dbg);
   }
 
-  virtual void StartThread(void (*function)(void* arg), void* arg) override {
-    base_env_->StartThread(function, arg);
-  }
+  IOStatus LockFile(const std::string& fname, const IOOptions& options,
+                    FileLock** lock, IODebugContext* dbg) override;
 
-  virtual void WaitForJoin() override { base_env_->WaitForJoin(); }
-
-  virtual unsigned int GetThreadPoolQueueLen(
-      Priority pri = LOW) const override {
-    return base_env_->GetThreadPoolQueueLen(pri);
-  }
-
-  virtual Status GetTestDirectory(std::string* path) override {
-    return base_env_->GetTestDirectory(path);
-  }
-
-  virtual uint64_t NowMicros() override { return base_env_->NowMicros(); }
-
-  virtual void SleepForMicroseconds(int micros) override {
-    base_env_->SleepForMicroseconds(micros);
-  }
-
-  virtual Status GetHostName(char* name, uint64_t len) override {
-    return base_env_->GetHostName(name, len);
-  }
-
-  virtual Status GetCurrentTime(int64_t* unix_time) override {
-    return base_env_->GetCurrentTime(unix_time);
-  }
-
-  virtual Status GetAbsolutePath(const std::string& db_path,
-                                 std::string* output_path) override {
-    return base_env_->GetAbsolutePath(db_path, output_path);
-  }
-
-  virtual void SetBackgroundThreads(int number, Priority pri = LOW) override {
-    base_env_->SetBackgroundThreads(number, pri);
-  }
-  int GetBackgroundThreads(Priority pri) override {
-    return base_env_->GetBackgroundThreads(pri);
-  }
-
-  virtual void IncBackgroundThreadsIfNeeded(int number, Priority pri) override {
-    base_env_->IncBackgroundThreadsIfNeeded(number, pri);
-  }
-
-  virtual std::string TimeToString(uint64_t number) override {
-    return base_env_->TimeToString(number);
-  }
-
-  virtual uint64_t GetThreadID() const override {
-    return base_env_->GetThreadID();
-  }
-
-  virtual Status LockFile(const std::string& fname, FileLock** lock) override;
-
-  virtual Status UnlockFile(FileLock* lock) override;
+  IOStatus UnlockFile(FileLock* lock, const IOOptions& options,
+                      IODebugContext* dbg) override;
 
   std::string GetWALCacheDir();
 
   // Saves and retrieves the dbid->dirname mapping in S3
-  Status SaveDbid(const std::string& bucket_name, const std::string& dbid,
-                  const std::string& dirname) override;
-  Status GetPathForDbid(const std::string& bucket, const std::string& dbid,
-                        std::string* dirname) override;
-  Status GetDbidList(const std::string& bucket, DbidList* dblist) override;
-  Status DeleteDbid(const std::string& bucket,
-                    const std::string& dbid) override;
+  IOStatus SaveDbid(const std::string& bucket_name, const std::string& dbid,
+                    const std::string& dirname) override;
+  IOStatus GetPathForDbid(const std::string& bucket, const std::string& dbid,
+                          std::string* dirname) override;
+  IOStatus GetDbidList(const std::string& bucket, DbidList* dblist) override;
+  IOStatus DeleteDbid(const std::string& bucket,
+                      const std::string& dbid) override;
 
-  Status SanitizeDirectory(const DBOptions& options,
-                           const std::string& clone_name, bool read_only);
-  Status LoadCloudManifest(const std::string& local_dbname, bool read_only);
+  IOStatus SanitizeDirectory(const DBOptions& options,
+                             const std::string& clone_name, bool read_only);
+  IOStatus LoadCloudManifest(const std::string& local_dbname, bool read_only);
   // The separator used to separate dbids while creating the dbid of a clone
   static constexpr const char* DBID_SEPARATOR = "rockset";
 
   // A map from a dbid to the list of all its parent dbids.
   typedef std::map<std::string, std::vector<std::string>> DbidParents;
 
-  Status FindObsoleteFiles(const std::string& bucket_name_prefix,
-                           std::vector<std::string>* pathnames);
-  Status FindObsoleteDbid(const std::string& bucket_name_prefix,
-                          std::vector<std::string>* dbids);
+  IOStatus FindObsoleteFiles(const std::string& bucket_name_prefix,
+                             std::vector<std::string>* pathnames);
+  IOStatus FindObsoleteDbid(const std::string& bucket_name_prefix,
+                            std::vector<std::string>* dbids);
 
   // Find all live files based on cloud_manifest_ and local MANIFEST FILE
   // If local MANIFEST file doesn't exist, it will pull from cloud
   // 
   // REQUIRES: cloud_manifest_ is loaded
   // REQUIRES: cloud_manifest_ is not updated when calling this function
-  Status FindAllLiveFiles(const std::string& local_dbname,
-                          std::vector<std::string>* live_sst_files,
-                          std::string* manifest_file) override;
-  Status FindAllLiveFilesAndFetchManifest(
+  IOStatus FindAllLiveFiles(const std::string& local_dbname,
+                            std::vector<std::string>* live_sst_files,
+                            std::string* manifest_file) override;
+  IOStatus FindAllLiveFilesAndFetchManifest(
       const std::string& local_dbname, std::vector<std::string>* live_sst_files,
       std::string* manifest_file, std::string* manifest_file_version) override;
 
-  Status extractParents(const std::string& bucket_name_prefix,
-                        const DbidList& dbid_list, DbidParents* parents);
-  Status PreloadCloudManifest(const std::string& local_dbname) override;
-  Status MigrateFromPureRocksDB(const std::string& local_dbname) override;
+  IOStatus extractParents(const std::string& bucket_name_prefix,
+                          const DbidList& dbid_list, DbidParents* parents);
+  IOStatus PreloadCloudManifest(const std::string& local_dbname) override;
+  IOStatus MigrateFromPureRocksDB(const std::string& local_dbname) override;
 
   // Load CLOUDMANIFEST if exists in local disk to current env.
-  Status LoadLocalCloudManifest(const std::string& dbname);
+  IOStatus LoadLocalCloudManifest(const std::string& dbname);
   // TODO(wei): this function is used to temporarily support open db and switch
   // cookie. Remove it once that's not needed
-  Status LoadLocalCloudManifest(const std::string& dbname,
-                                const std::string& cookie);
+  IOStatus LoadLocalCloudManifest(const std::string& dbname,
+                                  const std::string& cookie);
 
   // Local CLOUDMANIFEST from `base_env` into `cloud_manifest`.
-  static Status LoadLocalCloudManifest(
-      const std::string& dbname, Env* base_env, const std::string& cookie,
+  static IOStatus LoadLocalCloudManifest(
+      const std::string& dbname, const std::shared_ptr<FileSystem>& base_fs,
+      const std::string& cookie,
       std::unique_ptr<CloudManifest>* cloud_manifest);
 
-  Status CreateCloudManifest(const std::string& local_dbname);
+  IOStatus CreateCloudManifest(const std::string& local_dbname);
   // TODO(wei): this function is used to temporarily support open db and switch
   // cookie. Remove it once that's not needed
-  Status CreateCloudManifest(const std::string& local_dbname,
-                             const std::string& cookie);
+  IOStatus CreateCloudManifest(const std::string& local_dbname,
+                               const std::string& cookie);
 
   // Transfers the filename from RocksDB's domain to the physical domain, based
   // on information stored in CLOUDMANIFEST.
@@ -219,47 +192,50 @@ class CloudEnvImpl : public CloudEnv {
   // Files both in S3 and in the local directory have this [epoch] suffix.
   std::string RemapFilename(const std::string& logical_path) const override;
 
-  EnvOptions OptimizeForLogRead(const EnvOptions& env_options) const override {
-    return base_env_->OptimizeForLogRead(env_options);
+  FileOptions OptimizeForLogRead(
+      const FileOptions& file_options) const override {
+    return base_env_->OptimizeForLogRead(file_options);
   }
-  EnvOptions OptimizeForManifestRead(
-      const EnvOptions& env_options) const override {
-    return base_env_->OptimizeForManifestRead(env_options);
+  FileOptions OptimizeForManifestRead(
+      const FileOptions& file_options) const override {
+    return base_env_->OptimizeForManifestRead(file_options);
   }
-  EnvOptions OptimizeForLogWrite(const EnvOptions& env_options,
-                                 const DBOptions& db_options) const override {
-    return base_env_->OptimizeForLogWrite(env_options, db_options);
+  FileOptions OptimizeForLogWrite(const FileOptions& file_options,
+                                  const DBOptions& db_options) const override {
+    return base_env_->OptimizeForLogWrite(file_options, db_options);
   }
-  EnvOptions OptimizeForManifestWrite(
-      const EnvOptions& env_options) const override {
-    return base_env_->OptimizeForManifestWrite(env_options);
+  FileOptions OptimizeForManifestWrite(
+      const FileOptions& file_options) const override {
+    return base_env_->OptimizeForManifestWrite(file_options);
   }
-  EnvOptions OptimizeForCompactionTableWrite(
-      const EnvOptions& env_options,
+  FileOptions OptimizeForCompactionTableWrite(
+      const FileOptions& file_options,
       const ImmutableDBOptions& immutable_ops) const override {
-    return base_env_->OptimizeForCompactionTableWrite(env_options,
+    return base_env_->OptimizeForCompactionTableWrite(file_options,
                                                       immutable_ops);
   }
-  EnvOptions OptimizeForCompactionTableRead(
-      const EnvOptions& env_options,
+  FileOptions OptimizeForCompactionTableRead(
+      const FileOptions& file_options,
       const ImmutableDBOptions& db_options) const override {
-    return base_env_->OptimizeForCompactionTableRead(env_options, db_options);
+    return base_env_->OptimizeForCompactionTableRead(file_options, db_options);
   }
-  Status GetFreeSpace(const std::string& path, uint64_t* diskfree) override {
-    return base_env_->GetFreeSpace(path, diskfree);
+  IOStatus GetFreeSpace(const std::string& path, const IOOptions& options,
+                        uint64_t* diskfree, IODebugContext* dbg) override {
+    return base_env_->GetFreeSpace(path, options, diskfree, dbg);
+  }
+  IOStatus IsDirectory(const std::string& /*path*/,
+                       const IOOptions& /*options*/, bool* /*is_dir*/,
+                       IODebugContext* /*dbg*/) override {
+    return IOStatus::NotSupported("CloudEnvImpl::IsDirectory() not supported.");
   }
 
   CloudManifest* GetCloudManifest() { return cloud_manifest_.get(); }
   void TEST_InitEmptyCloudManifest();
   void TEST_DisableCloudManifest() { test_disable_cloud_manifest_ = true; }
 
-  Status GetThreadList(std::vector<ThreadStatus>* thread_list) override {
-    return base_env_->GetThreadList(thread_list);
-  }
-
-  Status DeleteCloudFileFromDest(const std::string& fname) override;
-  Status CopyLocalFileToDest(const std::string& local_name,
-                             const std::string& cloud_name) override;
+  IOStatus DeleteCloudFileFromDest(const std::string& fname) override;
+  IOStatus CopyLocalFileToDest(const std::string& local_name,
+                               const std::string& cloud_name) override;
 
   void RemoveFileFromDeletionQueue(const std::string& filename);
 
@@ -279,22 +255,22 @@ class CloudEnvImpl : public CloudEnv {
 
   // Apply cloud manifest delta to in-memory cloud manifest. Does not change the
   // on-disk state.
-  Status ApplyCloudManifestDelta(const CloudManifestDelta& delta,
-                                 bool* delta_applied) override;
+  IOStatus ApplyCloudManifestDelta(const CloudManifestDelta& delta,
+                                   bool* delta_applied) override;
 
   // See comments in the parent class
-  Status RollNewCookie(const std::string& local_dbname,
-                       const std::string& cookie,
-                       const CloudManifestDelta& delta) const override;
+  IOStatus RollNewCookie(const std::string& local_dbname,
+                         const std::string& cookie,
+                         const CloudManifestDelta& delta) const override;
 
   // Upload MANIFEST-epoch  to the cloud
-  Status UploadManifest(const std::string& local_dbname,
-                        const std::string& epoch) const;
+  IOStatus UploadManifest(const std::string& local_dbname,
+                          const std::string& epoch) const;
 
   // Upload local CLOUDMANIFEST-cookie file only.
   // REQURIES: the file exists locally
-  Status UploadCloudManifest(const std::string& local_dbname,
-                             const std::string& cookie) const;
+  IOStatus UploadCloudManifest(const std::string& local_dbname,
+                               const std::string& cookie) const;
 
   // Get current number of scheduled jobs in cloud scheduler
   // Used for test only
@@ -303,7 +279,7 @@ class CloudEnvImpl : public CloudEnv {
   // Delete invisible files in cloud.
   //
   // REQUIRES: Dest bucket set
-  Status DeleteCloudInvisibleFiles(
+  IOStatus DeleteCloudInvisibleFiles(
       const std::vector<std::string>& active_cookies) override;
 
  protected:
@@ -317,34 +293,34 @@ class CloudEnvImpl : public CloudEnv {
   }
 
   // Checks to see if the input fname exists in the dest or src bucket
-  Status ExistsCloudObject(const std::string& fname);
+  IOStatus ExistsCloudObject(const std::string& fname);
 
   // Gets the cloud object fname from the dest or src bucket
-  Status GetCloudObject(const std::string& fname);
+  IOStatus GetCloudObject(const std::string& fname);
 
   // Gets the size of the named cloud object from the dest or src bucket
-  Status GetCloudObjectSize(const std::string& fname, uint64_t* remote_size);
+  IOStatus GetCloudObjectSize(const std::string& fname, uint64_t* remote_size);
 
   // Gets the modification time of the named cloud object from the dest or src
   // bucket
-  Status GetCloudObjectModificationTime(const std::string& fname,
-                                        uint64_t* time);
+  IOStatus GetCloudObjectModificationTime(const std::string& fname,
+                                          uint64_t* time);
 
   // Returns the list of cloud objects from the src and dest buckets.
-  Status ListCloudObjects(const std::string& path,
-                          std::vector<std::string>* result);
+  IOStatus ListCloudObjects(const std::string& path,
+                            std::vector<std::string>* result);
 
   // Returns a CloudStorageReadableFile from the dest or src bucket
-  Status NewCloudReadableFile(const std::string& fname,
-                              std::unique_ptr<CloudStorageReadableFile>* result,
-                              const EnvOptions& options);
+  IOStatus NewCloudReadableFile(
+      const std::string& fname, const FileOptions& options,
+      std::unique_ptr<CloudStorageReadableFile>* result, IODebugContext* dbg);
 
   // Copy IDENTITY file to cloud storage. Update dbid registry.
-  Status SaveIdentityToCloud(const std::string& localfile,
-                             const std::string& idfile);
+  IOStatus SaveIdentityToCloud(const std::string& localfile,
+                               const std::string& idfile);
 
   // Check if options are compatible with the storage system
-  virtual Status CheckOption(const EnvOptions& options);
+  virtual Status CheckOption(const FileOptions& file_opts);
 
   // Converts a local pathname to an object name in the src bucket
   std::string srcname(const std::string& localname);
@@ -353,19 +329,19 @@ class CloudEnvImpl : public CloudEnv {
   std::string destname(const std::string& localname);
 
   // Does the dir need to be re-initialized?
-  Status NeedsReinitialization(const std::string& clone_dir, bool* do_reinit);
+  IOStatus NeedsReinitialization(const std::string& clone_dir, bool* do_reinit);
 
-  Status GetCloudDbid(const std::string& local_dir, std::string* src_dbid,
-                      std::string* dest_dbid);
+  IOStatus GetCloudDbid(const std::string& local_dir, std::string* src_dbid,
+                        std::string* dest_dbid);
 
-  Status ResyncDir(const std::string& local_dir);
+  IOStatus ResyncDir(const std::string& local_dir);
 
-  Status CreateNewIdentityFile(const std::string& dbid,
-                               const std::string& local_name);
+  IOStatus CreateNewIdentityFile(const std::string& dbid,
+                                 const std::string& local_name);
 
-  Status FetchCloudManifest(const std::string& local_dbname);
+  IOStatus FetchCloudManifest(const std::string& local_dbname);
 
-  Status RollNewEpoch(const std::string& local_dbname);
+  IOStatus RollNewEpoch(const std::string& local_dbname);
 
   // helper methods to access the file cache
   void FileCacheAccess(const std::string& fname);
@@ -393,8 +369,9 @@ class CloudEnvImpl : public CloudEnv {
 
  private:
   // Delete all local files that are invisible
-  Status DeleteLocalInvisibleFiles(const std::string& dbname,
-                                   const std::vector<std::string>& active_cookies);
+  IOStatus DeleteLocalInvisibleFiles(
+      const std::string& dbname,
+      const std::vector<std::string>& active_cookies);
   // Files are invisibile if:
   // - It's CLOUDMANFIEST file and cookie is not active. NOTE: empty cookie is
   // always active
@@ -408,11 +385,13 @@ class CloudEnvImpl : public CloudEnv {
   void log(InfoLogLevel level, const std::string& fname,
            const std::string& msg);
   // Fetch the cloud manifest based on the cookie
-  Status FetchCloudManifest(const std::string& local_dbname, const std::string& cookie);
-  Status writeCloudManifest(CloudManifest* manifest,
-                            const std::string& fname) const;
-  Status FetchManifest(const std::string& local_dbname, const std::string& epoch);
-  std::string generateNewEpochId();
+  IOStatus FetchCloudManifest(const std::string& local_dbname,
+                              const std::string& cookie);
+  IOStatus WriteCloudManifest(CloudManifest* manifest,
+                              const std::string& fname) const;
+  IOStatus FetchManifest(const std::string& local_dbname,
+                         const std::string& epoch);
+  std::string GenerateNewEpochId();
   std::unique_ptr<CloudManifest> cloud_manifest_;
   // This runs only in tests when we want to disable cloud manifest
   // functionality

--- a/cloud/cloud_env_wrapper.h
+++ b/cloud/cloud_env_wrapper.h
@@ -14,89 +14,90 @@ namespace ROCKSDB_NAMESPACE {
 
 class MockStorageProvider : public CloudStorageProvider {
  public:
-  MockStorageProvider() { notsup_ = Status::NotSupported(); }
+  MockStorageProvider() { notsup_ = IOStatus::NotSupported(); }
   virtual const char* Name() const override { return "Mock"; }
-  virtual Status CreateBucket(const std::string& /*bucket_name*/) override {
+  IOStatus CreateBucket(const std::string& /*bucket_name*/) override {
     return notsup_;
   }
 
-  virtual Status ExistsBucket(const std::string& /*bucket_name*/) override {
+  IOStatus ExistsBucket(const std::string& /*bucket_name*/) override {
     return notsup_;
   }
 
-  virtual Status EmptyBucket(const std::string& /*bucket_name*/,
-                             const std::string& /*path_prefix*/) override {
+  IOStatus EmptyBucket(const std::string& /*bucket_name*/,
+                       const std::string& /*path_prefix*/) override {
     return notsup_;
   }
-  Status ListCloudObjects(const std::string& /*bucket_name*/,
-                          const std::string& /*object_path*/,
-                          std::vector<std::string>* /*result*/) override {
-    return notsup_;
-  }
-  Status DeleteCloudObject(const std::string& /*bucket_name*/,
-                           const std::string& /*object_path*/) override {
-    return notsup_;
-  }
-  Status ExistsCloudObject(const std::string& /*bucket_name*/,
-                           const std::string& /*object_path*/) override {
-    return notsup_;
-  }
-  Status GetCloudObjectSize(const std::string& /*bucket_name*/,
+  IOStatus ListCloudObjects(const std::string& /*bucket_name*/,
                             const std::string& /*object_path*/,
-                            uint64_t* /*size*/) override {
+                            std::vector<std::string>* /*result*/) override {
     return notsup_;
   }
-  Status GetCloudObjectModificationTime(const std::string& /*bucket_name*/,
-                                        const std::string& /*object_path*/,
-                                        uint64_t* /*time*/) override {
+  IOStatus DeleteCloudObject(const std::string& /*bucket_name*/,
+                             const std::string& /*object_path*/) override {
     return notsup_;
   }
-  Status GetCloudObjectMetadata(const std::string& /*bucket_name*/,
-                                const std::string& /*object_path*/,
-                                CloudObjectInformation* /* info */) override {
+  IOStatus ExistsCloudObject(const std::string& /*bucket_name*/,
+                             const std::string& /*object_path*/) override {
     return notsup_;
   }
-  Status CopyCloudObject(const std::string& /*bucket_name_src*/,
-                         const std::string& /*object_path_src*/,
-                         const std::string& /*bucket_name_dest*/,
-                         const std::string& /*object_path_dest*/) override {
+  IOStatus GetCloudObjectSize(const std::string& /*bucket_name*/,
+                              const std::string& /*object_path*/,
+                              uint64_t* /*size*/) override {
     return notsup_;
   }
-  Status PutCloudObjectMetadata(
+  IOStatus GetCloudObjectModificationTime(const std::string& /*bucket_name*/,
+                                          const std::string& /*object_path*/,
+                                          uint64_t* /*time*/) override {
+    return notsup_;
+  }
+  IOStatus GetCloudObjectMetadata(const std::string& /*bucket_name*/,
+                                  const std::string& /*object_path*/,
+                                  CloudObjectInformation* /* info */) override {
+    return notsup_;
+  }
+  IOStatus CopyCloudObject(const std::string& /*bucket_name_src*/,
+                           const std::string& /*object_path_src*/,
+                           const std::string& /*bucket_name_dest*/,
+                           const std::string& /*object_path_dest*/) override {
+    return notsup_;
+  }
+  IOStatus PutCloudObjectMetadata(
       const std::string& /*bucket_name*/, const std::string& /*object_path*/,
       const std::unordered_map<std::string, std::string>& /*metadata*/)
       override {
     return notsup_;
   }
-  Status NewCloudWritableFile(
+  IOStatus NewCloudWritableFile(
       const std::string& /*local_path*/, const std::string& /*bucket_name*/,
-      const std::string& /*object_path*/,
+      const std::string& /*object_path*/, const FileOptions& /*options*/,
       std::unique_ptr<CloudStorageWritableFile>* /*result*/,
-      const EnvOptions& /*options*/) override {
+      IODebugContext* /*dbg*/) override {
     return notsup_;
   }
 
-  Status NewCloudReadableFile(
+  IOStatus NewCloudReadableFile(
       const std::string& /*bucket*/, const std::string& /*fname*/,
+      const FileOptions& /*options*/,
       std::unique_ptr<CloudStorageReadableFile>* /*result*/,
-      const EnvOptions& /*options*/) override {
+      IODebugContext* /*dbg*/) override {
     return notsup_;
   }
 
-  Status GetCloudObject(const std::string& /*bucket_name*/,
-                        const std::string& /*object_path*/,
-                        const std::string& /*local_path*/) override {
+  IOStatus GetCloudObject(const std::string& /*bucket_name*/,
+                          const std::string& /*object_path*/,
+                          const std::string& /*local_path*/) override {
     return notsup_;
   }
 
-  Status PutCloudObject(const std::string& /*local_path*/,
-                        const std::string& /*bucket_name*/,
-                        const std::string& /*object_path*/) override {
+  IOStatus PutCloudObject(const std::string& /*local_path*/,
+                          const std::string& /*bucket_name*/,
+                          const std::string& /*object_path*/) override {
     return notsup_;
   }
 
  protected:
-  Status notsup_;
+  IOStatus notsup_;
 };
 // An implementation of Env that forwards all calls to another Env.
 // May be useful to clients who wish to override just part of the
@@ -106,204 +107,148 @@ class MockCloudEnv : public CloudEnv {
  public:
   // Initialize an EnvWrapper that delegates all calls to *t
   explicit MockCloudEnv(const CloudEnvOptions& opts = CloudEnvOptions())
-      : CloudEnv(opts, Env::Default(), nullptr) {
-    notsup_ = Status::NotSupported();
+      : CloudEnv(opts, FileSystem::Default(), nullptr) {
+    notsup_ = IOStatus::NotSupported();
   }
 
   virtual ~MockCloudEnv() {}
 
   const char* Name() const override { return "MockCloudEnv"; }
 
-  Status PreloadCloudManifest(const std::string& /*local_dbname*/) override {
+  IOStatus PreloadCloudManifest(const std::string& /*local_dbname*/) override {
     return notsup_;
   }
 
-  virtual Status NewSequentialFileCloud(
-      const std::string& /*bucket_name*/, const std::string& /*fname*/,
-      std::unique_ptr<SequentialFile>* /*result*/,
-      const EnvOptions& /*options*/) override {
+  IOStatus NewSequentialFileCloud(const std::string& /*bucket_name*/,
+                                  const std::string& /*fname*/,
+                                  const FileOptions& /*options*/,
+                                  std::unique_ptr<FSSequentialFile>* /*result*/,
+                                  IODebugContext* /*dbg*/) override {
     return notsup_;
   }
-  virtual Status SaveDbid(const std::string& /*bucket_name*/,
-                          const std::string& /*dbid */,
-                          const std::string& /*dirname*/) override {
+  IOStatus SaveDbid(const std::string& /*bucket_name*/,
+                    const std::string& /*dbid */,
+                    const std::string& /*dirname*/) override {
     return notsup_;
   }
-  virtual Status GetPathForDbid(const std::string& /*bucket_name*/,
-                                const std::string& /*dbid*/,
-                                std::string* /*dirname*/) override {
+  IOStatus GetPathForDbid(const std::string& /*bucket_name*/,
+                          const std::string& /*dbid*/,
+                          std::string* /*dirname*/) override {
     return notsup_;
   }
-  virtual Status GetDbidList(const std::string& /*bucket_name*/,
-                             DbidList* /*dblist*/) override {
+  IOStatus GetDbidList(const std::string& /*bucket_name*/,
+                       DbidList* /*dblist*/) override {
     return notsup_;
   }
-  virtual Status DeleteDbid(const std::string& /*bucket_name*/,
-                            const std::string& /*dbid*/) override {
-    return notsup_;
-  }
-
-  // Ability to read a file directly from cloud storage
-  virtual Status NewSequentialFileCloud(
-      const std::string& /*fname*/, std::unique_ptr<SequentialFile>* /*result*/,
-      const EnvOptions& /*options*/) {
+  IOStatus DeleteDbid(const std::string& /*bucket_name*/,
+                      const std::string& /*dbid*/) override {
     return notsup_;
   }
 
   // The following text is boilerplate that forwards all methods to base_env
-  Status NewSequentialFile(const std::string& f,
-                           std::unique_ptr<SequentialFile>* r,
-                           const EnvOptions& options) override {
-    return base_env_->NewSequentialFile(f, r, options);
+  IOStatus NewSequentialFile(const std::string& f, const FileOptions& o,
+                             std::unique_ptr<FSSequentialFile>* r,
+                             IODebugContext* dbg) override {
+    return base_env_->NewSequentialFile(f, o, r, dbg);
   }
-  Status NewRandomAccessFile(const std::string& f,
-                             std::unique_ptr<RandomAccessFile>* r,
-                             const EnvOptions& options) override {
-    return base_env_->NewRandomAccessFile(f, r, options);
+  IOStatus NewRandomAccessFile(const std::string& f, const FileOptions& o,
+                               std::unique_ptr<FSRandomAccessFile>* r,
+                               IODebugContext* dbg) override {
+    return base_env_->NewRandomAccessFile(f, o, r, dbg);
   }
-  Status NewWritableFile(const std::string& f, std::unique_ptr<WritableFile>* r,
-                         const EnvOptions& options) override {
-    return base_env_->NewWritableFile(f, r, options);
+  IOStatus NewWritableFile(const std::string& f, const FileOptions& o,
+                           std::unique_ptr<FSWritableFile>* r,
+                           IODebugContext* dbg) override {
+    return base_env_->NewWritableFile(f, o, r, dbg);
   }
-  Status ReuseWritableFile(const std::string& fname,
-                           const std::string& old_fname,
-                           std::unique_ptr<WritableFile>* r,
-                           const EnvOptions& options) override {
-    return base_env_->ReuseWritableFile(fname, old_fname, r, options);
+  IOStatus ReuseWritableFile(const std::string& fname,
+                             const std::string& old_fname, const FileOptions& o,
+                             std::unique_ptr<FSWritableFile>* r,
+                             IODebugContext* dbg) override {
+    return base_env_->ReuseWritableFile(fname, old_fname, o, r, dbg);
   }
-  Status NewRandomRWFile(const std::string& fname,
-                         std::unique_ptr<RandomRWFile>* result,
-                         const EnvOptions& options) override {
-    return base_env_->NewRandomRWFile(fname, result, options);
+  IOStatus NewRandomRWFile(const std::string& fname, const FileOptions& o,
+                           std::unique_ptr<FSRandomRWFile>* result,
+                           IODebugContext* dbg) override {
+    return base_env_->NewRandomRWFile(fname, o, result, dbg);
   }
-  virtual Status NewDirectory(const std::string& name,
-                              std::unique_ptr<Directory>* result) override {
-    return base_env_->NewDirectory(name, result);
+  IOStatus NewDirectory(const std::string& name, const IOOptions& o,
+                        std::unique_ptr<FSDirectory>* result,
+                        IODebugContext* dbg) override {
+    return base_env_->NewDirectory(name, o, result, dbg);
   }
-  Status FileExists(const std::string& f) override {
-    return base_env_->FileExists(f);
+  IOStatus FileExists(const std::string& f, const IOOptions& o,
+                      IODebugContext* dbg) override {
+    return base_env_->FileExists(f, o, dbg);
   }
-  Status GetChildren(const std::string& dir,
-                     std::vector<std::string>* r) override {
-    return base_env_->GetChildren(dir, r);
+  IOStatus GetChildren(const std::string& dir, const IOOptions& o,
+                       std::vector<std::string>* r,
+                       IODebugContext* dbg) override {
+    return base_env_->GetChildren(dir, o, r, dbg);
   }
-  Status GetChildrenFileAttributes(
-      const std::string& dir, std::vector<FileAttributes>* result) override {
-    return base_env_->GetChildrenFileAttributes(dir, result);
+  IOStatus GetChildrenFileAttributes(const std::string& dir, const IOOptions& o,
+                                     std::vector<FileAttributes>* result,
+                                     IODebugContext* dbg) override {
+    return base_env_->GetChildrenFileAttributes(dir, o, result, dbg);
   }
-  Status DeleteFile(const std::string& f) override {
-    return base_env_->DeleteFile(f);
+  IOStatus DeleteFile(const std::string& f, const IOOptions& o,
+                      IODebugContext* dbg) override {
+    return base_env_->DeleteFile(f, o, dbg);
   }
-  Status CreateDir(const std::string& d) override {
-    return base_env_->CreateDir(d);
+  IOStatus CreateDir(const std::string& d, const IOOptions& o,
+                     IODebugContext* dbg) override {
+    return base_env_->CreateDir(d, o, dbg);
   }
-  Status CreateDirIfMissing(const std::string& d) override {
-    return base_env_->CreateDirIfMissing(d);
+  IOStatus CreateDirIfMissing(const std::string& d, const IOOptions& o,
+                              IODebugContext* dbg) override {
+    return base_env_->CreateDirIfMissing(d, o, dbg);
   }
-  Status DeleteDir(const std::string& d) override {
-    return base_env_->DeleteDir(d);
+  IOStatus DeleteDir(const std::string& d, const IOOptions& o,
+                     IODebugContext* dbg) override {
+    return base_env_->DeleteDir(d, o, dbg);
   }
-  Status GetFileSize(const std::string& f, uint64_t* s) override {
-    return base_env_->GetFileSize(f, s);
-  }
-
-  Status GetFileModificationTime(const std::string& fname,
-                                 uint64_t* file_mtime) override {
-    return base_env_->GetFileModificationTime(fname, file_mtime);
-  }
-
-  Status RenameFile(const std::string& s, const std::string& t) override {
-    return base_env_->RenameFile(s, t);
-  }
-
-  Status LinkFile(const std::string& s, const std::string& t) override {
-    return base_env_->LinkFile(s, t);
+  IOStatus GetFileSize(const std::string& f, const IOOptions& o, uint64_t* s,
+                       IODebugContext* dbg) override {
+    return base_env_->GetFileSize(f, o, s, dbg);
   }
 
-  Status LockFile(const std::string& f, FileLock** l) override {
-    return base_env_->LockFile(f, l);
+  IOStatus GetFileModificationTime(const std::string& fname, const IOOptions& o,
+                                   uint64_t* file_mtime,
+                                   IODebugContext* dbg) override {
+    return base_env_->GetFileModificationTime(fname, o, file_mtime, dbg);
   }
 
-  Status UnlockFile(FileLock* l) override { return base_env_->UnlockFile(l); }
-
-  void Schedule(void (*f)(void* arg), void* a, Priority pri,
-                void* tag = nullptr, void (*u)(void* arg) = 0) override {
-    return base_env_->Schedule(f, a, pri, tag, u);
+  IOStatus RenameFile(const std::string& s, const std::string& t,
+                      const IOOptions& o, IODebugContext* dbg) override {
+    return base_env_->RenameFile(s, t, o, dbg);
   }
 
-  int UnSchedule(void* tag, Priority pri) override {
-    return base_env_->UnSchedule(tag, pri);
+  IOStatus LinkFile(const std::string& s, const std::string& t,
+                    const IOOptions& o, IODebugContext* dbg) override {
+    return base_env_->LinkFile(s, t, o, dbg);
   }
 
-  void StartThread(void (*f)(void*), void* a) override {
-    return base_env_->StartThread(f, a);
-  }
-  void WaitForJoin() override { return base_env_->WaitForJoin(); }
-  virtual unsigned int GetThreadPoolQueueLen(
-      Priority pri = LOW) const override {
-    return base_env_->GetThreadPoolQueueLen(pri);
-  }
-  virtual Status GetTestDirectory(std::string* path) override {
-    return base_env_->GetTestDirectory(path);
-  }
-  virtual Status NewLogger(const std::string& fname,
-                           std::shared_ptr<Logger>* result) override {
-    return base_env_->NewLogger(fname, result);
-  }
-  uint64_t NowMicros() override { return base_env_->NowMicros(); }
-  void SleepForMicroseconds(int micros) override {
-    base_env_->SleepForMicroseconds(micros);
-  }
-  Status GetHostName(char* name, uint64_t len) override {
-    return base_env_->GetHostName(name, len);
-  }
-  Status GetCurrentTime(int64_t* unix_time) override {
-    return base_env_->GetCurrentTime(unix_time);
-  }
-  Status GetAbsolutePath(const std::string& db_path,
-                         std::string* output_path) override {
-    return base_env_->GetAbsolutePath(db_path, output_path);
-  }
-  void SetBackgroundThreads(int num, Priority pri) override {
-    return base_env_->SetBackgroundThreads(num, pri);
-  }
-  int GetBackgroundThreads(Priority pri) override {
-    return base_env_->GetBackgroundThreads(pri);
+  IOStatus LockFile(const std::string& f, const IOOptions& o, FileLock** l,
+                    IODebugContext* dbg) override {
+    return base_env_->LockFile(f, o, l, dbg);
   }
 
-  void IncBackgroundThreadsIfNeeded(int num, Priority pri) override {
-    return base_env_->IncBackgroundThreadsIfNeeded(num, pri);
+  IOStatus UnlockFile(FileLock* l, const IOOptions& o,
+                      IODebugContext* dbg) override {
+    return base_env_->UnlockFile(l, o, dbg);
   }
 
-  void LowerThreadPoolIOPriority(Priority pool = LOW) override {
-    base_env_->LowerThreadPoolIOPriority(pool);
-  }
-
-  std::string TimeToString(uint64_t time) override {
-    return base_env_->TimeToString(time);
-  }
-
-  Status GetThreadList(std::vector<ThreadStatus>* thread_list) override {
-    return base_env_->GetThreadList(thread_list);
-  }
-
-  ThreadStatusUpdater* GetThreadStatusUpdater() const override {
-    return base_env_->GetThreadStatusUpdater();
-  }
-
-  uint64_t GetThreadID() const override { return base_env_->GetThreadID(); }
-
-  Status DeleteCloudFileFromDest(const std::string& /*path*/) override {
+  IOStatus DeleteCloudFileFromDest(const std::string& /*path*/) override {
     return notsup_;
   }
 
-  Status FindAllLiveFiles(const std::string& /* local_dbname */,
-                          std::vector<std::string>* /* live_sst_files */,
-                          std::string* /* manifest_file */) override {
+  IOStatus FindAllLiveFiles(const std::string& /* local_dbname */,
+                            std::vector<std::string>* /* live_sst_files */,
+                            std::string* /* manifest_file */) override {
     return notsup_;
   }
 
-  Status FindAllLiveFilesAndFetchManifest(
+  IOStatus FindAllLiveFilesAndFetchManifest(
       const std::string& /* local_dbname */,
       std::vector<std::string>* /* live_sst_files */,
       std::string* /* manifest_file */,
@@ -312,7 +257,7 @@ class MockCloudEnv : public CloudEnv {
   }
 
  private:
-  Status notsup_;
+  IOStatus notsup_;
   std::string empty_;
 };
 }  // namespace ROCKSDB_NAMESPACE

--- a/cloud/cloud_file_cache.cc
+++ b/cloud/cloud_file_cache.cc
@@ -90,7 +90,7 @@ void CloudEnvImpl::FileCacheErase(const std::string& fname) {
 // When the cache is full, delete files from local store
 //
 void CloudEnvImpl::FileCacheDeleter(const std::string& fname) {
-  Status st = base_env_->DeleteFile(fname);
+  base_env_->DeleteFile(fname, IOOptions(), nullptr /*dbg*/);
   log(InfoLogLevel::INFO_LEVEL, fname, "purged");
 }
 
@@ -131,13 +131,11 @@ void CloudEnvImpl::FileCachePurge() {
   clear_callback_state();
   cloud_env_options.sst_file_cache->ApplyToAllCacheEntries(callback, true);
   // for all those items that have a matching cenv, remove them from cache.
-  uint64_t count = 0;
   for (auto& it : callback_state) {
     Value* value = it.first;
     if (value->cenv == this) {
       Slice key(value->path);
       cloud_env_options.sst_file_cache->Erase(key);
-      count++;
     }
   }
   log(InfoLogLevel::INFO_LEVEL, "ENV-DELETE", "purged");

--- a/cloud/cloud_file_deletion_scheduler.h
+++ b/cloud/cloud_file_deletion_scheduler.h
@@ -25,8 +25,8 @@ class CloudFileDeletionScheduler
   using FileDeletionRunnable = std::function<void()>;
   // Schedule the file deletion runnable(which actually delets the file from
   // cloud) to be executed in the future (specified by `file_deletion_delay_`).
-  rocksdb::Status ScheduleFileDeletion(const std::string& filename,
-                                       FileDeletionRunnable runnable);
+  rocksdb::IOStatus ScheduleFileDeletion(const std::string& filename,
+                                         FileDeletionRunnable runnable);
 
   void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
     std::lock_guard<std::mutex> lk(files_to_delete_mutex_);

--- a/cloud/cloud_manifest.h
+++ b/cloud/cloud_manifest.h
@@ -35,15 +35,15 @@ namespace ROCKSDB_NAMESPACE {
 // CloudManifest is thread safe after Finalize() is called.
 class CloudManifest {
  public:
-  static Status LoadFromLog(std::unique_ptr<SequentialFileReader> log,
-                            std::unique_ptr<CloudManifest>* manifest);
+  static IOStatus LoadFromLog(std::unique_ptr<SequentialFileReader> log,
+                              std::unique_ptr<CloudManifest>* manifest);
   // Creates CloudManifest for an empty database
-  static Status CreateForEmptyDatabase(
+  static IOStatus CreateForEmptyDatabase(
       std::string currentEpoch, std::unique_ptr<CloudManifest>* manifest);
 
   std::unique_ptr<CloudManifest> clone() const;
 
-  Status WriteToLog(std::unique_ptr<WritableFileWriter> log) const;
+  IOStatus WriteToLog(std::unique_ptr<WritableFileWriter> log) const;
 
   // Add an epoch that starts with startFileNumber and is identified by epochId.
   // GetEpoch(startFileNumber) == epochId

--- a/cloud/cloud_storage_provider_impl.h
+++ b/cloud/cloud_storage_provider_impl.h
@@ -13,17 +13,21 @@ class CloudStorageReadableFileImpl : public CloudStorageReadableFile {
   CloudStorageReadableFileImpl(Logger* info_log, const std::string& bucket,
                                const std::string& fname, uint64_t size);
   // sequential access, read data at current offset in file
-  virtual Status Read(size_t n, Slice* result, char* scratch) override;
+  IOStatus Read(size_t n, const IOOptions& options, Slice* result,
+                char* scratch, IODebugContext* dbg) override;
 
   // random access, read data from specified offset in file
-  virtual Status Read(uint64_t offset, size_t n, Slice* result,
-                      char* scratch) const override;
+  IOStatus Read(uint64_t offset, size_t n, const IOOptions& options,
+                Slice* result, char* scratch,
+                IODebugContext* dbg) const override;
 
-  virtual Status Skip(uint64_t n) override;
+  IOStatus Skip(uint64_t n) override;
 
  protected:
-  virtual Status DoCloudRead(uint64_t offset, size_t n, char* scratch,
-                             uint64_t* bytes_read) const = 0;
+  virtual IOStatus DoCloudRead(uint64_t offset, size_t n,
+                               const IOOptions& options, char* scratch,
+                               uint64_t* bytes_read,
+                               IODebugContext* dbg) const = 0;
 
   Logger* info_log_;
   std::string bucket_;
@@ -39,8 +43,8 @@ class CloudStorageWritableFileImpl : public CloudStorageWritableFile {
   const char* class_;
   std::string fname_;
   std::string tmp_file_;
-  Status status_;
-  std::unique_ptr<WritableFile> local_file_;
+  IOStatus status_;
+  std::unique_ptr<FSWritableFile> local_file_;
   std::string bucket_;
   std::string cloud_fname_;
   bool is_manifest_;
@@ -49,24 +53,30 @@ class CloudStorageWritableFileImpl : public CloudStorageWritableFile {
   CloudStorageWritableFileImpl(CloudEnv* env, const std::string& local_fname,
                                const std::string& bucket,
                                const std::string& cloud_fname,
-                               const EnvOptions& options);
+                               const FileOptions& file_opts);
 
   virtual ~CloudStorageWritableFileImpl();
   using CloudStorageWritableFile::Append;
-  virtual Status Append(const Slice& data) override {
+  IOStatus Append(const Slice& data, const IOOptions& opts,
+                  IODebugContext* dbg) override {
     assert(status_.ok());
     // write to temporary file
-    return local_file_->Append(data);
+    return local_file_->Append(data, opts, dbg);
   }
 
   using CloudStorageWritableFile::PositionedAppend;
-  Status PositionedAppend(const Slice& data, uint64_t offset) override {
-    return local_file_->PositionedAppend(data, offset);
+  IOStatus PositionedAppend(const Slice& data, uint64_t offset,
+                            const IOOptions& opts,
+                            IODebugContext* dbg) override {
+    return local_file_->PositionedAppend(data, offset, opts, dbg);
   }
-  Status Truncate(uint64_t size) override {
-    return local_file_->Truncate(size);
+  IOStatus Truncate(uint64_t size, const IOOptions& opts,
+                    IODebugContext* dbg) override {
+    return local_file_->Truncate(size, opts, dbg);
   }
-  Status Fsync() override { return local_file_->Fsync(); }
+  IOStatus Fsync(const IOOptions& opts, IODebugContext* dbg) override {
+    return local_file_->Fsync(opts, dbg);
+  }
   bool IsSyncThreadSafe() const override {
     return local_file_->IsSyncThreadSafe();
   }
@@ -74,27 +84,31 @@ class CloudStorageWritableFileImpl : public CloudStorageWritableFile {
   size_t GetRequiredBufferAlignment() const override {
     return local_file_->GetRequiredBufferAlignment();
   }
-  uint64_t GetFileSize() override { return local_file_->GetFileSize(); }
+  uint64_t GetFileSize(const IOOptions& opts, IODebugContext* dbg) override {
+    return local_file_->GetFileSize(opts, dbg);
+  }
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return local_file_->GetUniqueId(id, max_size);
   }
-  Status InvalidateCache(size_t offset, size_t length) override {
+  IOStatus InvalidateCache(size_t offset, size_t length) override {
     return local_file_->InvalidateCache(offset, length);
   }
-  Status RangeSync(uint64_t offset, uint64_t nbytes) override {
-    return local_file_->RangeSync(offset, nbytes);
+  IOStatus RangeSync(uint64_t offset, uint64_t nbytes, const IOOptions& opts,
+                     IODebugContext* dbg) override {
+    return local_file_->RangeSync(offset, nbytes, opts, dbg);
   }
-  Status Allocate(uint64_t offset, uint64_t len) override {
-    return local_file_->Allocate(offset, len);
+  IOStatus Allocate(uint64_t offset, uint64_t len, const IOOptions& opts,
+                    IODebugContext* dbg) override {
+    return local_file_->Allocate(offset, len, opts, dbg);
   }
 
-  virtual Status Flush() override {
+  IOStatus Flush(const IOOptions& opts, IODebugContext* dbg) override {
     assert(status_.ok());
-    return local_file_->Flush();
+    return local_file_->Flush(opts, dbg);
   }
-  virtual Status status() override { return status_; }
-  virtual Status Sync() override;
-  virtual Status Close() override;
+  IOStatus status() override { return status_; }
+  IOStatus Sync(const IOOptions& opts, IODebugContext* dbg) override;
+  IOStatus Close(const IOOptions& opts, IODebugContext* dbg) override;
 };
 
 // All writes to this DB can be configured to be persisted
@@ -107,44 +121,44 @@ class CloudStorageProviderImpl : public CloudStorageProvider {
 
   CloudStorageProviderImpl();
   virtual ~CloudStorageProviderImpl();
-  Status GetCloudObject(const std::string& bucket_name,
-                        const std::string& object_path,
-                        const std::string& local_destination) override;
-  virtual Status GetCloudObjectAndVersion(const std::string& bucket_name,
-                                          const std::string& object_path,
-                                          const std::string& local_destination,
-                                          std::string* version);
+  IOStatus GetCloudObject(const std::string& bucket_name,
+                          const std::string& object_path,
+                          const std::string& local_destination) override;
+  virtual IOStatus GetCloudObjectAndVersion(
+      const std::string& bucket_name, const std::string& object_path,
+      const std::string& local_destination, std::string* version);
   // check that a version of cloud object exists. Only used in tests
-  virtual Status TEST_ExistsCloudObject(const std::string& bucket_name,
-                                        const std::string& object_path,
-                                        const std::string& version) = 0;
-  Status PutCloudObject(const std::string& local_file,
-                        const std::string& bucket_name,
-                        const std::string& object_path) override;
-  Status NewCloudReadableFile(const std::string& bucket,
-                              const std::string& fname,
-                              std::unique_ptr<CloudStorageReadableFile>* result,
-                              const EnvOptions& options) override;
-  virtual Status PrepareOptions(const ConfigOptions& options) override;
+  virtual IOStatus TEST_ExistsCloudObject(const std::string& bucket_name,
+                                          const std::string& object_path,
+                                          const std::string& version) = 0;
+  IOStatus PutCloudObject(const std::string& local_file,
+                          const std::string& bucket_name,
+                          const std::string& object_path) override;
+  IOStatus NewCloudReadableFile(
+      const std::string& bucket, const std::string& fname,
+      const FileOptions& options,
+      std::unique_ptr<CloudStorageReadableFile>* result,
+      IODebugContext* dbg) override;
+  Status PrepareOptions(const ConfigOptions& options) override;
 
  protected:
   Random64 rng_;
-  virtual Status DoNewCloudReadableFile(
+  virtual IOStatus DoNewCloudReadableFile(
       const std::string& bucket, const std::string& fname, uint64_t fsize,
-      const std::string& content_hash,
+      const std::string& content_hash, const FileOptions& options,
       std::unique_ptr<CloudStorageReadableFile>* result,
-      const EnvOptions& options) = 0;
+      IODebugContext* dbg) = 0;
 
   // Downloads object from the cloud into a local directory
-  virtual Status DoGetCloudObject(const std::string& bucket_name,
-                                  const std::string& object_path,
-                                  const std::string& local_path,
-                                  uint64_t* remote_size,
-                                  std::string* version) = 0;
-  virtual Status DoPutCloudObject(const std::string& local_file,
-                                  const std::string& object_path,
-                                  const std::string& bucket_name,
-                                  uint64_t file_size) = 0;
+  virtual IOStatus DoGetCloudObject(const std::string& bucket_name,
+                                    const std::string& object_path,
+                                    const std::string& local_path,
+                                    uint64_t* remote_size,
+                                    std::string* version) = 0;
+  virtual IOStatus DoPutCloudObject(const std::string& local_file,
+                                    const std::string& object_path,
+                                    const std::string& bucket_name,
+                                    uint64_t file_size) = 0;
 
   CloudEnv* env_;
   Status status_;

--- a/cloud/db_cloud_impl.h
+++ b/cloud/db_cloud_impl.h
@@ -4,6 +4,7 @@
 
 #ifndef ROCKSDB_LITE
 #include <deque>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -42,7 +43,9 @@ class DBCloudImpl : public DBCloud {
   // Maximum manifest file size
   static const uint64_t max_manifest_file_size = 4 * 1024L * 1024L;
 
-  explicit DBCloudImpl(DB* db);
+  DBCloudImpl(DB* db, std::unique_ptr<Env> local_env);
+
+  std::unique_ptr<Env> local_env_;
 };
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // ROCKSDB_LITE

--- a/cloud/manifest_reader.h
+++ b/cloud/manifest_reader.h
@@ -31,13 +31,13 @@ class LocalManifestReader {
   // not updated when calling the function
   // REQUIRES: cloud storage has versioning enabled if manifest_file_version !=
   // nullptr
-  Status GetLiveFilesLocally(const std::string& local_dbname,
-                             std::set<uint64_t>* list,
-                             std::string* manifest_file_version = nullptr) const;
+  IOStatus GetLiveFilesLocally(
+      const std::string& local_dbname, std::set<uint64_t>* list,
+      std::string* manifest_file_version = nullptr) const;
 
  protected:
   // Get all the live sst file number by reading version_edit records from file_reader
-  Status GetLiveFilesFromFileReader(
+  IOStatus GetLiveFilesFromFileReader(
       std::unique_ptr<SequentialFileReader> file_reader,
       std::set<uint64_t>* list) const;
 
@@ -57,11 +57,13 @@ class ManifestReader: public LocalManifestReader {
   // It will read from CLOUDMANIFEST and MANIFEST file in s3 directly
   // TODO(wei): remove this function. Reading from s3 directly is very slow for
   // large MANIFEST file
-  Status GetLiveFiles(const std::string& bucket_path,
-                      std::set<uint64_t>* list) const;
+  IOStatus GetLiveFiles(const std::string& bucket_path,
+                        std::set<uint64_t>* list) const;
 
-  static Status GetMaxFileNumberFromManifest(Env* env, const std::string& fname,
-                                             uint64_t* maxFileNumber);
+  static IOStatus GetMaxFileNumberFromManifest(FileSystem* fs,
+                                               const std::string& fname,
+                                               uint64_t* maxFileNumber);
+
  private:
   std::string bucket_prefix_;
 };

--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -370,6 +370,4 @@ class CompositeEnvWrapper : public CompositeEnv {
   EnvWrapper::Target target_;
 };
 
-std::unique_ptr<FSSequentialFile> NewLegacySequentialFileWrapper(
-    std::unique_ptr<SequentialFile>& file);
 }  // namespace ROCKSDB_NAMESPACE

--- a/env/env.cc
+++ b/env/env.cc
@@ -1184,12 +1184,6 @@ const std::shared_ptr<SystemClock>& Env::GetSystemClock() const {
   return system_clock_;
 }
 
-std::unique_ptr<FSSequentialFile> NewLegacySequentialFileWrapper(
-    std::unique_ptr<SequentialFile>& file) {
-  return std::unique_ptr<FSSequentialFile>(
-      new LegacySequentialFileWrapper(std::move(file)));
-}
-
 namespace {
 static std::unordered_map<std::string, OptionTypeInfo> sc_wrapper_type_info = {
 #ifndef ROCKSDB_LITE

--- a/include/rocksdb/cloud/cloud_log_controller.h
+++ b/include/rocksdb/cloud/cloud_log_controller.h
@@ -5,48 +5,42 @@
 #include <thread>
 
 #include "rocksdb/configurable.h"
-#include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
 #include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
 class CloudEnv;
 class CloudEnvOptions;
+class Env;
 
 // Creates a new file, appends data to a file or delete an existing file via
 // logging into a cloud stream (such as Kinesis).
 //
-class CloudLogWritableFile : public WritableFile {
+class CloudLogWritableFile : public FSWritableFile {
  public:
-  CloudLogWritableFile(CloudEnv* env, const std::string& fname,
-                       const EnvOptions& options);
-  virtual ~CloudLogWritableFile();
+  CloudLogWritableFile(Env* env, CloudEnv* cloud_fs, const std::string& fname,
+                       const FileOptions& options);
 
-  virtual Status Flush() {
+  IOStatus Flush(const IOOptions& /*opts*/, IODebugContext* /*dbg*/) override {
     assert(status_.ok());
     return status_;
   }
 
-  virtual Status Sync() {
+  IOStatus Sync(const IOOptions& /*opts*/, IODebugContext* /*dbg*/) override {
     assert(status_.ok());
     return status_;
   }
 
-  virtual Status status() { return status_; }
-
-  // Appends data to the file. If the file doesn't exist, it'll get created.
-  using WritableFile::Append;
-  virtual Status Append(const Slice& data) = 0;
-
-  // Closes a file by writing an EOF marker to the Cloud stream.
-  virtual Status Close() = 0;
+  virtual IOStatus status() { return status_; }
 
   // Delete a file by logging a delete operation to the Cloud stream.
-  virtual Status LogDelete() = 0;
+  virtual IOStatus LogDelete() = 0;
 
  protected:
-  CloudEnv* env_;
-  const std::string fname_;
-  Status status_;
+  Env* env_;
+  CloudEnv* cloud_fs_;
+  std::string fname_;
+  IOStatus status_;
 };
 
 class CloudLogController : public Configurable {
@@ -63,37 +57,38 @@ class CloudLogController : public Configurable {
   virtual const char* Name() const = 0;
 
   // Create a stream to store all log files.
-  virtual Status CreateStream(const std::string& topic) = 0;
+  virtual IOStatus CreateStream(const std::string& topic) = 0;
 
   // Waits for stream to be ready (blocking).
-  virtual Status WaitForStreamReady(const std::string& topic) = 0;
+  virtual IOStatus WaitForStreamReady(const std::string& topic) = 0;
 
   // Continuously tail the cloud log stream and apply changes to
   // the local file system (blocking).
-  virtual Status TailStream() = 0;
+  virtual IOStatus TailStream() = 0;
 
   // Creates a new cloud log writable file.
-  virtual CloudLogWritableFile* CreateWritableFile(
-      const std::string& fname, const EnvOptions& options) = 0;
-
+  virtual CloudLogWritableFile* CreateWritableFile(const std::string& fname,
+                                                   const FileOptions& options,
+                                                   IODebugContext* dbg) = 0;
 
   // Directory where files are cached locally.
   virtual const std::string& GetCacheDir() const = 0;
-  virtual Status const status() const = 0;
+  virtual Status status() const = 0;
 
-  virtual Status StartTailingStream(const std::string& topic) = 0;
+  virtual IOStatus StartTailingStream(const std::string& topic) = 0;
   virtual void StopTailingStream() = 0;
-  virtual Status GetFileModificationTime(const std::string& fname,
-                                         uint64_t* time) = 0;
-  virtual Status NewSequentialFile(const std::string& fname,
-                                   std::unique_ptr<SequentialFile>* result,
-                                   const EnvOptions& options) = 0;
-  virtual Status NewRandomAccessFile(const std::string& fname,
-                                     std::unique_ptr<RandomAccessFile>* result,
-                                     const EnvOptions& options) = 0;
-  virtual Status FileExists(const std::string& fname) = 0;
-  virtual Status GetFileSize(const std::string& logical_fname,
-                             uint64_t* size) = 0;
+  virtual IOStatus GetFileModificationTime(const std::string& fname,
+                                           uint64_t* time) = 0;
+  virtual IOStatus NewSequentialFile(const std::string& fname,
+                                     const FileOptions& file_opts,
+                                     std::unique_ptr<FSSequentialFile>* result,
+                                     IODebugContext* dbg) = 0;
+  virtual IOStatus NewRandomAccessFile(
+      const std::string& fname, const FileOptions& file_opts,
+      std::unique_ptr<FSRandomAccessFile>* result, IODebugContext* dbg) = 0;
+  virtual IOStatus FileExists(const std::string& fname) = 0;
+  virtual IOStatus GetFileSize(const std::string& logical_fname,
+                               uint64_t* size) = 0;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/cloud/cloud_storage_provider.h
+++ b/include/rocksdb/cloud/cloud_storage_provider.h
@@ -5,7 +5,8 @@
 #include <unordered_map>
 
 #include "rocksdb/configurable.h"
-#include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
+#include "rocksdb/io_status.h"
 #include "rocksdb/status.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -15,17 +16,17 @@ class Logger;
 struct ColumnFamilyOptions;
 struct DBOptions;
 
-class CloudStorageReadableFile : virtual public SequentialFile,
-                                 virtual public RandomAccessFile {
+class CloudStorageReadableFile : virtual public FSSequentialFile,
+                                 virtual public FSRandomAccessFile {
  public:
   virtual const char* Name() const { return "cloud"; }
 };
 
 // Appends to a file in S3.
-class CloudStorageWritableFile : public WritableFile {
+class CloudStorageWritableFile : public FSWritableFile {
  public:
   virtual ~CloudStorageWritableFile() {}
-  virtual Status status() = 0;
+  virtual IOStatus status() = 0;
 
   virtual const char* Name() const { return "cloud"; }
 };
@@ -58,76 +59,77 @@ class CloudStorageProvider : public Configurable {
   // Returns name of the cloud storage provider type (e.g., S3)
   virtual const char* Name() const = 0;
 
-  virtual Status CreateBucket(const std::string& bucket_name) = 0;
-  virtual Status ExistsBucket(const std::string& bucket_name) = 0;
+  virtual IOStatus CreateBucket(const std::string& bucket_name) = 0;
+  virtual IOStatus ExistsBucket(const std::string& bucket_name) = 0;
 
   // Empties all contents of the associated cloud storage bucket.
-  virtual Status EmptyBucket(const std::string& bucket_name,
-                             const std::string& object_path) = 0;
+  virtual IOStatus EmptyBucket(const std::string& bucket_name,
+                               const std::string& object_path) = 0;
   // Delete the specified object from the specified cloud bucket
-  virtual Status DeleteCloudObject(const std::string& bucket_name,
-                                   const std::string& object_path) = 0;
+  virtual IOStatus DeleteCloudObject(const std::string& bucket_name,
+                                     const std::string& object_path) = 0;
 
   // Does the specified object exist in the cloud storage
   // returns all the objects that have the specified path prefix and
   // are stored in a cloud bucket
-  virtual Status ListCloudObjects(const std::string& bucket_name,
-                                  const std::string& object_path,
-                                  std::vector<std::string>* path_names) = 0;
+  virtual IOStatus ListCloudObjects(const std::string& bucket_name,
+                                    const std::string& object_path,
+                                    std::vector<std::string>* path_names) = 0;
 
   // Does the specified object exist in the cloud storage
-  virtual Status ExistsCloudObject(const std::string& bucket_name,
-                                   const std::string& object_path) = 0;
+  virtual IOStatus ExistsCloudObject(const std::string& bucket_name,
+                                     const std::string& object_path) = 0;
 
   // Get the size of the object in cloud storage
-  virtual Status GetCloudObjectSize(const std::string& bucket_name,
-                                    const std::string& object_path,
-                                    uint64_t* filesize) = 0;
+  virtual IOStatus GetCloudObjectSize(const std::string& bucket_name,
+                                      const std::string& object_path,
+                                      uint64_t* filesize) = 0;
 
   // Get the modification time of the object in cloud storage
-  virtual Status GetCloudObjectModificationTime(const std::string& bucket_name,
-                                                const std::string& object_path,
-                                                uint64_t* time) = 0;
+  virtual IOStatus GetCloudObjectModificationTime(
+      const std::string& bucket_name, const std::string& object_path,
+      uint64_t* time) = 0;
 
   // Get the metadata of the object in cloud storage
-  virtual Status GetCloudObjectMetadata(const std::string& bucket_name,
-                                        const std::string& object_path,
-                                        CloudObjectInformation* info) = 0;
+  virtual IOStatus GetCloudObjectMetadata(const std::string& bucket_name,
+                                          const std::string& object_path,
+                                          CloudObjectInformation* info) = 0;
 
   // Copy the specified cloud object from one location in the cloud
   // storage to another location in cloud storage
-  virtual Status CopyCloudObject(const std::string& src_bucket_name,
-                                 const std::string& src_object_path,
-                                 const std::string& dest_bucket_name,
-                                 const std::string& dest_object_path) = 0;
+  virtual IOStatus CopyCloudObject(const std::string& src_bucket_name,
+                                   const std::string& src_object_path,
+                                   const std::string& dest_bucket_name,
+                                   const std::string& dest_object_path) = 0;
 
   // Downloads object from the cloud into a local directory
-  virtual Status GetCloudObject(const std::string& bucket_name,
-                                const std::string& object_path,
-                                const std::string& local_path) = 0;
+  virtual IOStatus GetCloudObject(const std::string& bucket_name,
+                                  const std::string& object_path,
+                                  const std::string& local_path) = 0;
 
   // Uploads object to the cloud
-  virtual Status PutCloudObject(const std::string& local_path,
-                                const std::string& bucket_name,
-                                const std::string& object_path) = 0;
+  virtual IOStatus PutCloudObject(const std::string& local_path,
+                                  const std::string& bucket_name,
+                                  const std::string& object_path) = 0;
 
   // Updates/Sets the metadata of the object in cloud storage
-  virtual Status PutCloudObjectMetadata(
+  virtual IOStatus PutCloudObjectMetadata(
       const std::string& bucket_name, const std::string& object_path,
       const std::unordered_map<std::string, std::string>& metadata) = 0;
 
   // Create a new cloud file in the appropriate location from the input path.
   // Updates result with the file handle.
-  virtual Status NewCloudWritableFile(
+  virtual IOStatus NewCloudWritableFile(
       const std::string& local_path, const std::string& bucket_name,
-      const std::string& object_path,
+      const std::string& object_path, const FileOptions& options,
       std::unique_ptr<CloudStorageWritableFile>* result,
-      const EnvOptions& options) = 0;
+      IODebugContext* dbg) = 0;
 
   // Create a new readable cloud file, returning the file handle in result.
-  virtual Status NewCloudReadableFile(
+  virtual IOStatus NewCloudReadableFile(
       const std::string& bucket, const std::string& fname,
+      const FileOptions& options,
       std::unique_ptr<CloudStorageReadableFile>* result,
-      const EnvOptions& options) = 0;
+      IODebugContext* dbg) = 0;
 };
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
## Summary

The file system interfaces from Env are deprecated. Migrate CloudEnv and friends to FileSystem. This allows us to access FileOptions and IOOptions when creating/reading from files.

SYS-2757

## Test plan

Unit tests still pass