### PR TITLE
Add method to create a `CompositeEnv` from `(env, fs)`

### DIFF
--- a/cloud/cloud_file_system.cc
+++ b/cloud/cloud_file_system.cc
@@ -638,5 +638,11 @@ Status CloudFileSystem::NewAwsFileSystem(
 }
 #endif
 
+std::unique_ptr<Env> CloudFileSystem::NewCompositeEnv(
+    Env* env,
+    const std::shared_ptr<FileSystem>& fs) {
+  return std::make_unique<CompositeEnvWrapper>(env, fs);
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // ROCKSDB_LITE

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -166,7 +166,7 @@ class CloudTest : public testing::Test {
     ASSERT_TRUE(cimpl);
     cimpl->TEST_SetFileDeletionDelay(std::chrono::seconds(0));
     std::shared_ptr<FileSystem> fs(cfs);
-    aenv_.reset(new CompositeEnvWrapper(base_env_, std::move(fs)));
+    aenv_ = CloudFileSystem::NewCompositeEnv(base_env_, std::move(fs));
   }
 
   // Open database via the cloud interface

--- a/cloud/remote_compaction_test.cc
+++ b/cloud/remote_compaction_test.cc
@@ -106,7 +106,7 @@ class RemoteCompactionTest : public testing::Test {
     auto* cimpl = static_cast<CloudFileSystemImpl*>(afs);
     cimpl->TEST_SetFileDeletionDelay(std::chrono::seconds(0));
     std::shared_ptr<FileSystem> fs(cimpl);
-    aenv_.reset(new CompositeEnvWrapper(base_env_, std::move(fs)));
+    aenv_ = CloudFileSystem::NewCompositeEnv(base_env_, std::move(fs));
   }
 
   // Open database via the cloud interface

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -673,6 +673,13 @@ class CloudFileSystem : public FileSystem {
                                  const CloudFileSystemOptions& fs_options,
                                  const std::shared_ptr<Logger>& logger,
                                  CloudFileSystem** cfs);
+
+
+  // Creates a new Env that delegates all thread/time related
+  // calls to env, and all file operations to fs
+  static std::unique_ptr<Env> NewCompositeEnv(
+      Env* env,
+      const std::shared_ptr<FileSystem>& fs);
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
## Summary

There is no method in the public RocksDb interfaces to create an Env based on both and `Env` and a `FileSystem`.
`NewCompositeEnv` from `env.h` only takes a `FileSystem`, and uses `Env::Default` for the other argument.

## Test plan

Used new method in existing tests