### PR TITLE
[sys-4035] Add mutable cf option to disable write stall

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -848,6 +848,9 @@ ColumnFamilyData::GetWriteStallConditionAndCause(
     uint64_t num_compaction_needed_bytes,
     const MutableCFOptions& mutable_cf_options,
     const ImmutableCFOptions& immutable_cf_options) {
+  if (mutable_cf_options.disable_write_stall) {
+    return {WriteStallCondition::kNormal, WriteStallCause::kNone};
+  }
   if (!mutable_cf_options.disable_auto_flush &&
       num_unflushed_memtables >= mutable_cf_options.max_write_buffer_number) {
     return {WriteStallCondition::kStopped, WriteStallCause::kMemtableLimit};
@@ -890,10 +893,28 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
     uint64_t compaction_needed_bytes =
         vstorage->estimated_compaction_needed_bytes();
 
-    auto write_stall_condition_and_cause = GetWriteStallConditionAndCause(
-        imm()->NumNotFlushed(), vstorage->l0_delay_trigger_count(),
-        vstorage->estimated_compaction_needed_bytes(), mutable_cf_options,
-        *ioptions());
+    // NOTE: we should check lastest `mutable_cf_options_` instead of
+    // the passed `mutable_cf_options`. We want to make sure that
+    // once `disable_write_stall=true` is set, there won't be any
+    // write stall afterwards. But it's possible for async compaction jobs
+    // to install new super version with stale `mutable_cf_options`. For
+    // example:
+    // - Compaction starts with own copy of
+    // `mutable_cf_options(disable_write_stall=false)`
+    // - `SetOptions()` with `disable_write_stall=true`
+    // - Compaction finishes and calls `InstallSuperVersion` with
+    // `mutable_cf_options(disable_write_stall=true)`
+    std::pair<WriteStallCondition, ColumnFamilyData::WriteStallCause>
+        write_stall_condition_and_cause;
+    if (mutable_cf_options_.disable_write_stall) {
+      write_stall_condition_and_cause = {WriteStallCondition::kNormal,
+                                         WriteStallCause::kNone};
+    } else {
+      write_stall_condition_and_cause = GetWriteStallConditionAndCause(
+          imm()->NumNotFlushed(), vstorage->l0_delay_trigger_count(),
+          vstorage->estimated_compaction_needed_bytes(), mutable_cf_options,
+          *ioptions());
+    }
     write_stall_condition = write_stall_condition_and_cause.first;
     auto write_stall_cause = write_stall_condition_and_cause.second;
 
@@ -1301,10 +1322,10 @@ void ColumnFamilyData::InstallSuperVersion(
     // `old_superversion->mutable_cf_options.disable_auto_flush !=
     // new_superversion->mutable_cf_options.disable_auto_flush` here since
     // following sequence of actions is possible:
-    // - Flush/Compaction starts with own copy of `mutable_cf_options`
+    // - Compaction starts with own copy of `mutable_cf_options`
     // (`disable_auto_flush=true`)
     // - `SetOptions()` with `disable_auto_flush=false`
-    // - Flush/Compaction finishes and calls `InstallSuperVersion` with
+    // - Compaction finishes and calls `InstallSuperVersion` with
     // `mutable_cf_options`(`disable_auto_flush=true`)
     //
     // At this time, old_superversion has `disable_auto_flush=false` while

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -893,7 +893,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
     uint64_t compaction_needed_bytes =
         vstorage->estimated_compaction_needed_bytes();
 
-    // NOTE: we should check lastest `mutable_cf_options_` instead of
+    // NOTE: we should check latest `mutable_cf_options_` instead of
     // the passed `mutable_cf_options`. We want to make sure that
     // once `disable_write_stall=true` is set, there won't be any
     // write stall afterwards. But it's possible for async compaction jobs

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3089,7 +3089,7 @@ TEST_F(DBFlushTest, AutoCompactionBeforeEnablingFlush) {
   // created but not running yet
   // - SetOptions with disable_auto_flush=false starts
   // - SetOptions with disable_auto_flush=false done
-  // - CompactionJob continues to run and InstallSuperVersionw with old
+  // - CompactionJob continues to run and InstallSuperVersion with old
   // mutable_cf_options(disable_auto_flush=true)
   SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::BackgroundCompaction:NonTrivial:BeforeRun",

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1057,6 +1057,9 @@ class DBImpl : public DB {
   // is only for the special test of CancelledCompactions
   Status TEST_WaitForCompact(bool waitUnscheduled = false);
 
+  // Wait until all scheduled compactions are done
+  Status TEST_WaitForScheduledCompaction();
+
   // Wait for any background purge
   Status TEST_WaitForPurge();
 

--- a/db/db_impl/db_impl_debug.cc
+++ b/db/db_impl/db_impl_debug.cc
@@ -13,6 +13,7 @@
 #include "db/db_impl/db_impl.h"
 #include "db/error_handler.h"
 #include "db/periodic_work_scheduler.h"
+#include "monitoring/thread_status_updater.h"
 #include "util/cast_util.h"
 
 namespace ROCKSDB_NAMESPACE {

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -451,6 +451,191 @@ TEST_P(DBWriteTest, ConcurrentlyDisabledWAL) {
     ASSERT_LE(bytes_num, 1024 * 100);
 }
 
+TEST_P(DBWriteTest, DisableWriteStall) {
+  Options options = GetOptions();
+  options.disable_write_stall = true;
+  options.max_write_buffer_number = 2;
+  options.use_options_file = false;
+  Reopen(options);
+  db_->PauseBackgroundWork();
+  ASSERT_OK(Put("k1", "v1"));
+  FlushOptions opts;
+  opts.wait = false;
+  opts.allow_write_stall = true;
+  ASSERT_OK(db_->Flush(opts));
+  ASSERT_OK(Put("k2", "v2"));
+  ASSERT_OK(db_->Flush(opts));
+
+  // no write stall since it's disabled
+  ASSERT_OK(Put("k3", "v3"));
+
+  // now enable write stall
+  ASSERT_OK(db_->SetOptions({{"disable_write_stall", "false"}}));
+  WriteOptions wopts;
+  wopts.no_slowdown = true;
+  auto st = db_->Put(wopts, "k4", "v4");
+  EXPECT_TRUE(st.IsIncomplete());
+
+  // now disable again
+  ASSERT_OK(db_->SetOptions({{"disable_write_stall", "true"}}));
+  // no write stall since it's disabled
+  ASSERT_OK(Put("k4", "v4"));
+
+  // verify that disable write stall will unblock writes
+  ASSERT_OK(db_->SetOptions({{"disable_write_stall", "false"}}));
+
+  std::thread t([&]() {
+    // writes will be blocked due to write stall
+    // but once we disable write stall, the writes are unblocked
+    ASSERT_OK(Put("k5", "v5"));
+  });
+  // sleep to make sure t is blocked on write. Not ideal but it works
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ASSERT_OK(db_->SetOptions({{"disable_write_stall", "true"}}));
+  t.join();
+
+  Close();
+}
+
+void functionTrampoline(void* arg) {
+    (*reinterpret_cast<std::function<void()>*>(arg))();
+}
+
+// Test the case that non-trival compaction is triggered before we disable write stall
+// and make sure compaction job with old mutable_cf_options won't cause write stall
+TEST_P(DBWriteTest, AutoCompactionBeforeDisableWriteStall) {
+  const int kNumKeysPerFile = 100;
+
+  Options options;
+  options.env = env_;
+  options.use_options_file = false;
+
+  // auto flush/compaction enabled so that write stall will be triggered
+  options.disable_auto_compactions = false;
+  options.disable_auto_flush = false;
+
+  // set write buffer number to trigger write stall
+  options.max_write_buffer_number = 2;
+  options.disable_write_stall = false;
+
+  // set compaction trigger to trigger non trival auto compaction
+  options.num_levels = 3;
+  options.level0_file_num_compaction_trigger = 3;
+
+  // large write buffer size so auto flush never triggered
+  options.write_buffer_size = 10 << 20;
+
+  options.max_background_jobs = 2;
+
+  options.info_log = info_log_;
+  CreateAndReopenWithCF({"pikachu"}, options);
+
+  auto cfd = static_cast_with_check<ColumnFamilyHandleImpl>(handles_[1])->cfd();
+
+  Random rnd(301);
+
+  for (int num = 0; num < options.level0_file_num_compaction_trigger - 1;
+       num++) {
+    std::vector<std::string> values;
+    // Write 100KB (100 values, each 1K)
+    for (int i = 0; i < kNumKeysPerFile; i++) {
+      values.push_back(rnd.RandomString(990));
+      ASSERT_OK(Put(1, Key(i), values[i]));
+    }
+    ASSERT_OK(dbfull()->Flush({}, handles_[1]));
+    ASSERT_EQ(NumTableFilesAtLevel(0, 1), num + 1);
+  }
+
+  // We are trying to simulate following case:
+  // 1. non trival compaction job scheduled but not starting yet
+  // 2. continuous writes trigger flush, which generates too many memtables and
+  // stalls writes
+  // 3. disable write stall through setOption API
+  // 4. compaction job is done. Even though it installs super version with stale
+  // `mutable_cf_options`, which still has `disable_write_stall=false`, the
+  // writes are not stalled since latest `mutable_cf_options` has
+  // `disable_write_stall=true`
+  // 5. flush jobs are done
+  SyncPoint::GetInstance()->LoadDependency(
+      {{"DBImpl::BackgroundCompaction:NonTrivial:BeforeRun",
+        "DBWriteTest::CompactionBeforeDisableWriteStall:BeforeDisableWriteStall"},
+        {
+          "DBWriteTest::CompactionBeforeDisableWriteStall:AfterDisableWriteStall",
+          "CompactionJob::Run():Start"
+        }});
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  // Write one more file to trigger auto compaction
+  std::vector<std::string> values;
+  for (int i = 0; i < kNumKeysPerFile; i++) {
+    values.push_back(rnd.RandomString(990));
+    ASSERT_OK(Put(1, Key(i), values[i]));
+  }
+  ASSERT_OK(dbfull()->Flush({}, handles_[1]));
+
+  TEST_SYNC_POINT("DBWriteTest::CompactionBeforeDisableWriteStall:BeforeDisableWriteStall");
+  // writes not stalled yet
+  EXPECT_FALSE(cfd->GetSuperVersion()->mutable_cf_options.disable_write_stall);
+  EXPECT_FALSE(dbfull()
+                   ->GetVersionSet()
+                   ->GetColumnFamilySet()
+                   ->write_controller()
+                   ->IsStopped());
+
+  auto cork = std::make_shared<std::atomic<bool>>();
+  cork->store(true);
+  std::function<void()> corkFunction = [cork]() {
+    while (cork->load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  };
+
+  // schedule high priority jobs to block the flush from finishing.
+  // We can't `pauseBackgroundWork` here since that would prevent the compaction
+  // from finishing as well
+  for (int i = 0; i < 2; i++) {
+    env_->Schedule(&functionTrampoline, &corkFunction, rocksdb::Env::Priority::HIGH);
+  }
+
+  ASSERT_OK(Put(1, "k1", "v1"));
+  FlushOptions fopts;
+  fopts.wait = false;
+  fopts.allow_write_stall = true;
+  ASSERT_OK(dbfull()->Flush(fopts, handles_[1]));
+  ASSERT_OK(Put(1, "k2", "v2"));
+  // write stall condition triggered after this flush
+  ASSERT_OK(dbfull()->Flush(fopts, handles_[1]));
+  EXPECT_EQ(cfd->imm()->NumNotFlushed(), 2);
+  EXPECT_TRUE(dbfull()
+                  ->GetVersionSet()
+                  ->GetColumnFamilySet()
+                  ->write_controller()
+                  ->IsStopped());
+
+  ASSERT_OK(db_->SetOptions(
+    handles_[1], {{"disable_write_stall", "true"}}));
+
+  TEST_SYNC_POINT("DBWriteTest::CompactionBeforeDisableWriteStall:AfterDisableWriteStall");
+
+  ASSERT_OK(dbfull()->TEST_WaitForScheduledCompaction());
+  // compaction job installs super version with stale mutable_cf_options
+  EXPECT_FALSE(cfd->GetSuperVersion()->mutable_cf_options.disable_write_stall);
+  // but latest mutable_cf_options should be correctly set
+  EXPECT_TRUE(cfd->GetLatestMutableCFOptions()->disable_write_stall);
+  // and writes are not stalled!
+  EXPECT_FALSE(dbfull()->GetVersionSet()->GetColumnFamilySet()->write_controller()->IsStopped());
+
+  WriteOptions wopts;
+  wopts.no_slowdown = true;
+  EXPECT_OK(db_->Put(wopts, handles_[1], "k3", "v3"));
+
+  cork->store(false);
+  // wait for flush to be done
+  ASSERT_OK(dbfull()->TEST_WaitForBackgroundWork());
+
+  Close();
+}
+
 INSTANTIATE_TEST_CASE_P(DBWriteTestInstance, DBWriteTest,
                         testing::Values(DBTestBase::kDefault,
                                         DBTestBase::kConcurrentWALWrites,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -325,6 +325,12 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // Default: false, auto flush is enabled
   bool disable_auto_flush = false;
 
+  // No write stall will be triggered if true.
+  //
+  // Dynamically changeable through SetOptions() API
+  // Default: false, write stall will be enabled
+  bool disable_write_stall = false;
+
   // Create ColumnFamilyOptions with default values for all fields
   ColumnFamilyOptions();
   // Create ColumnFamilyOptions from Options

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -503,6 +503,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
         {"disable_auto_flush",
          {offsetof(struct MutableCFOptions, disable_auto_flush),
           OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
+        {"disable_write_stall",
+         {offsetof(struct MutableCFOptions, disable_write_stall),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}}
         // End special case properties
 };

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -154,7 +154,8 @@ struct MutableCFOptions {
         sample_for_compression(
             options.sample_for_compression),  // TODO: is 0 fine here?
         compression_per_level(options.compression_per_level),
-        disable_auto_flush(options.disable_auto_flush) {
+        disable_auto_flush(options.disable_auto_flush),
+        disable_write_stall(options.disable_write_stall) {
     RefreshDerivedOptions(options.num_levels, options.compaction_style);
   }
 
@@ -198,7 +199,8 @@ struct MutableCFOptions {
         bottommost_compression(kDisableCompressionOption),
         bottommost_temperature(Temperature::kUnknown),
         sample_for_compression(0),
-        disable_auto_flush(false) {}
+        disable_auto_flush(false),
+        disable_write_stall(false) {}
 
   explicit MutableCFOptions(const Options& options);
 
@@ -279,6 +281,7 @@ struct MutableCFOptions {
   std::vector<uint64_t> max_file_size;
 
   bool disable_auto_flush;
+  bool disable_write_stall;
 };
 
 uint64_t MultiplyCheckOverflow(uint64_t op1, double op2);

--- a/options/options.cc
+++ b/options/options.cc
@@ -416,6 +416,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
         blob_compaction_readahead_size);
     ROCKS_LOG_HEADER(log, "                     Options.disable_auto_flush: %d",
                      disable_auto_flush);
+    ROCKS_LOG_HEADER(log, "                    Options.disable_write_stall: %d",
+                     disable_write_stall);
 }  // ColumnFamilyOptions::Dump
 
 void Options::Dump(Logger* log) const {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -217,6 +217,7 @@ void UpdateColumnFamilyOptions(const MutableCFOptions& moptions,
   cf_opts->inplace_update_num_locks = moptions.inplace_update_num_locks;
   cf_opts->prefix_extractor = moptions.prefix_extractor;
   cf_opts->disable_auto_flush = moptions.disable_auto_flush;
+  cf_opts->disable_write_stall = moptions.disable_write_stall;
 
   // Compaction related options
   cf_opts->disable_auto_compactions = moptions.disable_auto_compactions;

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -250,6 +250,7 @@ TEST_F(OptionsTest, GetOptionsFromMapTest) {
   ASSERT_EQ(new_cf_opt.blob_compaction_readahead_size, 262144);
   ASSERT_EQ(new_cf_opt.bottommost_temperature, Temperature::kWarm);
   ASSERT_EQ(new_cf_opt.disable_auto_flush, false);
+  ASSERT_EQ(new_cf_opt.disable_write_stall, false);
 
   cf_options_map["write_buffer_size"] = "hello";
   ASSERT_NOK(GetColumnFamilyOptionsFromMap(exact, base_cf_opt, cf_options_map,


### PR DESCRIPTION
Added new mutable cf option: `disable_write_stall`. Once it's set as true, write stall won't be triggered. Also, if writes are already blocked by write stall, calling `setOptions` will unblock the writes.

To avoid the issue we discussed [here](https://rockset-io.slack.com/archives/C0394R37RM4/p1664442085445909?thread_ts=1664277522.453319&cid=C0394R37RM4), we have to check latest `mutable_cf_options_` when calculating the write stall condition.

- [x] Added tests to verify the new cf options