### PR TITLE
skip DisableWriteStallNotWriteManifest for pipelined write

### DIFF
--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -513,6 +513,10 @@ class DummyListener : public ReplicationLogListener {
 // verifies that when `disable_write_stall` is the only cf option we set,
 // there won't be manifest updates
 TEST_P(DBWriteTest, DisableWriteStallNotWriteManifest) {
+  // pipelined write is conflicted with atomic flush
+  if (GetParam() == kPipelinedWrite) {
+    return ;
+  }
   Options options = GetOptions();
   options.disable_write_stall = false;
   // make sure manifest update seq is bumped


### PR DESCRIPTION
We checked the manifest update seq here, which needs `atomic_flush=true` and `replication_log_listener` enabled. But `pipelined write` is conflicted with atomic flush, so skipping this for pipelined write. 

