### PR TITLE
Make "SanitizeDirectory local directory cleanup needed" INFO log

### DIFF
--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -1719,7 +1719,7 @@ IOStatus CloudFileSystemImpl::SanitizeDirectory(const DBOptions& options,
         local_name.c_str());
     return IOStatus::OK();
   }
-  Log(InfoLogLevel::ERROR_LEVEL, info_log_,
+  Log(InfoLogLevel::INFO_LEVEL, info_log_,
       "[cloud_fs_impl] SanitizeDirectory local directory %s cleanup needed",
       local_name.c_str());
 


### PR DESCRIPTION
We see it continuously in logs, which is confusing while debugging. It isn't an error condition