### PR TITLE
[SYS-4270] Fix memory leak in AwsFileSystem

### DIFF
--- a/cloud/aws/aws_file_system.cc
+++ b/cloud/aws/aws_file_system.cc
@@ -7,7 +7,6 @@
 #include <cinttypes>
 #include <fstream>
 #include <iostream>
-#include <memory>
 #include <set>
 
 #include "cloud/cloud_log_controller_impl.h"
@@ -200,8 +199,7 @@ Status AwsCloudAccessCredentials::GetCredentialsProvider(
 AwsFileSystem::AwsFileSystem(const std::shared_ptr<FileSystem>& underlying_fs,
                              const CloudFileSystemOptions& _cloud_fs_options,
                              const std::shared_ptr<Logger>& info_log)
-    : CloudFileSystemImpl(_cloud_fs_options, underlying_fs, info_log) {
-  Aws::InitAPI(Aws::SDKOptions());
+    : CloudFileSystemImpl(_cloud_fs_options, underlying_fs, info_log), awsGuard_(useAWS()) {
 }
 
 // If you do not specify a region, then S3 buckets are created in the

--- a/cloud/aws/aws_file_system.cc
+++ b/cloud/aws/aws_file_system.cc
@@ -7,6 +7,7 @@
 #include <cinttypes>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <set>
 
 #include "cloud/cloud_log_controller_impl.h"
@@ -174,7 +175,7 @@ Status AwsCloudAccessCredentials::GetCredentialsProvider(
 AwsFileSystem::AwsFileSystem(const std::shared_ptr<FileSystem>& underlying_fs,
                              const CloudFileSystemOptions& _cloud_fs_options,
                              const std::shared_ptr<Logger>& info_log)
-    : CloudFileSystemImpl(_cloud_fs_options, underlying_fs, info_log), awsGuard_(useAWS()) {
+    : CloudFileSystemImpl(_cloud_fs_options, underlying_fs, info_log) {
 }
 
 // If you do not specify a region, then S3 buckets are created in the

--- a/cloud/aws/aws_file_system.cc
+++ b/cloud/aws/aws_file_system.cc
@@ -32,31 +32,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-std::shared_ptr<void> useAWS() {
-    static std::mutex gMutex;
-    static std::weak_ptr<void> gInstance;
-
-    std::lock_guard lock(gMutex);
-
-    auto existing = gInstance.lock();
-    if (existing) {
-        return existing;
-    }
-
-    Aws::InitAPI(Aws::SDKOptions());
-
-    // No need to actually allocate or delete real memory
-    static bool dummy;
-
-    auto rv = std::shared_ptr<void>(&dummy, [](bool*) {
-        // Shut down AWS API.
-        Aws::ShutdownAPI(Aws::SDKOptions());
-    });
-
-    gInstance = rv;
-    return rv;
-}
-
 static const std::unordered_map<std::string, AwsAccessType> AwsAccessTypeMap = {
     {"undefined", AwsAccessType::kUndefined},
     {"simple", AwsAccessType::kSimple},

--- a/cloud/aws/aws_file_system.cc
+++ b/cloud/aws/aws_file_system.cc
@@ -209,8 +209,6 @@ Status AwsFileSystem::PrepareOptions(const ConfigOptions& options) {
   return CloudFileSystemImpl::PrepareOptions(options);
 }
 
-void AwsFileSystem::Shutdown() { Aws::ShutdownAPI(Aws::SDKOptions()); }
-
 // The factory method for creating an S3 Env
 Status AwsFileSystem::NewAwsFileSystem(
     const std::shared_ptr<FileSystem>& base_fs,

--- a/cloud/aws/aws_file_system.h
+++ b/cloud/aws/aws_file_system.h
@@ -19,6 +19,12 @@
 #include <unordered_map>
 
 namespace ROCKSDB_NAMESPACE {
+
+// Initializes AWS, or joins an existing initialization. Keep the
+// returned shared_ptr alive for as long as you will be using AWS
+// operations
+std::shared_ptr<void> useAWS();
+
 //
 // The S3 environment for rocksdb. This class overrides all the
 // file/dir access methods and delegates all other methods to the

--- a/cloud/aws/aws_file_system.h
+++ b/cloud/aws/aws_file_system.h
@@ -21,11 +21,6 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-// Initializes AWS, or joins an existing initialization. Keep the
-// returned shared_ptr alive for as long as you will be using AWS
-// operations
-std::shared_ptr<void> useAWS();
-
 //
 // The S3 environment for rocksdb. This class overrides all the
 // file/dir access methods and delegates all other methods to the

--- a/cloud/aws/aws_file_system.h
+++ b/cloud/aws/aws_file_system.h
@@ -7,7 +7,6 @@
 
 #include <algorithm>
 #include <iostream>
-#include <memory>
 
 #include "cloud/cloud_file_system_impl.h"
 
@@ -20,7 +19,6 @@
 #include <unordered_map>
 
 namespace ROCKSDB_NAMESPACE {
-
 //
 // The S3 environment for rocksdb. This class overrides all the
 // file/dir access methods and delegates all other methods to the
@@ -78,8 +76,6 @@ class AwsFileSystem : public CloudFileSystemImpl {
   explicit AwsFileSystem(const std::shared_ptr<FileSystem>& underlying_fs,
                          const CloudFileSystemOptions& cloud_options,
                          const std::shared_ptr<Logger>& info_log = nullptr);
-
-  std::shared_ptr<void> awsGuard_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/cloud/aws/aws_file_system.h
+++ b/cloud/aws/aws_file_system.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <memory>
 
 #include "cloud/cloud_file_system_impl.h"
 
@@ -82,6 +83,8 @@ class AwsFileSystem : public CloudFileSystemImpl {
   explicit AwsFileSystem(const std::shared_ptr<FileSystem>& underlying_fs,
                          const CloudFileSystemOptions& cloud_options,
                          const std::shared_ptr<Logger>& info_log = nullptr);
+
+  std::shared_ptr<void> awsGuard_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/cloud/aws/aws_file_system.h
+++ b/cloud/aws/aws_file_system.h
@@ -42,6 +42,10 @@ namespace ROCKSDB_NAMESPACE {
 // AwsFileSystem internally share PosixFileSystem for sharing common file system
 // resources.
 //
+// NOTE: The AWS SDK must be initialized before any AwsFileSystem is
+// constructed, and remain active (Aws::ShutdownAPI() not called) as long as any
+// AwsFileSystem objects exist.
+//
 class AwsFileSystem : public CloudFileSystemImpl {
  public:
   // A factory method for creating S3 envs
@@ -55,12 +59,6 @@ class AwsFileSystem : public CloudFileSystemImpl {
 
   static const char* kName() { return kAws(); }
   const char* Name() const override { return kAws(); }
-
-  // We cannot invoke Aws::ShutdownAPI from the destructor because there could
-  // be multiple AwsFileSystem's ceated by a process and Aws::ShutdownAPI should
-  // be called only once by the entire process when all AwsFileSystem are
-  // destroyed.
-  static void Shutdown();
 
   Status PrepareOptions(const ConfigOptions& options) override;
   // If you do not specify a region, then S3 buckets are created in the

--- a/cloud/cloud_file_system.cc
+++ b/cloud/cloud_file_system.cc
@@ -453,7 +453,7 @@ Status CloudFileSystemOptions::Serialize(const ConfigOptions& config_options,
 CloudFileSystem::CloudFileSystem(const CloudFileSystemOptions& options,
                                  const std::shared_ptr<FileSystem>& base,
                                  const std::shared_ptr<Logger>& logger)
-    : cloud_fs_options(options), base_fs_(base), info_log_(logger) {
+    : awsGuard_(useAWS()), cloud_fs_options(options), base_fs_(base), info_log_(logger) {
   RegisterOptions(&cloud_fs_options, &cloud_fs_option_type_info);
 }
 

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -3281,7 +3281,10 @@ TEST_F(CloudTest, ReplayCloudManifestDeltaTest) {
 // A black-box test for the cloud wrapper around rocksdb
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  Aws::InitAPI(Aws::SDKOptions());
+  auto r = RUN_ALL_TESTS();
+  Aws::ShutdownAPI(Aws::SDKOptions());
+  return r;
 }
 
 #else  // USE_AWS

--- a/cloud/remote_compaction_test.cc
+++ b/cloud/remote_compaction_test.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cinttypes>
+#include <aws/core/Aws.h>
 
 #include "cloud/cloud_file_system_impl.h"
 #include "cloud/db_cloud_impl.h"
@@ -513,7 +514,10 @@ TEST_F(RemoteCompactionTest, ColumnFamilyTest) {
 // Run all pluggable compaction tests
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  Aws::InitAPI(Aws::SDKOptions());
+  auto r = RUN_ALL_TESTS();
+  Aws::ShutdownAPI(Aws::SDKOptions());
+  return r;
 }
 
 #else  // USE_AWS

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -508,6 +508,9 @@ struct CloudManifestDelta {
 //
 class CloudFileSystem : public FileSystem {
  protected:
+  // awsGuard_ must be declared before cloud_fs_options so that the AWS SDK is
+  // not shut down until after we have destroyed AWS-related resources.
+  std::shared_ptr<void> awsGuard_;
   CloudFileSystemOptions cloud_fs_options;
   std::shared_ptr<FileSystem> base_fs_;  // The underlying file system
 

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -26,6 +26,13 @@ class S3Client;
 
 namespace ROCKSDB_NAMESPACE {
 
+#ifdef USE_AWS
+// Initializes AWS, or joins an existing initialization. Keep the
+// returned shared_ptr alive for as long as you will be using AWS
+// operations
+std::shared_ptr<void> useAWS();
+#endif
+
 class CloudFileSystem;
 class CloudLogController;
 class CloudStorageProvider;

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -26,13 +26,6 @@ class S3Client;
 
 namespace ROCKSDB_NAMESPACE {
 
-#ifdef USE_AWS
-// Initializes AWS, or joins an existing initialization. Keep the
-// returned shared_ptr alive for as long as you will be using AWS
-// operations
-std::shared_ptr<void> useAWS();
-#endif
-
 class CloudFileSystem;
 class CloudLogController;
 class CloudStorageProvider;
@@ -508,9 +501,6 @@ struct CloudManifestDelta {
 //
 class CloudFileSystem : public FileSystem {
  protected:
-  // awsGuard_ must be declared before cloud_fs_options so that the AWS SDK is
-  // not shut down until after we have destroyed AWS-related resources.
-  std::shared_ptr<void> awsGuard_;
   CloudFileSystemOptions cloud_fs_options;
   std::shared_ptr<FileSystem> base_fs_;  // The underlying file system
 

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -499,6 +499,9 @@ struct CloudManifestDelta {
 //
 // The Cloud file system
 //
+// NOTE: The AWS SDK must be initialized before the CloudFileSystem is
+// constructed, and remain active (Aws::ShutdownAPI() not called) as long as any
+// CloudFileSystem objects exist.
 class CloudFileSystem : public FileSystem {
  protected:
   CloudFileSystemOptions cloud_fs_options;


### PR DESCRIPTION
See https://linear.app/rockset/issue/SYS-4270/potential-memory-leak-of-remote-compactors

InitAPI must be called only once, not on every creation of an AwsEnv.