### PR TITLE
[sys-4244] Add function to bump manifest update sequence in manifest file

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -339,6 +339,7 @@ class DBImpl : public DB {
       const ReplicationLogRecord& record, std::string* out) const override;
   Status GetPersistedReplicationSequence(std::string* out) override;
   Status GetManifestUpdateSequence(uint64_t* out) override;
+  Status BumpManifestUpdateSequence(uint64_t* out) override;
 
   using DB::SetOptions;
   Status SetOptions(

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3248,6 +3248,9 @@ class ModelDB : public DB {
   Status GetManifestUpdateSequence(uint64_t* /*out*/) override {
     return Status::NotSupported("Not supported in Model DB");
   }
+  Status BumpManifestUpdateSequence(uint64_t* /*out*/) override {
+    return Status::NotSupported("Not supported in Model DB");
+  }
   Status GetReplicationRecordDebugString(const ReplicationLogRecord& /* record */,
                                          std::string* /* out */) const override {
     return Status::NotSupported("Not supported in Model DB");

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1284,6 +1284,12 @@ class DB {
   virtual Status GetPersistedReplicationSequence(std::string* out) = 0;
   // Returns latest ManifestUpdateSequence.
   virtual Status GetManifestUpdateSequence(uint64_t* out) = 0;
+  // Increase the manifest update sequence by 1. The MUS in manifest file will
+  // be updated as well.
+  //
+  // Returns ManifestUpdateSequence after the bump
+  // REQUIRES: `replication_log_listener` set
+  virtual Status BumpManifestUpdateSequence(uint64_t* out) = 0;
 
   // Dynamically change column family options or table factory options in a
   // running DB, for the specified column family. Only options internally

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -494,6 +494,9 @@ class StackableDB : public DB {
   Status GetManifestUpdateSequence(uint64_t* out) override {
     return db_->GetManifestUpdateSequence(out);
   }
+  Status BumpManifestUpdateSequence(uint64_t* out) override {
+    return db_->BumpManifestUpdateSequence(out);
+  }
 
   using DB::SetOptions;
   virtual Status SetOptions(ColumnFamilyHandle* column_family_handle,


### PR DESCRIPTION
In leader follower, we have the assumption that there should be at lease one `kManifestWrite` for each epoch (necessary for the divergence check).  To help maintain this assumption, we add one function which just applies a dummy `VersionEdit` and bumps the MUS.  This is necessary to support readonly mode for leader follower, in which case, there is no other manifest writes.

- [x] tested by running db_cloud_test and the newly added test