### PR TITLE
[SYS-4401] Fix disable_write_stall

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1342,7 +1342,9 @@ void ColumnFamilyData::InstallSuperVersion(
   super_version_->version_number = super_version_number_;
   if (old_superversion == nullptr || old_superversion->current != current() ||
       old_superversion->mem != mem_ ||
-      old_superversion->imm != imm_.current()) {
+      old_superversion->imm != imm_.current() ||
+      old_superversion->mutable_cf_options.disable_write_stall !=
+          mutable_cf_options.disable_write_stall) {
     // Should not recalculate slow down condition if nothing has changed, since
     // currently RecalculateWriteStallConditions() treats it as further slowing
     // down is needed.

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3410,7 +3410,6 @@ TEST_F(DBFlushTest, NoStopWritesWhenAutoFlushDisabled) {
   Close();
 }
 
-#if 0 // RocksDB-Cloud disabled
 TEST_P(DBAtomicFlushTest, NoWaitWhenWritesStopped) {
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
@@ -3448,7 +3447,6 @@ TEST_P(DBAtomicFlushTest, NoWaitWhenWritesStopped) {
 
   SyncPoint::GetInstance()->DisableProcessing();
 }
-#endif
 
 INSTANTIATE_TEST_CASE_P(DBFlushDirectIOTest, DBFlushDirectIOTest,
                         testing::Bool());

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2022,15 +2022,12 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
   // This method should not be called if atomic_flush is true.
   assert(!immutable_db_options_.atomic_flush);
   assert(!immutable_db_options_.replication_log_listener);
-
-#if 0 // RocksDB-Cloud disabled
   if (!flush_options.wait && write_controller_.IsStopped()) {
     std::ostringstream oss;
     oss << "Writes have been stopped, thus unable to perform manual flush. "
            "Please try again later after writes are resumed";
     return Status::TryAgain(oss.str());
   }
-#endif
   Status s;
   if (!flush_options.allow_write_stall) {
     bool flush_needed = true;
@@ -2171,14 +2168,12 @@ Status DBImpl::AtomicFlushMemTables(
     const FlushOptions& flush_options, FlushReason flush_reason,
     bool entered_write_thread) {
   assert(immutable_db_options_.atomic_flush);
-#if 0 // RocksDB-Cloud disabled
   if (!flush_options.wait && write_controller_.IsStopped()) {
     std::ostringstream oss;
     oss << "Writes have been stopped, thus unable to perform manual flush. "
            "Please try again later after writes are resumed";
     return Status::TryAgain(oss.str());
   }
-#endif
   Status s;
   if (!flush_options.allow_write_stall) {
     int num_cfs_to_flush = 0;


### PR DESCRIPTION
Summary:
A change was made in
https://github.com/rockset/rocksdb-cloud/commit/61152544166ecf9fd50f90ad190561e5b11ccf55
to avoid recalculating write stall condition is the conditions didn't
change. In RocksDB-Cloud, we have an additional disable_write_stall that
influences write stall conditions, so we need an additional check.

This PR additionally removes the revert of
https://github.com/rockset/rocksdb-cloud/commit/edda219fc3 in
RocksDB-Cloud. We should strive for a match with RocksDB as much as
possible, and we'll change our higher-level code to account for the
change in semantics.

Test Plan:
DBWriteTest.DisableWriteStall was actually broken, this PR fixes it.

Reviewers:
