### PR TITLE
[SYS-4401] Don't fail the flush if writes are stalled

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3410,6 +3410,7 @@ TEST_F(DBFlushTest, NoStopWritesWhenAutoFlushDisabled) {
   Close();
 }
 
+#if 0 // RocksDB-Cloud disabled
 TEST_P(DBAtomicFlushTest, NoWaitWhenWritesStopped) {
   Options options = GetDefaultOptions();
   options.create_if_missing = true;
@@ -3447,6 +3448,7 @@ TEST_P(DBAtomicFlushTest, NoWaitWhenWritesStopped) {
 
   SyncPoint::GetInstance()->DisableProcessing();
 }
+#endif
 
 INSTANTIATE_TEST_CASE_P(DBFlushDirectIOTest, DBFlushDirectIOTest,
                         testing::Bool());

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2022,12 +2022,15 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
   // This method should not be called if atomic_flush is true.
   assert(!immutable_db_options_.atomic_flush);
   assert(!immutable_db_options_.replication_log_listener);
+
+#if 0 // RocksDB-Cloud disabled
   if (!flush_options.wait && write_controller_.IsStopped()) {
     std::ostringstream oss;
     oss << "Writes have been stopped, thus unable to perform manual flush. "
            "Please try again later after writes are resumed";
     return Status::TryAgain(oss.str());
   }
+#endif
   Status s;
   if (!flush_options.allow_write_stall) {
     bool flush_needed = true;
@@ -2168,12 +2171,14 @@ Status DBImpl::AtomicFlushMemTables(
     const FlushOptions& flush_options, FlushReason flush_reason,
     bool entered_write_thread) {
   assert(immutable_db_options_.atomic_flush);
+#if 0 // RocksDB-Cloud disabled
   if (!flush_options.wait && write_controller_.IsStopped()) {
     std::ostringstream oss;
     oss << "Writes have been stopped, thus unable to perform manual flush. "
            "Please try again later after writes are resumed";
     return Status::TryAgain(oss.str());
   }
+#endif
   Status s;
   if (!flush_options.allow_write_stall) {
     int num_cfs_to_flush = 0;


### PR DESCRIPTION
This was a feature from the upstream RocksDB that was hard to adapt to
in our upper layer code, so here we just disable it.
