### PR TITLE
Adding check that logs_ is also empty when checking for empty WAL buffer

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1818,6 +1818,11 @@ bool DBImpl::WALBufferIsEmpty(bool lock) {
   if (lock) {
     log_write_mutex_.Lock();
   }
+  
+  if (logs_.empty()) {
+    return true;
+  }
+    
   log::Writer* cur_log_writer = logs_.back().writer;
   auto res = cur_log_writer->BufferIsEmpty();
   if (lock) {


### PR DESCRIPTION
If we’re checking something is empty shouldn’t we check that logs_ is also not empty