### PR TITLE
[sys-4870] set next file num for memtable switch event on follower

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1318,6 +1318,11 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
           }
         }
 
+        // `next_log_number` is allocated by bumping `next_file_number`. We need
+        // to set file number to make sure follower's file number is
+        // consistent with leader. Otherwise, file number might be reused when follower
+        // tries to take over after memtable switch event.
+        versions_->SetNextFileNumber(mem_switch_record.next_log_num + 1);
         break;
       }
       case ReplicationLogRecord::kManifestWrite: {


### PR DESCRIPTION
Make sure file number is consistent between leader and follower for memtable switch event. This is important since otherwise follower which takes over after memtable switch could potentially reuse existing file number to create new sst files. Currently we get around this issue since we limit max number of memtables to 2.

NOTE: even after this change, we can still run into inconsistent file number between leader and follower when a follower tries to roll manifest file after applying `kManifestWrite`. This will cause follower's next file number to be greater than leader's next file number. I think this is fine since:
1) next time we apply `kMemSwitch` or `kManifestWrite`, we will reset file number.
2) it's ok for manifest file to have the same file number as sst files
3) follower's file number will always be >= leader's file number (so we won't reuse same file number for sst files).

Will add more tests in rockset as well.

