### PR TITLE
[sys-4870] make sure file number won't go backwards

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1320,9 +1320,12 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
 
         // `next_log_number` is allocated by bumping `next_file_number`. We need
         // to set file number to make sure follower's file number is
-        // consistent with leader. Otherwise, file number might be reused when follower
-        // tries to take over after memtable switch event.
-        versions_->SetNextFileNumber(mem_switch_record.next_log_num + 1);
+        // consistent with leader. Otherwise, file number might be reused when
+        // follower tries to take over after memtable switch event.
+        if (mem_switch_record.next_log_num >=
+            versions_->current_next_file_number()) {
+          versions_->SetNextFileNumber(mem_switch_record.next_log_num + 1);
+        }
         break;
       }
       case ReplicationLogRecord::kManifestWrite: {


### PR DESCRIPTION
When a follower shard tries to recover based on local log, it's possible for it to apply memtable switch record with log number much smaller than `next_file_number`. We need to make sure `next_file_number` on follower shard doesn't go backwards for this case.

We don't have this issue for manifest write since if a manifest write has been applied (by checking manifest update sequence), we never apply it again.

# TEST
- [x] Added test to verify that file number doesn't go backwards if memtable switch record is applied again