### PR TITLE
[sys-4900] only entries evicted from lru list are freed

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -35,6 +35,8 @@ LRUHandleTable::~LRUHandleTable() {
   ApplyToEntriesRange(
       [](LRUHandle* h) {
         if (!h->HasRefs()) {
+          h->prev = nullptr;
+          h->next = nullptr;
           h->Free();
         }
       },

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -212,6 +212,9 @@ struct LRUHandle {
 
   void Free() {
     assert(refs == 0);
+    if (prev != nullptr || next != nullptr) {
+      std::terminate();
+    }
 
     if (!IsSecondaryCacheCompatible() && info_.deleter) {
       (*info_.deleter)(key(), value);


### PR DESCRIPTION
We noticed that sometimes evicted entries from lru list don't have the right `helper`. I guess this happens when an entry is freed while it's still in LRU list, so next time it's evicted it causes the sigsegv. 

I added the null check to make sure only evicted entries from lru list are freed. This will make it to crash earlier and easier to debug.

## TEST
- [x] lru_cache_test
- [x] rockset test