### PR TITLE
Revert "[sys-4900] only entries evicted from lru list are freed"

### DIFF
--- a/cache/lru_cache.cc
+++ b/cache/lru_cache.cc
@@ -35,8 +35,6 @@ LRUHandleTable::~LRUHandleTable() {
   ApplyToEntriesRange(
       [](LRUHandle* h) {
         if (!h->HasRefs()) {
-          h->prev = nullptr;
-          h->next = nullptr;
           h->Free();
         }
       },

--- a/cache/lru_cache.h
+++ b/cache/lru_cache.h
@@ -212,9 +212,6 @@ struct LRUHandle {
 
   void Free() {
     assert(refs == 0);
-    if (prev != nullptr || next != nullptr) {
-      std::terminate();
-    }
 
     if (!IsSecondaryCacheCompatible() && info_.deleter) {
       (*info_.deleter)(key(), value);


### PR DESCRIPTION
Reverts rockset/rocksdb-cloud#255

It doesn't seem to be caused by freeing an lru handle while it's in the lru list.