### PR TITLE
[sys-4993] don't apply manifest writes if allow_new_manifest_write is false

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -402,6 +402,7 @@ class DBImpl : public DB {
   Status ApplyReplicationLogRecord(
       ReplicationLogRecord record, std::string replication_sequence,
       CFOptionsFactory cf_options_factory,
+      bool allow_new_manifest_writes,
       ApplyReplicationLogRecordInfo* info) override;
   Status GetReplicationRecordDebugString(
       const ReplicationLogRecord& record, std::string* out) const override;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3397,6 +3397,7 @@ class ModelDB : public DB {
   Status ApplyReplicationLogRecord(
       ReplicationLogRecord /*record*/, std::string /*replication_sequence*/,
       CFOptionsFactory /* cf_options_factory */,
+      bool /* allow_new_manifest_writes */,
       ApplyReplicationLogRecordInfo* /*info*/) override {
     return Status::NotSupported("Not supported in Model DB");
   }

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -500,9 +500,11 @@ class StackableDB : public DB {
   Status ApplyReplicationLogRecord(
       ReplicationLogRecord record, std::string replication_sequence,
       CFOptionsFactory cf_options_factory,
+      bool allow_new_manifest_writes,
       ApplyReplicationLogRecordInfo* info) override {
-    return db_->ApplyReplicationLogRecord(record, replication_sequence,
-                                          std::move(cf_options_factory), info);
+    return db_->ApplyReplicationLogRecord(
+        record, replication_sequence, std::move(cf_options_factory),
+        allow_new_manifest_writes, info);
   }
   Status GetReplicationRecordDebugString(const ReplicationLogRecord& record,
                                          std::string* out) const override {


### PR DESCRIPTION
Added new parameter: `allow_new_manifest_write` to `ApplyReplicationEvents`. If it's false, new manifest writes after DB's manifest update sequence won't be applied. 

This is useful to help detect local log divergence without applying the extra manifest writes.


## TEST
- [x] Added test to verify this works as expected
- [ ] Use in rockset