### PR TITLE
[sys-4675] new option to set custom cloud file deletion scheduler

### DIFF
--- a/cloud/cloud_file_deletion_scheduler.h
+++ b/cloud/cloud_file_deletion_scheduler.h
@@ -1,40 +1,35 @@
 //  Copyright (c) 2016-present, Rockset, Inc.  All rights reserved.
 
 #pragma once
-#include <chrono>
+#include "rocksdb/cloud/cloud_file_system.h"
 #include "util/mutexlock.h"
 
 namespace ROCKSDB_NAMESPACE {
 class CloudScheduler;
 
 // schedule/unschedule file deletion jobs
-class CloudFileDeletionScheduler
-    : public std::enable_shared_from_this<CloudFileDeletionScheduler> {
+class DefaultCloudFileDeletionScheduler
+    : public CloudFileDeletionScheduler,
+      public std::enable_shared_from_this<DefaultCloudFileDeletionScheduler> {
   struct PrivateTag {};
 
  public:
   static std::shared_ptr<CloudFileDeletionScheduler> Create(
-      const std::shared_ptr<CloudScheduler>& scheduler,
-      std::chrono::seconds file_deletion_delay);
+      const std::shared_ptr<CloudScheduler>& scheduler);
 
-  explicit CloudFileDeletionScheduler(
-      PrivateTag, const std::shared_ptr<CloudScheduler>& scheduler,
-      std::chrono::seconds file_deletion_delay)
-      : scheduler_(scheduler), file_deletion_delay_(file_deletion_delay) {}
+  explicit DefaultCloudFileDeletionScheduler(
+      PrivateTag, const std::shared_ptr<CloudScheduler>& scheduler)
+      : scheduler_(scheduler) {}
 
-  ~CloudFileDeletionScheduler();
+  ~DefaultCloudFileDeletionScheduler();
 
-  void UnscheduleFileDeletion(const std::string& filename);
+  void UnscheduleFileDeletion(const std::string& filename) override;
   using FileDeletionRunnable = std::function<void()>;
   // Schedule the file deletion runnable(which actually delets the file from
   // cloud) to be executed in the future (specified by `file_deletion_delay_`).
   rocksdb::IOStatus ScheduleFileDeletion(const std::string& filename,
-                                         FileDeletionRunnable runnable);
-
-  void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
-    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-    file_deletion_delay_ = delay;
-  }
+                                         FileDeletionRunnable runnable,
+                                         std::chrono::seconds delay) override;
 
   // Return all the files that are scheduled to be deleted(but not deleted yet)
   std::vector<std::string> TEST_FilesToDelete() const {
@@ -54,7 +49,6 @@ class CloudFileDeletionScheduler
 
   mutable std::mutex files_to_delete_mutex_;
   std::unordered_map<std::string, int> files_to_delete_;
-  std::chrono::seconds file_deletion_delay_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/cloud/cloud_file_system_impl.h
+++ b/cloud/cloud_file_system_impl.h
@@ -18,7 +18,6 @@ namespace ROCKSDB_NAMESPACE {
 class CloudScheduler;
 class CloudStorageReadableFile;
 class ObjectLibrary;
-class CloudFileDeletionScheduler;
 
 //
 // The Cloud file system
@@ -402,6 +401,7 @@ class CloudFileSystemImpl : public CloudFileSystem {
   // scratch space in local dir
   static constexpr const char* SCRATCH_LOCAL_DIR = "/tmp";
   std::shared_ptr<CloudFileDeletionScheduler> cloud_file_deletion_scheduler_;
+  std::chrono::seconds file_deletion_delay_{std::chrono::hours(1)};
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
Added a new option so that we can provide our own customized `CloudFileDeletionScheduler`. Main goal here is to use our own cron executor to replace the `CloudScheduler`. 


## TESTS
- [x] db_cloud_test
