### PR TITLE
[sys-4675] Don't schedule file deletions if delay not set

### DIFF
--- a/cloud/cloud_file_deletion_scheduler.cc
+++ b/cloud/cloud_file_deletion_scheduler.cc
@@ -78,4 +78,11 @@ void CloudFileDeletionScheduler::DoDeleteFile(const std::string& fname,
 
   runnable();
 }
+
+#ifndef NDEBUG
+size_t CloudFileDeletionScheduler::TEST_NumScheduledJobs() const {
+  return scheduler_->TEST_NumScheduledJobs();
+}
+#endif
+
 }

--- a/cloud/cloud_file_deletion_scheduler.h
+++ b/cloud/cloud_file_deletion_scheduler.h
@@ -31,10 +31,8 @@ class CloudFileDeletionScheduler
   rocksdb::IOStatus ScheduleFileDeletion(const std::string& filename,
                                          FileDeletionRunnable runnable);
 
-  void TEST_SetFileDeletionDelay(std::chrono::seconds delay) {
-    std::lock_guard<std::mutex> lk(files_to_delete_mutex_);
-    file_deletion_delay_ = delay;
-  }
+#ifndef NDEBUG
+  size_t TEST_NumScheduledJobs() const;
 
   // Return all the files that are scheduled to be deleted(but not deleted yet)
   std::vector<std::string> TEST_FilesToDelete() const {
@@ -46,6 +44,7 @@ class CloudFileDeletionScheduler
     }
     return files;
   }
+#endif
 
  private:
   // execute the `FileDeletionRunnable`

--- a/cloud/cloud_file_system.cc
+++ b/cloud/cloud_file_system.cc
@@ -80,8 +80,10 @@ void CloudFileSystemOptions::Dump(Logger* log) const {
          new_cookie_on_open.c_str());
   Header(log, "COptions.delete_cloud_invisible_files_on_open: %d",
          delete_cloud_invisible_files_on_open);
-  Header(log, "          COptions.cloud_file_deletion_delay: %ld",
-         cloud_file_deletion_delay.count());
+  if (cloud_file_deletion_delay) {
+    Header(log, "          COptions.cloud_file_deletion_delay: %ld",
+           cloud_file_deletion_delay->count());
+  }
   if (sst_file_cache != nullptr) {
     Header(log, "           COptions.sst_file_cache size: %ld bytes",
            sst_file_cache->GetCapacity());

--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -33,9 +33,10 @@ CloudFileSystemImpl::CloudFileSystemImpl(
     const CloudFileSystemOptions& opts, const std::shared_ptr<FileSystem>& base,
     const std::shared_ptr<Logger>& l)
     : CloudFileSystem(opts, base, l), purger_is_running_(true) {
-  scheduler_ = CloudScheduler::Get();
-  cloud_file_deletion_scheduler_ =
-      CloudFileDeletionScheduler::Create(scheduler_, opts.cloud_file_deletion_delay);
+  if (opts.cloud_file_deletion_delay) {
+    cloud_file_deletion_scheduler_ = CloudFileDeletionScheduler::Create(
+        CloudScheduler::Get(), *opts.cloud_file_deletion_delay);
+  }
 }
 
 CloudFileSystemImpl::~CloudFileSystemImpl() {
@@ -786,19 +787,13 @@ IOStatus CloudFileSystemImpl::DeleteFile(const std::string& logical_fname,
   return st;
 }
 
-void CloudFileSystemImpl::RemoveFileFromDeletionQueue(
-    const std::string& filename) {
-  cloud_file_deletion_scheduler_->UnscheduleFileDeletion(filename);
-}
-
-void CloudFileSystemImpl::TEST_SetFileDeletionDelay(
-    std::chrono::seconds delay) {
-  cloud_file_deletion_scheduler_->TEST_SetFileDeletionDelay(delay);
-}
-
 IOStatus CloudFileSystemImpl::CopyLocalFileToDest(
     const std::string& local_name, const std::string& dest_name) {
-  RemoveFileFromDeletionQueue(basename(local_name));
+  if (cloud_file_deletion_scheduler_) {
+    // Remove file from deletion queue
+    cloud_file_deletion_scheduler_->UnscheduleFileDeletion(
+        basename(local_name));
+  }
   return GetStorageProvider()->PutCloudObject(local_name, GetDestBucketName(),
                                               dest_name);
 }
@@ -809,27 +804,31 @@ IOStatus CloudFileSystemImpl::DeleteCloudFileFromDest(
   auto base = basename(fname);
   auto path = GetDestObjectPath() + pathsep + base;
   auto bucket = GetDestBucketName();
-  std::weak_ptr<Logger> info_log_wp = info_log_;
-  std::weak_ptr<CloudStorageProvider> storage_provider_wp =
-      GetStorageProvider();
-  auto file_deletion_runnable =
-      [path = std::move(path), bucket = std::move(bucket),
-       info_log_wp = std::move(info_log_wp),
-       storage_provider_wp = std::move(storage_provider_wp)]() {
-        auto storage_provider = storage_provider_wp.lock();
-        auto info_log = info_log_wp.lock();
-        if (!storage_provider || !info_log) {
-          return;
-        }
-        auto st = storage_provider->DeleteCloudObject(bucket, path);
-        if (!st.ok() && !st.IsNotFound()) {
-          Log(InfoLogLevel::ERROR_LEVEL, info_log,
-              "[CloudFileSystemImpl] DeleteFile file %s error %s", path.c_str(),
-              st.ToString().c_str());
-        }
-      };
-  return cloud_file_deletion_scheduler_->ScheduleFileDeletion(
-      base, std::move(file_deletion_runnable));
+  if (cloud_file_deletion_scheduler_) {
+    std::weak_ptr<Logger> info_log_wp = info_log_;
+    std::weak_ptr<CloudStorageProvider> storage_provider_wp =
+        GetStorageProvider();
+    auto file_deletion_runnable =
+        [path = std::move(path), bucket = std::move(bucket),
+         info_log_wp = std::move(info_log_wp),
+         storage_provider_wp = std::move(storage_provider_wp)]() {
+          auto storage_provider = storage_provider_wp.lock();
+          auto info_log = info_log_wp.lock();
+          if (!storage_provider || !info_log) {
+            return;
+          }
+          auto st = storage_provider->DeleteCloudObject(bucket, path);
+          if (!st.ok() && !st.IsNotFound()) {
+            Log(InfoLogLevel::ERROR_LEVEL, info_log,
+                "[CloudFileSystemImpl] DeleteFile file %s error %s",
+                path.c_str(), st.ToString().c_str());
+          }
+        };
+    return cloud_file_deletion_scheduler_->ScheduleFileDeletion(
+        base, std::move(file_deletion_runnable));
+  } else {
+    return GetStorageProvider()->DeleteCloudObject(bucket, path);
+  }
 }
 
 // Copy my IDENTITY file to cloud storage. Update dbid registry.
@@ -1023,10 +1022,6 @@ bool CloudFileSystemImpl::IsFileInvisible(
     }
   }
   return false;
-}
-
-void CloudFileSystemImpl::TEST_InitEmptyCloudManifest() {
-  CloudManifest::CreateForEmptyDatabase("", &cloud_manifest_);
 }
 
 IOStatus CloudFileSystemImpl::CreateNewIdentityFile(
@@ -2060,9 +2055,6 @@ IOStatus CloudFileSystemImpl::UploadCloudManifest(
   return st;
 }
 
-size_t CloudFileSystemImpl::TEST_NumScheduledJobs() const {
-  return scheduler_->TEST_NumScheduledJobs();
-};
 
 IOStatus CloudFileSystemImpl::ApplyCloudManifestDelta(
     const CloudManifestDelta& delta, bool* delta_applied) {
@@ -2361,6 +2353,17 @@ IOStatus CloudFileSystemImpl::FindAllLiveFiles(
 std::string CloudFileSystemImpl::CloudManifestFile(const std::string& dbname) {
   return MakeCloudManifestFile(dbname, cloud_fs_options.cookie_on_open);
 }
+
+#ifndef NDEBUG
+void CloudFileSystemImpl::TEST_InitEmptyCloudManifest() {
+  CloudManifest::CreateForEmptyDatabase("", &cloud_manifest_);
+}
+
+size_t CloudFileSystemImpl::TEST_NumScheduledJobs() const {
+  return cloud_file_deletion_scheduler_ ? cloud_file_deletion_scheduler_->TEST_NumScheduledJobs() : 0;
+}
+
+#endif
 
 }  // namespace ROCKSDB_NAMESPACE
 #endif  // ROCKSDB_LITE

--- a/cloud/cloud_file_system_impl.h
+++ b/cloud/cloud_file_system_impl.h
@@ -228,16 +228,10 @@ class CloudFileSystemImpl : public CloudFileSystem {
   }
 
   CloudManifest* GetCloudManifest() { return cloud_manifest_.get(); }
-  void TEST_InitEmptyCloudManifest();
-  void TEST_DisableCloudManifest() { test_disable_cloud_manifest_ = true; }
 
   IOStatus DeleteCloudFileFromDest(const std::string& fname) override;
   IOStatus CopyLocalFileToDest(const std::string& local_name,
                                const std::string& cloud_name) override;
-
-  void RemoveFileFromDeletionQueue(const std::string& filename);
-
-  void TEST_SetFileDeletionDelay(std::chrono::seconds delay);
 
   Status PrepareOptions(const ConfigOptions& config_options) override;
   Status ValidateOptions(const DBOptions& /*db_opts*/,
@@ -274,15 +268,19 @@ class CloudFileSystemImpl : public CloudFileSystem {
   IOStatus UploadCloudManifest(const std::string& local_dbname,
                                const std::string& cookie) const;
 
-  // Get current number of scheduled jobs in cloud scheduler
-  // Used for test only
-  size_t TEST_NumScheduledJobs() const;
-
   // Delete invisible files in cloud.
   //
   // REQUIRES: Dest bucket set
   IOStatus DeleteCloudInvisibleFiles(
       const std::vector<std::string>& active_cookies) override;
+
+#ifndef NDEBUG
+  void TEST_InitEmptyCloudManifest();
+  void TEST_DisableCloudManifest() { test_disable_cloud_manifest_ = true; }
+  // Get current number of scheduled jobs in cloud scheduler
+  // Used for test only
+  size_t TEST_NumScheduledJobs() const;
+#endif
 
  protected:
   Status CheckValidity() const;
@@ -362,8 +360,6 @@ class CloudFileSystemImpl : public CloudFileSystem {
   // purger_cv_);
   bool purger_is_running_;
   std::thread purge_thread_;
-
-  std::shared_ptr<CloudScheduler> scheduler_;
 
   // A background thread that deletes orphaned objects in cloud storage
   void Purger();

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -696,12 +696,13 @@ Env* DBTestBase::CreateNewAwsEnv(const std::string& prefix, Env* parent) {
   CloudFileSystem* cfs = nullptr;
   std::string region;
   coptions.TEST_Initialize("dbtest.", prefix, region);
+  // Delete cloud files immediately
+  coptions.cloud_file_deletion_delay = std::nullopt;
   Status st = CloudFileSystem::NewAwsFileSystem(parent->GetFileSystem(),
                                                 coptions, info_log_, &cfs);
   auto* cimpl = dynamic_cast<CloudFileSystemImpl*>(cfs);
   assert(cimpl);
   cimpl->TEST_DisableCloudManifest();
-  cimpl->TEST_SetFileDeletionDelay(std::chrono::seconds(0));
   ROCKS_LOG_INFO(info_log_, "Created new aws env with path %s", prefix.c_str());
   if (!st.ok()) {
     Log(InfoLogLevel::DEBUG_LEVEL, info_log_, "%s", st.ToString().c_str());

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
 #include "rocksdb/cache.h"
@@ -398,10 +399,13 @@ class CloudFileSystemOptions {
 
   // Experimental option!
   // Delay after files(including both invisible and obsolete files) are
-  // scheduled to be deleted
+  // scheduled to be deleted.
+  // If not set, file deletion won't be scheduled asynchronously but deleted
+  // right away. Note this is different from setting the value to 0, in which
+  // case the file deletion is still scheduled async.
   //
   // Default: 1 hour
-  std::chrono::seconds cloud_file_deletion_delay;
+  std::optional<std::chrono::seconds> cloud_file_deletion_delay;
 
   CloudFileSystemOptions(
       CloudType _cloud_type = CloudType::kCloudAws,


### PR DESCRIPTION
Changed `cloud_file_deletion_delay` to `std::optional`. If it's not set, instead of scheduling cloud file deletion on file deletion queue asynchronously, we delete the cloud files immediately. This is different from setting the value to 0, in which case, the file deletion is still scheduled asynchronously. 

Also did some minor cleanup:
- [x] removed useless `TEST_` functions
- [x] only included `TEST_` functions if compiling in debug build

## TESTS
- [x] db_cloud_test