### PR TITLE
[sys-4478] don't generate mem switch for empty flush

### DIFF
--- a/cloud/replication_test.cc
+++ b/cloud/replication_test.cc
@@ -1012,6 +1012,24 @@ TEST_F(ReplicationTest, AllowNewManifestWrite) {
   EXPECT_LT(followerMUS, leaderMUS);
 }
 
+// Memtable switch record won't be generated if all memtables are empty
+TEST_F(ReplicationTest, NoMemSwitchRecordIfEmpty) {
+  auto leader = openLeader();
+  openFollower();
+
+  auto cf = [](int i) { return "cf" + std::to_string(i); };
+
+  for (int i = 0; i < 10; ++i) {
+    createColumnFamily(cf(i));
+  }
+
+  EXPECT_GT(catchUpFollower(), 0);
+
+  ASSERT_OK(leader->Flush({}));
+  // no mem switch record
+  EXPECT_EQ(catchUpFollower(), 0);
+}
+
 TEST_F(ReplicationTest, Stress) {
   std::string val;
   auto leader = openLeader();

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2230,7 +2230,7 @@ Status DBImpl::AtomicFlushMemTables(
 
     MemTableSwitchRecord mem_switch_record;
     std::string replication_sequence;
-    if (immutable_db_options_.replication_log_listener) {
+    if (immutable_db_options_.replication_log_listener && !cfds.empty()) {
       mem_switch_record.next_log_num = versions_->NewFileNumber();
       replication_sequence = RecordMemTableSwitch(
         immutable_db_options_.replication_log_listener,

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1755,7 +1755,7 @@ Status DBImpl::HandleWriteBufferManagerFlush(WriteContext* write_context) {
 
   MemTableSwitchRecord mem_switch_record;
   std::string replication_sequence;
-  if (immutable_db_options_.replication_log_listener) {
+  if (immutable_db_options_.replication_log_listener && !cfds.empty()) {
     mem_switch_record.next_log_num = versions_->NewFileNumber();
     replication_sequence = RecordMemTableSwitch(
         immutable_db_options_.replication_log_listener, mem_switch_record);
@@ -2048,7 +2048,7 @@ Status DBImpl::ScheduleFlushes(WriteContext* context) {
 
   MemTableSwitchRecord mem_switch_record;
   std::string replication_sequence;
-  if (immutable_db_options_.replication_log_listener) {
+  if (immutable_db_options_.replication_log_listener && !cfds.empty()) {
     mem_switch_record.next_log_num = versions_->NewFileNumber();
     replication_sequence = RecordMemTableSwitch(
       immutable_db_options_.replication_log_listener,


### PR DESCRIPTION
There is no need to generate a memtable switch log record if there is no column families flushed.


## TEST
- [x] Added test to make sure no memtable switch log record is generated for empty flush