### PR TITLE
[SYS-4840] Evict obsolete files from table cache on the follower

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -399,11 +399,12 @@ class DBImpl : public DB {
   virtual void EnableManualCompaction() override;
   virtual void DisableManualCompaction() override;
 
-  Status ApplyReplicationLogRecord(
-      ReplicationLogRecord record, std::string replication_sequence,
-      CFOptionsFactory cf_options_factory,
-      bool allow_new_manifest_writes,
-      ApplyReplicationLogRecordInfo* info) override;
+  Status ApplyReplicationLogRecord(ReplicationLogRecord record,
+                                   std::string replication_sequence,
+                                   CFOptionsFactory cf_options_factory,
+                                   bool allow_new_manifest_writes,
+                                   ApplyReplicationLogRecordInfo* info,
+                                   unsigned flags) override;
   Status GetReplicationRecordDebugString(
       const ReplicationLogRecord& record, std::string* out) const override;
   Status GetPersistedReplicationSequence(std::string* out) override;

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3394,11 +3394,12 @@ class ModelDB : public DB {
 
   ColumnFamilyHandle* DefaultColumnFamily() const override { return nullptr; }
 
-  Status ApplyReplicationLogRecord(
-      ReplicationLogRecord /*record*/, std::string /*replication_sequence*/,
-      CFOptionsFactory /* cf_options_factory */,
-      bool /* allow_new_manifest_writes */,
-      ApplyReplicationLogRecordInfo* /*info*/) override {
+  Status ApplyReplicationLogRecord(ReplicationLogRecord /*record*/,
+                                   std::string /*replication_sequence*/,
+                                   CFOptionsFactory /* cf_options_factory */,
+                                   bool /* allow_new_manifest_writes */,
+                                   ApplyReplicationLogRecordInfo* /*info*/,
+                                   unsigned /*flags*/) override {
     return Status::NotSupported("Not supported in Model DB");
   }
   Status GetPersistedReplicationSequence(std::string* /*out*/) override {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1323,12 +1323,16 @@ class DB {
   // the new manifest writes.
   //
   // REQUIRES: info needs to be provided, can't be nullptr.
+  enum ApplyReplicationLogRecordFlags : unsigned {
+    AR_EVICT_OBSOLETE_FILES = 1U << 0,
+  };
   using CFOptionsFactory = std::function<ColumnFamilyOptions(Slice)>;
-  virtual Status ApplyReplicationLogRecord(
-      ReplicationLogRecord record, std::string replication_sequence,
-      CFOptionsFactory cf_options_factory,
-      bool allow_new_manifest_writes,
-      ApplyReplicationLogRecordInfo* info) = 0;
+  virtual Status ApplyReplicationLogRecord(ReplicationLogRecord record,
+                                           std::string replication_sequence,
+                                           CFOptionsFactory cf_options_factory,
+                                           bool allow_new_manifest_writes,
+                                           ApplyReplicationLogRecordInfo* info,
+                                           unsigned flags = 0) = 0;
   virtual Status GetReplicationRecordDebugString(
       const ReplicationLogRecord& record, std::string* out) const = 0;
   // Returns the latest replication log sequence number (returned by

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -497,14 +497,15 @@ class StackableDB : public DB {
     return db_->GetDbSessionId(session_id);
   }
 
-  Status ApplyReplicationLogRecord(
-      ReplicationLogRecord record, std::string replication_sequence,
-      CFOptionsFactory cf_options_factory,
-      bool allow_new_manifest_writes,
-      ApplyReplicationLogRecordInfo* info) override {
+  Status ApplyReplicationLogRecord(ReplicationLogRecord record,
+                                   std::string replication_sequence,
+                                   CFOptionsFactory cf_options_factory,
+                                   bool allow_new_manifest_writes,
+                                   ApplyReplicationLogRecordInfo* info,
+                                   unsigned flags) override {
     return db_->ApplyReplicationLogRecord(
         record, replication_sequence, std::move(cf_options_factory),
-        allow_new_manifest_writes, info);
+        allow_new_manifest_writes, info, flags);
   }
   Status GetReplicationRecordDebugString(const ReplicationLogRecord& record,
                                          std::string* out) const override {


### PR DESCRIPTION
Summary:
Follower in the physical replication runs file deletions turned off,
i.e. `disable_delete_obsolete_files_on_open` is true, since it has no
business in deleting files that it doesn't own. Unfortunately, when file
deletions are turned off, so are table cache evictions. This means table
cache grows forever (in case of max_open_files=-1 setting) and we never
delete data structures of files we no longer need.

This PR fixes the problem, hiden under AR_EVICT_OBSOLETE_FILES flag for
safer rollout (this flag will eventually be removed and the new behavior
will be the default).

We evict obsolete files on every manifest write. If there are some files
that are pinned by the live iterator, we won't evict the files on
iterator deletion. Instead, we will keep them around until the next
manifest write. This is done to reduce the amount of changes to
RocksDB, and the impact of keeping a small number of obsolete file
metadatas alive for a short period is minor.

Test Plan:
Added a repro unit test.

Reviewers:
