### PR TITLE
deflake file deletion related tests

### DIFF
--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -60,7 +60,7 @@ class CloudTest : public testing::Test {
     cloud_fs_options_.use_aws_transfer_manager = true;
     // To catch any possible file deletion bugs, cloud files are deleted
     // right away
-    cloud_fs_options_.cloud_file_deletion_delay = std::nullopt;
+    cloud_fs_options_.cloud_file_deletion_delay = std::chrono::seconds(0);
 
     options_.create_if_missing = true;
     options_.stats_dump_period_sec = 0;


### PR DESCRIPTION
The file deletion related tests in `db_cloud_test` assumes that files to be scheduled on `CloudScheduler`. Setting the file deletion delay to 0s to make sure that files are indeed scheduled on the scheduler and getting deleted immediately.

## Tests
- [x] repeated db_cloud_test multiple times and confirmed tests pass