### PR TITLE
[sys-5310] DBCloud::Open respects db option create_if_missing

### DIFF
--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -146,8 +146,9 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
     }
   }
   if (new_db) {
-    if (read_only) {
-      return Status::NotFound("CLOUDMANIFEST not found and read_only is set.");
+    if (!options.create_if_missing) {
+      return Status::NotFound(
+          "CLOUDMANIFEST not found and create_if_missing false");
     }
     st = cfs->CreateCloudManifest(
         local_dbname, cfs->GetCloudFileSystemOptions().new_cookie_on_open);

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -146,9 +146,9 @@ Status DBCloud::Open(const Options& opt, const std::string& local_dbname,
     }
   }
   if (new_db) {
-    if (!options.create_if_missing) {
+    if (read_only || !options.create_if_missing) {
       return Status::NotFound(
-          "CLOUDMANIFEST not found and create_if_missing false");
+          "CLOUDMANIFEST not found and not creating new db");
     }
     st = cfs->CreateCloudManifest(
         local_dbname, cfs->GetCloudFileSystemOptions().new_cookie_on_open);

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -3276,6 +3276,28 @@ TEST_F(CloudTest, ReplayCloudManifestDeltaTest) {
   CloseDB();
 }
 
+TEST_F(CloudTest, CreateIfMissing) {
+  options_.create_if_missing = false;
+  ASSERT_TRUE(checkOpen().IsNotFound());
+  options_.create_if_missing = true;
+  OpenDB();
+  CloseDB();
+
+  // delete `CURRENT` file
+  DestroyDir(dbname_);
+  OpenDB();
+  CloseDB();
+
+  // Delete `CLOUDMANFIEST` file in cloud
+  auto cloudManifestFile =
+      MakeCloudManifestFile(dbname_, cloud_fs_options_.new_cookie_on_open);
+  ASSERT_OK(GetCloudFileSystem()->GetStorageProvider()->DeleteCloudObject(
+      GetCloudFileSystem()->GetSrcBucketName(), cloudManifestFile));
+
+  options_.create_if_missing = false;
+  ASSERT_TRUE(checkOpen().IsNotFound());
+}
+
 }  //  namespace ROCKSDB_NAMESPACE
 
 // A black-box test for the cloud wrapper around rocksdb

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -428,8 +428,7 @@ class CloudFileSystemOptions {
       bool _roll_cloud_manifest_on_open = true,
       std::string _cookie_on_open = "", std::string _new_cookie_on_open = "",
       bool _delete_cloud_invisible_files_on_open = true,
-      std::chrono::seconds _cloud_file_deletion_delay =
-          std::chrono::hours(1))
+      std::chrono::seconds _cloud_file_deletion_delay = std::chrono::hours(1))
       : log_type(_log_type),
         sst_file_cache(_sst_file_cache),
         keep_local_sst_files(_keep_local_sst_files),
@@ -457,8 +456,7 @@ class CloudFileSystemOptions {
         new_cookie_on_open(_new_cookie_on_open),
         delete_cloud_invisible_files_on_open(
             _delete_cloud_invisible_files_on_open),
-        cloud_file_deletion_delay(
-            _cloud_file_deletion_delay) {
+        cloud_file_deletion_delay(_cloud_file_deletion_delay) {
     (void) _cloud_type;
   }
 


### PR DESCRIPTION
If `DBOptions::create_if_missing` is false, don't create new cloud db.

## TESTS
- [x] newly added test to verify cloud db opening with `create_if_missing=false`