### PR TITLE
[SYS-5630] add missing cstdint includes

### DIFF
--- a/table/block_based/data_block_hash_index.h
+++ b/table/block_based/data_block_hash_index.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Summary:
Previously, libstdc++ defined uint8_t when you included <string>. This is no longer the case for the libstdc++ included in g++-13, so explicit <cstdint> includes are needed in a few places.

Test Plan:
compiles