### PR TITLE
[SYS-5319] Don't allocate buffer for WALs in CloudFileSystem

### DIFF
--- a/cloud/cloud_file_system_impl.h
+++ b/cloud/cloud_file_system_impl.h
@@ -199,7 +199,13 @@ class CloudFileSystemImpl : public CloudFileSystem {
   }
   FileOptions OptimizeForLogWrite(const FileOptions& file_options,
                                   const DBOptions& db_options) const override {
-    return base_fs_->OptimizeForLogWrite(file_options, db_options);
+    auto fo = base_fs_->OptimizeForLogWrite(file_options, db_options);
+    if (!fo.use_direct_writes) {
+      // RocksDB-Cloud doesn't use WALs, so don't waste memory on allocating
+      // their buffers.
+      fo.writable_file_max_buffer_size = 0;
+    }
+    return fo;
   }
   FileOptions OptimizeForManifestWrite(
       const FileOptions& file_options) const override {


### PR DESCRIPTION
Summary:
Each WAL file by default allocates 64KB buffer in which it holds pending
writes. Our use of RocksDB-Cloud doesn't utilize WALs, so this memory is
wasted. This PR sets the buffer size to 0 in
CloudFileSystemImpl::OptimizeForLogWrite.

Test Plan:
db_cloud_test

Reviewers:
