### PR TITLE
[sys-4729] ignore table handler loading error when apply replication log record

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1429,8 +1429,9 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
         }
         s = versions_->LogAndApply(cfds, mutable_cf_options_list, edit_lists,
                                    &mutex_, directories_.GetDbDir(),
-                                   false /* new_descriptor_log */,
-                                   &*cf_options);
+                                   false /* new_descriptor_log */, &*cf_options,
+                                   {} /* manifest_wcbs */,
+                                   true /* ignore_table_load_error */);
         if (!s.ok()) {
           break;
         }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1156,6 +1156,9 @@ class VersionSet {
   // The across-multi-cf batch version. If edit_lists contain more than
   // 1 version edits, caller must ensure that no edit in the []list is column
   // family manipulation.
+  //
+  // `ignore_table_load_error`: if true, errors of loading newly added table
+  // handlers are ignored even if paranoid_checks is true.
   virtual Status LogAndApply(
       const autovector<ColumnFamilyData*>& cfds,
       const autovector<const MutableCFOptions*>& mutable_cf_options_list,
@@ -1164,7 +1167,8 @@ class VersionSet {
       bool new_descriptor_log = false,
       const ColumnFamilyOptions* new_cf_options = nullptr,
       const std::vector<std::function<void(const Status&)>>& manifest_wcbs =
-          {});
+          {},
+      bool ignore_table_load_error = false);
 
   static Status GetCurrentManifestPath(const std::string& dbname,
                                        FileSystem* fs,
@@ -1603,7 +1607,8 @@ class VersionSet {
                                InstrumentedMutex* mu,
                                FSDirectory* dir_contains_current_file,
                                bool new_descriptor_log,
-                               const ColumnFamilyOptions* new_cf_options);
+                               const ColumnFamilyOptions* new_cf_options,
+                               bool ignore_table_load_error);
 
   void LogAndApplyCFHelper(VersionEdit* edit,
                            SequenceNumber* max_last_sequence);
@@ -1665,7 +1670,8 @@ class ReactiveVersionSet : public VersionSet {
       const autovector<autovector<VersionEdit*>>& /*edit_lists*/,
       InstrumentedMutex* /*mu*/, FSDirectory* /*dir_contains_current_file*/,
       bool /*new_descriptor_log*/, const ColumnFamilyOptions* /*new_cf_option*/,
-      const std::vector<std::function<void(const Status&)>>& /*manifest_wcbs*/)
+      const std::vector<std::function<void(const Status&)>>& /*manifest_wcbs*/,
+      bool /* ignore_table_load_error */)
       override {
     return Status::NotSupported("not supported in reactive mode");
   }


### PR DESCRIPTION
When follower applies `kManifestWrite` with newly added sst files, it also loads the table handlers and reads the footer blocks. If that fails due to leaf being overloaded, due to paranoid check, the shards will be errored permanently. Instead of erroring shards, it's actually safe to ignore the errors. But we still want to keep the paranoid checks, so adding a new parameter: `ignore_table_load_error` to `VersionSet::LogAndApply` function. If that's true, we force ignoring table handler loading error even if paranoid check is enabled.

