### PR TITLE
[sys-4815] consistency check when replicating epoch number

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -409,6 +409,16 @@ class DBImpl : public DB {
                                    bool allow_new_manifest_writes,
                                    ApplyReplicationLogRecordInfo* info,
                                    unsigned flags) override;
+
+  // Calculate epoch number on follower
+  Status InferEpochNumber(VersionEdit* e, ColumnFamilyData* cfd,
+                          ApplyReplicationLogRecordInfo* info, 
+                          bool reset_next_epoch_number);
+
+  // Check that replicated epoch number of newly flushed files >= cfd's next
+  // epoch number.
+  // TODO: make `VersionEdit` const
+  Status CheckNextEpochNumberConsistency(VersionEdit& e, ColumnFamilyData* cfd);
   Status GetReplicationRecordDebugString(
       const ReplicationLogRecord& record, std::string* out) const override;
   Status GetPersistedReplicationSequence(std::string* out) override;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1335,7 +1335,10 @@ class DB {
     // backwards. So follower needs to rewind it.
     // 2. follower reopens db, causing `next_epoch_number` on follower to go
     // backwards. So follower needs to advance it
-    AR_RESET_IF_EPOCH_MISMATCH = 1U << 2
+    AR_RESET_IF_EPOCH_MISMATCH = 1U << 2,
+
+    // Check the consistency of epoch number during replication
+    AR_CONSISTENCY_CHECK_ON_EPOCH_REPLICATION = 1U << 3
   };
   using CFOptionsFactory = std::function<ColumnFamilyOptions(Slice)>;
   virtual Status ApplyReplicationLogRecord(ReplicationLogRecord record,

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -89,6 +89,8 @@ class Status {
     kTryAgain = 13,
     kCompactionTooLarge = 14,
     kColumnFamilyDropped = 15,
+    // Temporary status code for rocksdb upgrade
+    kPoison = 100,
     kMaxCode
   };
 
@@ -176,6 +178,9 @@ class Status {
   }
   static Status Corruption(SubCode msg = kNone) {
     return Status(kCorruption, msg);
+  }
+  static Status Poison(const Slice& msg, const Slice& msg2 = Slice()) {
+    return Status(kPoison, msg, msg2);
   }
 
   static Status NotSupported(const Slice& msg, const Slice& msg2 = Slice()) {
@@ -310,6 +315,11 @@ class Status {
   bool IsCorruption() const {
     MarkChecked();
     return code() == kCorruption;
+  }
+
+  bool IsPoison() const {
+    MarkChecked();
+    return code() == kPoison;
   }
 
   // Returns true iff the status indicates a NotSupported error.

--- a/util/status.cc
+++ b/util/status.cc
@@ -132,6 +132,9 @@ std::string Status::ToString() const {
     case kMaxCode:
       assert(false);
       break;
+    case kPoison:
+      type = "Poison: ";
+      break;
   }
   char tmp[30];
   if (type == nullptr) {


### PR DESCRIPTION
Main changes:
* Fixed one minor issue found when upgrading rocksdb. It's possible for epoch number to be diverged between leader and follower. This can happen when we do epoch recovery during db open (i.e., nodes run with different rocksdb versions and nodes upgrading from old version to new version need to recover epoch. Epoch number of nodes which do epoch recovery might go backwards, causing divergence of epoch number). Poison is the best we can do here. 
* Add more checks when replicating epoch number between leader follower. 1) check that `next_epoch_number` on follower is correct. This is important to guarantee that epoch number doesn't go backwards after all nodes are on new versions. 2) check that replicated epoch number = epoch number inferred on follower

## TESTS
- [x] extended the stress test to cover the code changes