### PR TITLE
[sys-3153] remove resync_manifest_on_open option

### DIFF
--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -1538,8 +1538,7 @@ IOStatus CloudFileSystemImpl::LoadCloudManifest(const std::string& local_dbname,
     st = LoadLocalCloudManifest(local_dbname);
   }
 
-  if (st.ok() && cloud_fs_options.resync_on_open &&
-      cloud_fs_options.resync_manifest_on_open) {
+  if (st.ok() && cloud_fs_options.resync_on_open) {
     auto epoch = cloud_manifest_->GetCurrentEpoch();
     st = FetchManifest(local_dbname, epoch);
     if (st.IsNotFound()) {

--- a/cloud/db_cloud_test.cc
+++ b/cloud/db_cloud_test.cc
@@ -57,7 +57,6 @@ class CloudTest : public testing::Test {
     dbname_ = test::TmpDir() + "/db_cloud-" + test_id_;
     clone_dir_ = test::TmpDir() + "/ctest-" + test_id_;
     cloud_fs_options_.TEST_Initialize("dbcloudtest.", dbname_);
-    cloud_fs_options_.resync_manifest_on_open = true;
     cloud_fs_options_.use_aws_transfer_manager = true;
     // To catch any possible file deletion bugs, cloud files are deleted
     // right away
@@ -2813,7 +2812,6 @@ TEST_F(CloudTest, FileDeletionJobsCanceledWhenCloudEnvDestructed) {
 // The failure case of opening a corrupted db which doesn't have MANIFEST file
 TEST_F(CloudTest, OpenWithManifestMissing) {
   cloud_fs_options_.resync_on_open = true;
-  cloud_fs_options_.resync_manifest_on_open = true;
   OpenDB();
   auto epoch = GetCloudFileSystemImpl()->GetCloudManifest()->GetCurrentEpoch();
   CloseDB();

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -298,17 +298,6 @@ class CloudFileSystemOptions {
   // Default: false
   bool resync_on_open;
 
-  // Experimental option!
-  // This option only affects how resync_on_open works. If resync_on_open is
-  // true, and resync_manifest_on_open is true, besides fetching CLOUDMANFIEST
-  // from s3, we will fetch latest MANIFEST file as well.
-  //
-  // This is a temporary option to help quickly rollback the change if something
-  // unexpected is wrong.
-  // TODO(wei): remove this option once we are confident about the change.
-  // Default: true
-  bool resync_manifest_on_open;
-
   // If true, we will skip the dbid verification on startup. This is currently
   // only used in tests and is not recommended setting.
   // Default: false
@@ -418,7 +407,6 @@ class CloudFileSystemOptions {
       bool _server_side_encryption = false, std::string _encryption_key_id = "",
       bool _create_bucket_if_missing = true, uint64_t _request_timeout_ms = 0,
       bool _run_purger = false, bool _resync_on_open = false,
-      bool _resync_manifest_on_open = true,
       bool _skip_dbid_verification = false,
       bool _use_aws_transfer_manager = false,
       int _number_objects_listed_in_one_iteration = 5000,
@@ -443,7 +431,6 @@ class CloudFileSystemOptions {
         request_timeout_ms(_request_timeout_ms),
         run_purger(_run_purger),
         resync_on_open(_resync_on_open),
-        resync_manifest_on_open(_resync_manifest_on_open),
         skip_dbid_verification(_skip_dbid_verification),
         use_aws_transfer_manager(_use_aws_transfer_manager),
         number_objects_listed_in_one_iteration(


### PR DESCRIPTION
This option was a temporary option used to rollout manifest resync on shard open safely. It's ok to remove it now.

## TESTS
- [x] `CloudTest::OpenWithManifestMissing` verifies related behavior