### PR TITLE
Introduce SuperSnapshot

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -345,6 +345,11 @@ class DBImpl : public DB {
   SequenceNumber GetIteratorSequenceNumber(Iterator* it) override;
 
   virtual const Snapshot* GetSnapshot() override;
+  // RocksDB-Cloud contribution begin
+  Status GetSuperSnapshots(
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<const Snapshot*>* snapshots) override;
+  // RocksDB-Cloud contribution end
   virtual void ReleaseSnapshot(const Snapshot* snapshot) override;
   // Create a timestamped snapshot. This snapshot can be shared by multiple
   // readers. If any of them uses it for write conflict checking, then

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3196,6 +3196,12 @@ class ModelDB : public DB {
     return snapshot;
   }
 
+  virtual Status GetSuperSnapshots(
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<const Snapshot*>* snapshots) {
+    return Status::NotSupported("");
+  }
+
   void ReleaseSnapshot(const Snapshot* snapshot) override {
     delete reinterpret_cast<const ModelSnapshot*>(snapshot);
   }

--- a/db/snapshot_impl.h
+++ b/db/snapshot_impl.h
@@ -51,6 +51,24 @@ class SnapshotImpl : public Snapshot {
   bool is_write_conflict_boundary_;
 };
 
+// RocksDB-Cloud contribution begin
+class SuperVersion;
+class ColumnFamilyData;
+class SuperSnapshotImpl : public SnapshotImpl {
+ public:
+  SuperSnapshotImpl(ColumnFamilyData* cfd, SuperVersion* sv)
+      : cfd_(cfd), sv_(sv) {}
+
+  ColumnFamilyData* cfd() const { return cfd_; }
+  SuperVersion* sv() const { return sv_; }
+
+ private:
+  ColumnFamilyData* cfd_;
+  // We hold a ref to sv_
+  SuperVersion* sv_{nullptr};
+};
+// RocksDB-Cloud contribution end
+
 class SnapshotList {
  public:
   SnapshotList() {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -848,6 +848,23 @@ class DB {
   // not support snapshot (eg: inplace_update_support enabled).
   virtual const Snapshot* GetSnapshot() = 0;
 
+  // RocksDB-Cloud contribution begin
+  // SuperSnapshot is a combination of a snapshot and a super-version. They
+  // fulfill the same goal as snapshots, i.e. provide a consistent view of the
+  // database. However, unlike snapshots, they also pin the current
+  // super-version (memtable, immutable memtable list and file LSM tree). In
+  // that way they are similar to iterators, which also pin the current
+  // super-version for the duration of their lifetime.
+  // Each super-snapshot is tied to a column family and the column family in the
+  // read request has to match with the column family of the snapshot.
+  //
+  // Just like the regular snapshot, the caller must call ReleaseSnapshot() when
+  // it's done with the snapshot, and before closing the database.
+  virtual Status GetSuperSnapshots(
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<const Snapshot*>* snapshots) = 0;
+  // RocksDB-Cloud contribution end
+
   // Release a previously acquired snapshot.  The caller must not
   // use "snapshot" after this call.
   virtual void ReleaseSnapshot(const Snapshot* snapshot) = 0;

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -245,6 +245,14 @@ class StackableDB : public DB {
 
   virtual const Snapshot* GetSnapshot() override { return db_->GetSnapshot(); }
 
+  // RocksDB-Cloud contribution begin
+  Status GetSuperSnapshots(
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<const Snapshot*>* snapshots) override {
+    return db_->GetSuperSnapshots(column_families, snapshots);
+  }
+  // RocksDB-Cloud contribution end
+
   virtual void ReleaseSnapshot(const Snapshot* snapshot) override {
     return db_->ReleaseSnapshot(snapshot);
   }


### PR DESCRIPTION
Summary:
SuperSnapshot is a combination of a snapshot and a super-version. They
fulfill the same goal as snapshots, i.e. provide a consistent view of
the database. However, unlike snapshots, they also pin the current
super-version (memtable, immutable memtable list and file LSM tree). In
that way they are similar to iterators, which also pin the current
super-version for the duration of their lifetime.

Test Plan:
Added a basic unit test.

Reviewers:
