### PR TITLE
SuperVersion is a struct, not a class

### DIFF
--- a/db/snapshot_impl.h
+++ b/db/snapshot_impl.h
@@ -52,7 +52,7 @@ class SnapshotImpl : public Snapshot {
 };
 
 // RocksDB-Cloud contribution begin
-class SuperVersion;
+struct SuperVersion;
 class ColumnFamilyData;
 class SuperSnapshotImpl : public SnapshotImpl {
  public:


### PR DESCRIPTION
Summary:
```
./db/snapshot_impl.h:55:1: error: class 'SuperVersion' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
```

Test Plan:

Reviewers:
