### PR TITLE
[sys-6435] make DeleteLocalInvisibleFiles public

### DIFF
--- a/cloud/cloud_file_system_impl.h
+++ b/cloud/cloud_file_system_impl.h
@@ -365,11 +365,11 @@ class CloudFileSystemImpl : public CloudFileSystem {
   void Purger();
   void StopPurger();
 
- private:
   // Delete all local files that are invisible
   IOStatus DeleteLocalInvisibleFiles(
       const std::string& dbname,
       const std::vector<std::string>& active_cookies);
+ private:
   // Files are invisibile if:
   // - It's CLOUDMANFIEST file and cookie is not active. NOTE: empty cookie is
   // always active


### PR DESCRIPTION
This is to help with #sys-6435, in which live mount replicas never purge local manifest files.

My plan is to call `DeleteLocalInvisibleFiles` after follower applies `kNewEpoch`.  This will delete both invisible MANIFEST and  CLOUDMANIFEST files. NOTE that there is only one single CLOUDMANFIEST file locally since we never override the one in local disk once it's loaded. Also It's ok to delete local CLOUDMANIFEST files with live db. We only read it when opening rocksdb.