### PR TITLE
[SYS-6514] Introduce kLiveNonBottommostSstFilesSize statistic

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1123,8 +1123,8 @@ uint64_t ColumnFamilyData::GetTotalBlobFileSize() const {
   return VersionSet::GetTotalBlobFileSize(dummy_versions_);
 }
 
-uint64_t ColumnFamilyData::GetLiveSstFilesSize() const {
-  return current_->GetSstFilesSize();
+uint64_t ColumnFamilyData::GetLiveSstFilesSize(bool include_bottommost) const {
+  return current_->GetSstFilesSize(include_bottommost);
 }
 
 MemTable* ColumnFamilyData::ConstructNewMemtable(

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -356,7 +356,8 @@ class ColumnFamilyData {
   void SetCurrent(Version* _current);
   uint64_t GetNumLiveVersions() const;    // REQUIRE: DB mutex held
   uint64_t GetTotalSstFilesSize() const;  // REQUIRE: DB mutex held
-  uint64_t GetLiveSstFilesSize() const;   // REQUIRE: DB mutex held
+  uint64_t GetLiveSstFilesSize(
+      bool include_bottommost = true) const;  // REQUIRE: DB mutex held
   uint64_t GetTotalBlobFileSize() const;  // REQUIRE: DB mutex held
   void SetMemtable(MemTable* new_mem) {
     uint64_t memtable_id = last_memtable_id_.fetch_add(1) + 1;

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -1743,6 +1743,7 @@ TEST_F(DBPropertiesTest, SstFilesSize) {
   options.env = CurrentOptions().env;
   options.disable_auto_compactions = true;
   options.listeners.push_back(listener);
+  options.level_compaction_dynamic_level_bytes = true;
   Reopen(options);
 
   for (int i = 0; i < 10; i++) {
@@ -1757,10 +1758,18 @@ TEST_F(DBPropertiesTest, SstFilesSize) {
   bool ok = db_->GetIntProperty(DB::Properties::kTotalSstFilesSize, &sst_size);
   ASSERT_TRUE(ok);
   ASSERT_GT(sst_size, 0);
+  ok = db_->GetIntProperty(DB::Properties::kLiveNonBottommostSstFilesSize,
+                           &sst_size);
+  ASSERT_TRUE(ok);
+  ASSERT_GT(sst_size, 0);
   listener->size_before_compaction = sst_size;
   // Compact to clean all keys and trigger listener.
   ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
   ASSERT_TRUE(listener->callback_triggered);
+  ok = db_->GetIntProperty(DB::Properties::kLiveNonBottommostSstFilesSize,
+                           &sst_size);
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(sst_size, 0);
 }
 
 TEST_F(DBPropertiesTest, MinObsoleteSstNumberToKeep) {

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -284,6 +284,8 @@ static const std::string min_obsolete_sst_number_to_keep_str =
     "min-obsolete-sst-number-to-keep";
 static const std::string base_level_str = "base-level";
 static const std::string total_sst_files_size = "total-sst-files-size";
+static const std::string live_non_bottommost_sst_files_size =
+    "live-non-bottommost-sst-files-size";
 static const std::string live_sst_files_size = "live-sst-files-size";
 static const std::string live_sst_files_size_at_temperature =
     "live-sst-files-size-at-temperature";
@@ -382,6 +384,8 @@ const std::string DB::Properties::kMinObsoleteSstNumberToKeep =
     rocksdb_prefix + min_obsolete_sst_number_to_keep_str;
 const std::string DB::Properties::kTotalSstFilesSize =
     rocksdb_prefix + total_sst_files_size;
+const std::string DB::Properties::kLiveNonBottommostSstFilesSize =
+    rocksdb_prefix + live_non_bottommost_sst_files_size;
 const std::string DB::Properties::kLiveSstFilesSize =
     rocksdb_prefix + live_sst_files_size;
 const std::string DB::Properties::kBaseLevel = rocksdb_prefix + base_level_str;
@@ -545,6 +549,9 @@ const UnorderedMap<std::string, DBPropertyInfo>
           nullptr}},
         {DB::Properties::kLiveSstFilesSize,
          {false, nullptr, &InternalStats::HandleLiveSstFilesSize, nullptr,
+          nullptr}},
+        {DB::Properties::kLiveNonBottommostSstFilesSize,
+         {false, nullptr, &InternalStats::HandleLiveNonBottommostSstFilesSize, nullptr,
           nullptr}},
         {DB::Properties::kLiveSstFilesSizeAtTemperature,
          {false, &InternalStats::HandleLiveSstFilesSizeAtTemperature, nullptr,
@@ -1348,6 +1355,13 @@ bool InternalStats::HandleTotalSstFilesSize(uint64_t* value, DBImpl* /*db*/,
 bool InternalStats::HandleLiveSstFilesSize(uint64_t* value, DBImpl* /*db*/,
                                            Version* /*version*/) {
   *value = cfd_->GetLiveSstFilesSize();
+  return true;
+}
+
+bool InternalStats::HandleLiveNonBottommostSstFilesSize(uint64_t* value,
+                                                        DBImpl* /*db*/,
+                                                        Version* /*version*/) {
+  *value = cfd_->GetLiveSstFilesSize(false /* include_bottommost */);
   return true;
 }
 

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -790,6 +790,8 @@ class InternalStats {
   bool HandleBaseLevel(uint64_t* value, DBImpl* db, Version* version);
   bool HandleTotalSstFilesSize(uint64_t* value, DBImpl* db, Version* version);
   bool HandleLiveSstFilesSize(uint64_t* value, DBImpl* db, Version* version);
+  bool HandleLiveNonBottommostSstFilesSize(uint64_t* value, DBImpl* db,
+                                           Version* version);
   bool HandleEstimatePendingCompactionBytes(uint64_t* value, DBImpl* db,
                                             Version* version);
   bool HandleEstimateTableReadersMem(uint64_t* value, DBImpl* db,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1810,9 +1810,11 @@ void Version::GetColumnFamilyMetaData(ColumnFamilyMetaData* cf_meta) {
   }
 }
 
-uint64_t Version::GetSstFilesSize() {
+uint64_t Version::GetSstFilesSize(bool include_bottommost) {
   uint64_t sst_files_size = 0;
-  for (int level = 0; level < storage_info_.num_levels_; level++) {
+  for (int level = 0;
+       level + (include_bottommost ? 0 : 1) < storage_info_.num_levels_;
+       level++) {
     for (const auto& file_meta : storage_info_.LevelFiles(level)) {
       sst_files_size += file_meta->fd.GetFileSize();
     }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -973,7 +973,7 @@ class Version {
 
   void GetColumnFamilyMetaData(ColumnFamilyMetaData* cf_meta);
 
-  uint64_t GetSstFilesSize();
+  uint64_t GetSstFilesSize(bool include_bottommost = true);
 
   // Retrieves the file_creation_time of the oldest file in the DB.
   // Prerequisite for this API is max_open_files = -1

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1050,6 +1050,11 @@ class DB {
     //      files belong to the latest LSM tree.
     static const std::string kLiveSstFilesSize;
 
+    //  "rocksdb.live-non-bottommost-sst-files-size" - returns total size
+    //      (bytes) of all SST files not in the bottommost level that belong
+    //      to the latest LSM tree.
+    static const std::string kLiveNonBottommostSstFilesSize;
+
     // "rocksdb.live_sst_files_size_at_temperature" - returns total size (bytes)
     //      of SST files at all certain file temperature
     static const std::string kLiveSstFilesSizeAtTemperature;


### PR DESCRIPTION
Summary:
We can use this to measure the compactdness of the LSM tree. Size of 0
means the LSM tree is fully compacted.

Test Plan:
db_properties_test

Reviewers:
