### PR TITLE
[sys-6535] define DeleteLocalInvisibleFiles in CloudFileSystem

### DIFF
--- a/cloud/cloud_file_system_impl.h
+++ b/cloud/cloud_file_system_impl.h
@@ -368,7 +368,7 @@ class CloudFileSystemImpl : public CloudFileSystem {
   // Delete all local files that are invisible
   IOStatus DeleteLocalInvisibleFiles(
       const std::string& dbname,
-      const std::vector<std::string>& active_cookies);
+      const std::vector<std::string>& active_cookies) override;
  private:
   // Files are invisibile if:
   // - It's CLOUDMANFIEST file and cookie is not active. NOTE: empty cookie is

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -652,7 +652,15 @@ class CloudFileSystem : public FileSystem {
   virtual IOStatus GetMaxFileNumberFromCurrentManifest(
       const std::string& local_dbname, uint64_t* max_file_number) = 0;
 
+  // Delete both local and cloud invisble files
   virtual IOStatus DeleteCloudInvisibleFiles(
+      const std::vector<std::string>& active_cookies) = 0;
+  // Delete local invisible files. This could be helpful when there is one
+  // single instance managing lifetime of files in cloud while the other
+  // instances reference and download the files in cloud. The other instances
+  // can actively cleanup the local files once they are not needed.
+  virtual IOStatus DeleteLocalInvisibleFiles(
+      const std::string& dbname,
       const std::vector<std::string>& active_cookies) = 0;
 
   // Create a new AWS file system.


### PR DESCRIPTION
Follow up PR for https://github.com/rockset/rocksdb-cloud/pull/298. We have to define the function in `CloudFileSystem` so that services depending on rocksdb-cloud library can access it. 