### PR TITLE
Clarify CloudFileSystem API.

### DIFF
--- a/cloud/aws/aws_file_system.cc
+++ b/cloud/aws/aws_file_system.cc
@@ -1,22 +1,14 @@
 //  Copyright (c) 2016-present, Rockset, Inc.  All rights reserved.
 //
+#include "rocksdb/cloud/cloud_file_system.h"
 #ifndef ROCKSDB_LITE
-#include "cloud/aws/aws_file_system.h"
-
-#include <chrono>
-#include <cinttypes>
-#include <fstream>
-#include <iostream>
 #include <memory>
-#include <set>
 
+#include "cloud/aws/aws_file_system.h"
 #include "cloud/cloud_log_controller_impl.h"
-#include "cloud/cloud_scheduler.h"
-#include "rocksdb/cloud/cloud_storage_provider_impl.h"
-#include "cloud/filename.h"
-#include "port/port.h"
 #include "rocksdb/cloud/cloud_log_controller.h"
 #include "rocksdb/cloud/cloud_storage_provider.h"
+#include "rocksdb/cloud/cloud_storage_provider_impl.h"
 #include "rocksdb/env.h"
 #include "rocksdb/status.h"
 #include "rocksdb/utilities/object_registry.h"
@@ -28,7 +20,6 @@
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #endif
 
-#include "cloud/aws/aws_file.h"
 #include "cloud/db_cloud_impl.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -175,8 +166,7 @@ Status AwsCloudAccessCredentials::GetCredentialsProvider(
 AwsFileSystem::AwsFileSystem(const std::shared_ptr<FileSystem>& underlying_fs,
                              const CloudFileSystemOptions& _cloud_fs_options,
                              const std::shared_ptr<Logger>& info_log)
-    : CloudFileSystemImpl(_cloud_fs_options, underlying_fs, info_log) {
-}
+    : CloudFileSystemImpl(_cloud_fs_options, underlying_fs, info_log) {}
 
 // If you do not specify a region, then S3 buckets are created in the
 // standard-region which might not satisfy read-your-own-writes. So,
@@ -223,8 +213,8 @@ Status AwsFileSystem::NewAwsFileSystem(
   }
   std::unique_ptr<AwsFileSystem> afs(
       new AwsFileSystem(fs, cloud_options, info_log));
-
-  auto env = afs->NewCompositeEnvFromThis(Env::Default());
+  auto env =
+      CloudFileSystemEnv::NewCompositeEnvFromFs(afs.get(), Env::Default());
   ConfigOptions config_options;
   config_options.env = env.get();
   status = afs->PrepareOptions(config_options);

--- a/cloud/cloud_file_system.cc
+++ b/cloud/cloud_file_system.cc
@@ -11,16 +11,16 @@
 #include <unordered_map>
 
 #include "cloud/aws/aws_file_system.h"
-#include "rocksdb/cloud/cloud_file_system_impl.h"
 #include "cloud/cloud_log_controller_impl.h"
-#include "rocksdb/cloud/cloud_storage_provider_impl.h"
 #include "cloud/db_cloud_impl.h"
 #include "cloud/filename.h"
 #include "env/composite_env_wrapper.h"
 #include "options/configurable_helper.h"
 #include "options/options_helper.h"
 #include "port/likely.h"
+#include "rocksdb/cloud/cloud_file_system_impl.h"
 #include "rocksdb/cloud/cloud_log_controller.h"
+#include "rocksdb/cloud/cloud_storage_provider_impl.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
@@ -417,19 +417,19 @@ Status CloudFileSystemOptions::Serialize(const ConfigOptions& config_options,
       reinterpret_cast<const char*>(this), value);
 }
 
-CloudFileSystem::CloudFileSystem(const CloudFileSystemOptions& options,
-                                 const std::shared_ptr<FileSystem>& base,
-                                 const std::shared_ptr<Logger>& logger)
+CloudFileSystemEnv::CloudFileSystemEnv(const CloudFileSystemOptions& options,
+                                       const std::shared_ptr<FileSystem>& base,
+                                       const std::shared_ptr<Logger>& logger)
     : cloud_fs_options(options), base_fs_(base), info_log_(logger) {
   RegisterOptions(&cloud_fs_options, &cloud_fs_option_type_info);
 }
 
-CloudFileSystem::~CloudFileSystem() {
+CloudFileSystemEnv::~CloudFileSystemEnv() {
   cloud_fs_options.cloud_log_controller.reset();
   cloud_fs_options.storage_provider.reset();
 }
 
-Status CloudFileSystem::NewAwsFileSystem(
+Status CloudFileSystemEnv::NewAwsFileSystem(
     const std::shared_ptr<FileSystem>& base_fs,
     const std::string& src_cloud_bucket, const std::string& src_cloud_object,
     const std::string& src_cloud_region, const std::string& dest_cloud_bucket,
@@ -484,7 +484,7 @@ int DoRegisterCloudObjects(ObjectLibrary& library, const std::string& arg) {
   return count;
 }
 
-void CloudFileSystem::RegisterCloudObjects(const std::string& arg) {
+void CloudFileSystemEnv::RegisterCloudObjects(const std::string& arg) {
   static std::once_flag do_once;
   std::call_once(do_once, [&]() {
     auto library = ObjectLibrary::Default();
@@ -492,7 +492,7 @@ void CloudFileSystem::RegisterCloudObjects(const std::string& arg) {
   });
 }
 
-std::unique_ptr<Env> CloudFileSystem::NewCompositeEnvFromThis(Env* env) {
+std::unique_ptr<Env> CloudFileSystemEnv::NewCompositeEnvFromThis(Env* env) {
   // We need a shared_ptr<FileSystem> pointing to "this", to initialize the
   // env wrapper, but we don't want that shared_ptr to own the lifecycle for
   // "this". Creating a shared_ptr with a custom no-op deleter instead.
@@ -500,7 +500,7 @@ std::unique_ptr<Env> CloudFileSystem::NewCompositeEnvFromThis(Env* env) {
   return std::make_unique<CompositeEnvWrapper>(env, fs);
 }
 
-Status CloudFileSystem::CreateFromString(
+Status CloudFileSystemEnv::CreateFromString(
     const ConfigOptions& config_options, const std::string& value,
     std::unique_ptr<CloudFileSystem>* result) {
   RegisterCloudObjects();
@@ -529,7 +529,7 @@ Status CloudFileSystem::CreateFromString(
   copy.invoke_prepare_options = false;  // Prepare here, not there
   s = ObjectRegistry::NewInstance()->NewUniqueObject<FileSystem>(id, &fs);
   if (s.ok()) {
-    auto* cfs = dynamic_cast<CloudFileSystem*>(fs.get());
+    auto* cfs = dynamic_cast<CloudFileSystemEnv*>(fs.get());
     assert(cfs);
     if (!options.empty()) {
       s = cfs->ConfigureFromMap(copy, options);
@@ -553,7 +553,7 @@ Status CloudFileSystem::CreateFromString(
   return s;
 }
 
-Status CloudFileSystem::CreateFromString(
+Status CloudFileSystemEnv::CreateFromString(
     const ConfigOptions& config_options, const std::string& value,
     const CloudFileSystemOptions& cloud_options,
     std::unique_ptr<CloudFileSystem>* result) {
@@ -583,7 +583,7 @@ Status CloudFileSystem::CreateFromString(
   copy.invoke_prepare_options = false;  // Prepare here, not there
   s = ObjectRegistry::NewInstance()->NewUniqueObject<FileSystem>(id, &fs);
   if (s.ok()) {
-    auto* cfs = dynamic_cast<CloudFileSystem*>(fs.get());
+    auto* cfs = dynamic_cast<CloudFileSystemEnv*>(fs.get());
     assert(cfs);
     auto copts = cfs->GetOptions<CloudFileSystemOptions>();
     *copts = cloud_options;
@@ -610,18 +610,18 @@ Status CloudFileSystem::CreateFromString(
 }
 
 #ifndef USE_AWS
-Status CloudFileSystem::NewAwsFileSystem(
+Status CloudFileSystemEnv::NewAwsFileSystem(
     const std::shared_ptr<FileSystem>& /*base_fs*/,
     const CloudFileSystemOptions& /*options*/,
     const std::shared_ptr<Logger>& /*logger*/, CloudFileSystem** /*cfs*/) {
   return Status::NotSupported("RocksDB Cloud not compiled with AWS support");
 }
 #else
-Status CloudFileSystem::NewAwsFileSystem(
+Status CloudFileSystemEnv::NewAwsFileSystem(
     const std::shared_ptr<FileSystem>& base_fs,
     const CloudFileSystemOptions& options,
     const std::shared_ptr<Logger>& logger, CloudFileSystem** cfs) {
-  CloudFileSystem::RegisterCloudObjects();
+  CloudFileSystemEnv::RegisterCloudObjects();
   // Dump out cloud fs options
   options.Dump(logger.get());
 
@@ -640,9 +640,8 @@ Status CloudFileSystem::NewAwsFileSystem(
 }
 #endif
 
-std::unique_ptr<Env> CloudFileSystem::NewCompositeEnv(
-    Env* env,
-    const std::shared_ptr<FileSystem>& fs) {
+std::unique_ptr<Env> CloudFileSystemEnv::NewCompositeEnv(
+    Env* env, const std::shared_ptr<FileSystem>& fs) {
   return std::make_unique<CompositeEnvWrapper>(env, fs);
 }
 

--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -1,7 +1,6 @@
 // Copyright (c) 2017 Rockset.
+#include "rocksdb/utilities/options_type.h"
 #ifndef ROCKSDB_LITE
-
-#include "rocksdb/cloud/cloud_file_system_impl.h"
 
 #include <cinttypes>
 
@@ -10,14 +9,12 @@
 #include "cloud/cloud_scheduler.h"
 #include "cloud/filename.h"
 #include "cloud/manifest_reader.h"
-#include "db/db_impl/replication_codec.h"
-#include "env/composite_env_wrapper.h"
 #include "file/file_util.h"
 #include "file/filename.h"
 #include "file/writable_file_writer.h"
-#include "port/likely.h"
 #include "port/port_posix.h"
 #include "rocksdb/cloud/cloud_file_deletion_scheduler.h"
+#include "rocksdb/cloud/cloud_file_system_impl.h"
 #include "rocksdb/cloud/cloud_log_controller.h"
 #include "rocksdb/cloud/cloud_storage_provider.h"
 #include "rocksdb/db.h"
@@ -32,8 +29,13 @@ namespace ROCKSDB_NAMESPACE {
 
 CloudFileSystemImpl::CloudFileSystemImpl(
     const CloudFileSystemOptions& opts, const std::shared_ptr<FileSystem>& base,
-    const std::shared_ptr<Logger>& l)
-    : CloudFileSystemEnv(opts, base, l), purger_is_running_(true) {
+    const std::shared_ptr<Logger>& logger)
+    : info_log_(logger),
+      cloud_fs_options(opts),
+      base_fs_(base),
+      purger_is_running_(true) {
+  RegisterOptions(&cloud_fs_options,
+                  &CloudFileSystemOptions::cloud_fs_option_type_info);
   if (opts.cloud_file_deletion_delay) {
     cloud_file_deletion_scheduler_ = CloudFileDeletionScheduler::Create(
         CloudScheduler::Get(), *opts.cloud_file_deletion_delay);
@@ -45,6 +47,8 @@ CloudFileSystemImpl::~CloudFileSystemImpl() {
     cloud_fs_options.cloud_log_controller->StopTailingStream();
   }
   StopPurger();
+  cloud_fs_options.cloud_log_controller.reset();
+  cloud_fs_options.storage_provider.reset();
 }
 
 IOStatus CloudFileSystemImpl::ExistsCloudObject(const std::string& fname) {

--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -5,7 +5,6 @@
 
 #include <cinttypes>
 
-#include "rocksdb/cloud/cloud_file_deletion_scheduler.h"
 #include "cloud/cloud_log_controller_impl.h"
 #include "cloud/cloud_manifest.h"
 #include "cloud/cloud_scheduler.h"
@@ -18,6 +17,7 @@
 #include "file/writable_file_writer.h"
 #include "port/likely.h"
 #include "port/port_posix.h"
+#include "rocksdb/cloud/cloud_file_deletion_scheduler.h"
 #include "rocksdb/cloud/cloud_log_controller.h"
 #include "rocksdb/cloud/cloud_storage_provider.h"
 #include "rocksdb/db.h"
@@ -33,7 +33,7 @@ namespace ROCKSDB_NAMESPACE {
 CloudFileSystemImpl::CloudFileSystemImpl(
     const CloudFileSystemOptions& opts, const std::shared_ptr<FileSystem>& base,
     const std::shared_ptr<Logger>& l)
-    : CloudFileSystem(opts, base, l), purger_is_running_(true) {
+    : CloudFileSystemEnv(opts, base, l), purger_is_running_(true) {
   if (opts.cloud_file_deletion_delay) {
     cloud_file_deletion_scheduler_ = CloudFileDeletionScheduler::Create(
         CloudScheduler::Get(), *opts.cloud_file_deletion_delay);

--- a/cloud/cloud_file_system_test.cc
+++ b/cloud/cloud_file_system_test.cc
@@ -3,9 +3,9 @@
 #include "rocksdb/cloud/cloud_file_system.h"
 
 #include "cloud/cloud_log_controller_impl.h"
-#include "rocksdb/cloud/cloud_storage_provider_impl.h"
 #include "rocksdb/cloud/cloud_log_controller.h"
 #include "rocksdb/cloud/cloud_storage_provider.h"
+#include "rocksdb/cloud/cloud_storage_provider_impl.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/env.h"
 #include "test_util/testharness.h"
@@ -214,8 +214,8 @@ TEST(CloudFileSystemTest, DISABLED_ConfigureKinesisController) {
   ASSERT_OK(CloudFileSystem::CreateFromString(
       config_options, "id=aws; controller=kinesis; TEST=dbcloud:/test", &cfs));
   ASSERT_STREQ(cfs->Name(), "aws");
-  ASSERT_NE(cfs->GetLogController(), nullptr);
-  ASSERT_STREQ(cfs->GetLogController()->Name(),
+  ASSERT_NE(cfs->GetCloudFileSystemOptions().cloud_log_controller, nullptr);
+  ASSERT_STREQ(cfs->GetCloudFileSystemOptions().cloud_log_controller->Name(),
                CloudLogControllerImpl::kKinesis());
 #endif
 }
@@ -229,8 +229,8 @@ TEST(CloudFileSystemTest, ConfigureKafkaController) {
 #ifdef USE_KAFKA
   ASSERT_OK(s);
   ASSERT_NE(cfs, nullptr);
-  ASSERT_NE(cfs->GetLogController(), nullptr);
-  ASSERT_STREQ(cfs->GetLogController()->Name(),
+  ASSERT_NE(cfs->GetCloudFileSystemOptions().cloud_log_controller, nullptr);
+  ASSERT_STREQ(cfs->GetCloudFileSystemOptions().cloud_log_controller->Name(),
                CloudLogControllerImpl::kKafka());
 #else
   ASSERT_NOK(s);
@@ -244,4 +244,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-  

--- a/cloud/cloud_storage_provider.cc
+++ b/cloud/cloud_storage_provider.cc
@@ -4,20 +4,17 @@
 #include "rocksdb/cloud/cloud_storage_provider.h"
 
 #include <cinttypes>
-#include <mutex>
-#include <set>
 
-#include "rocksdb/cloud/cloud_file_system_impl.h"
-#include "rocksdb/cloud/cloud_storage_provider_impl.h"
 #include "cloud/filename.h"
 #include "file/filename.h"
 #include "rocksdb/cloud/cloud_file_system.h"
+#include "rocksdb/cloud/cloud_file_system_impl.h"
+#include "rocksdb/cloud/cloud_storage_provider_impl.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "rocksdb/status.h"
 #include "rocksdb/utilities/object_registry.h"
-#include "util/coding.h"
 #include "util/random.h"
 #include "util/string_util.h"
 
@@ -251,7 +248,8 @@ Status CloudStorageProvider::CreateFromString(
     provider->reset();
     return Status::OK();
   } else {
-    return ObjectRegistry::NewInstance()->NewSharedObject<CloudStorageProvider>(id, provider);
+    return ObjectRegistry::NewInstance()->NewSharedObject<CloudStorageProvider>(
+        id, provider);
   }
 }
 
@@ -289,7 +287,7 @@ Status CloudStorageProviderImpl::PrepareOptions(const ConfigOptions& options) {
 }
 
 CloudStorageProviderImpl::CloudStorageProviderImpl()
-  : rng_(std::make_unique<Random64>(time(nullptr))) {}
+    : rng_(std::make_unique<Random64>(time(nullptr))) {}
 
 CloudStorageProviderImpl::~CloudStorageProviderImpl() {}
 
@@ -315,8 +313,8 @@ IOStatus CloudStorageProviderImpl::GetCloudObject(
       local_destination + ".tmp-" + std::to_string(rng_->Next());
 
   uint64_t remote_size;
-  auto s = DoGetCloudObject(bucket_name, object_path, tmp_destination,
-                            &remote_size);
+  auto s =
+      DoGetCloudObject(bucket_name, object_path, tmp_destination, &remote_size);
   const IOOptions io_opts;
   IODebugContext* dbg = nullptr;
   if (!s.ok()) {

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -488,45 +488,15 @@ struct CloudManifestDelta {
   std::string epoch;  // epoch for the new manifest file
 };
 
-//
-// The Cloud file system
-//
-// NOTE: The AWS SDK must be initialized before the CloudFileSystem is
-// constructed, and remain active (Aws::ShutdownAPI() not called) as long as any
-// CloudFileSystem objects exist.
+/** Extension of the FileSystem API for "the Cloud" */
 class CloudFileSystem : public FileSystem {
- protected:
-  CloudFileSystemOptions cloud_fs_options;
-  std::shared_ptr<FileSystem> base_fs_;  // The underlying file system
-
-  // Creates a new CompositeEnv from "env" and "this".
-  // The returned Env must not outlive "this"
-  std::unique_ptr<Env> NewCompositeEnvFromThis(Env* env);
-
-  CloudFileSystem(const CloudFileSystemOptions& options,
-                  const std::shared_ptr<FileSystem>& base,
-                  const std::shared_ptr<Logger>& logger);
-
  public:
-  mutable std::shared_ptr<Logger> info_log_;  // informational messages
-
-  virtual ~CloudFileSystem();
-
-  static void RegisterCloudObjects(const std::string& mode = "");
-  static Status CreateFromString(const ConfigOptions& config_options,
-                                 const std::string& id,
-                                 std::unique_ptr<CloudFileSystem>* fs);
-  static Status CreateFromString(const ConfigOptions& config_options,
-                                 const std::string& id,
-                                 const CloudFileSystemOptions& cloud_options,
-                                 std::unique_ptr<CloudFileSystem>* fs);
   static const char* kCloud() { return "cloud"; }
   static const char* kAws() { return "aws"; }
-  virtual const char* Name() const { return "cloud-env"; }
+
   // Returns the underlying file system
-  const std::shared_ptr<FileSystem>& GetBaseFileSystem() const {
-    return base_fs_;
-  }
+  virtual const std::shared_ptr<FileSystem>& GetBaseFileSystem() const = 0;
+
   virtual IOStatus PreloadCloudManifest(const std::string& local_dbname) = 0;
   // This method will migrate the database that is using pure RocksDB into
   // RocksDB-Cloud. Call this before opening the database with RocksDB-Cloud.
@@ -549,52 +519,6 @@ class CloudFileSystem : public FileSystem {
                                DbidList* dblist) = 0;
   virtual IOStatus DeleteDbid(const std::string& bucket_prefix,
                               const std::string& dbid) = 0;
-
-  Logger* GetLogger() const { return info_log_.get(); }
-  const std::shared_ptr<CloudStorageProvider>& GetStorageProvider() const {
-    return cloud_fs_options.storage_provider;
-  }
-
-  const std::shared_ptr<CloudLogController>& GetLogController() const {
-    return cloud_fs_options.cloud_log_controller;
-  }
-
-  // The SrcBucketName identifies the cloud storage bucket and
-  // GetSrcObjectPath specifies the path inside that bucket
-  // where data files reside. The specified bucket is used in
-  // a readonly mode by the associated DBCloud instance.
-  const std::string& GetSrcBucketName() const {
-    return cloud_fs_options.src_bucket.GetBucketName();
-  }
-  const std::string& GetSrcObjectPath() const {
-    return cloud_fs_options.src_bucket.GetObjectPath();
-  }
-  bool HasSrcBucket() const { return cloud_fs_options.src_bucket.IsValid(); }
-
-  // The DestBucketName identifies the cloud storage bucket and
-  // GetDestObjectPath specifies the path inside that bucket
-  // where data files reside. The associated DBCloud instance
-  // writes newly created files to this bucket.
-  const std::string& GetDestBucketName() const {
-    return cloud_fs_options.dest_bucket.GetBucketName();
-  }
-  const std::string& GetDestObjectPath() const {
-    return cloud_fs_options.dest_bucket.GetObjectPath();
-  }
-
-  bool HasDestBucket() const { return cloud_fs_options.dest_bucket.IsValid(); }
-  bool SrcMatchesDest() const {
-    if (HasSrcBucket() && HasDestBucket()) {
-      return cloud_fs_options.src_bucket == cloud_fs_options.dest_bucket;
-    } else {
-      return false;
-    }
-  }
-
-  // returns the options used to create this object
-  const CloudFileSystemOptions& GetCloudFileSystemOptions() const {
-    return cloud_fs_options;
-  }
 
   // Deletes file from a destination bucket.
   virtual IOStatus DeleteCloudFileFromDest(const std::string& fname) = 0;
@@ -662,6 +586,117 @@ class CloudFileSystem : public FileSystem {
   virtual IOStatus DeleteLocalInvisibleFiles(
       const std::string& dbname,
       const std::vector<std::string>& active_cookies) = 0;
+
+  // returns the options used to create this object
+  virtual const CloudFileSystemOptions& GetCloudFileSystemOptions() const = 0;
+
+  // The SrcBucketName identifies the cloud storage bucket and
+  // GetSrcObjectPath specifies the path inside that bucket
+  // where data files reside. The specified bucket is used in
+  // a readonly mode by the associated DBCloud instance.
+  virtual const std::string& GetSrcBucketName() const = 0;
+  virtual const std::string& GetSrcObjectPath() const = 0;
+  virtual bool HasSrcBucket() const = 0;
+
+  // The DestBucketName identifies the cloud storage bucket and
+  // GetDestObjectPath specifies the path inside that bucket
+  // where data files reside. The associated DBCloud instance
+  // writes newly created files to this bucket.
+  virtual const std::string& GetDestBucketName() const = 0;
+  virtual const std::string& GetDestObjectPath() const = 0;
+  virtual bool HasDestBucket() const = 0;
+
+  virtual bool SrcMatchesDest() const = 0;
+
+  // Get the storage provider for the FileSystem.
+  virtual const std::shared_ptr<CloudStorageProvider>& GetStorageProvider()
+      const = 0;
+
+  virtual Logger* GetLogger() const = 0;
+};
+
+//
+// The Cloud file system
+//
+// NOTE: The AWS SDK must be initialized before the CloudFileSystem is
+// constructed, and remain active (Aws::ShutdownAPI() not called) as long as any
+// CloudFileSystem objects exist.
+class CloudFileSystemEnv : public CloudFileSystem {
+ protected:
+  CloudFileSystemOptions cloud_fs_options;
+  std::shared_ptr<FileSystem> base_fs_;  // The underlying file system
+
+  // Creates a new CompositeEnv from "env" and "this".
+  // The returned Env must not outlive "this"
+  std::unique_ptr<Env> NewCompositeEnvFromThis(Env* env);
+
+  CloudFileSystemEnv(const CloudFileSystemOptions& options,
+                     const std::shared_ptr<FileSystem>& base,
+                     const std::shared_ptr<Logger>& logger);
+
+ public:
+  mutable std::shared_ptr<Logger> info_log_;  // informational messages
+
+  virtual ~CloudFileSystemEnv();
+
+  static void RegisterCloudObjects(const std::string& mode = "");
+  static Status CreateFromString(const ConfigOptions& config_options,
+                                 const std::string& id,
+                                 std::unique_ptr<CloudFileSystem>* fs);
+  static Status CreateFromString(const ConfigOptions& config_options,
+                                 const std::string& id,
+                                 const CloudFileSystemOptions& cloud_options,
+                                 std::unique_ptr<CloudFileSystem>* fs);
+
+  const char* Name() const override { return "cloud-env"; }
+
+  const std::shared_ptr<FileSystem>& GetBaseFileSystem() const override {
+    return base_fs_;
+  }
+
+  Logger* GetLogger() const override { return info_log_.get(); }
+
+  const std::shared_ptr<CloudStorageProvider>& GetStorageProvider()
+      const override {
+    return cloud_fs_options.storage_provider;
+  }
+
+  const std::shared_ptr<CloudLogController>& GetLogController() const {
+    return cloud_fs_options.cloud_log_controller;
+  }
+
+  const std::string& GetSrcBucketName() const override {
+    return cloud_fs_options.src_bucket.GetBucketName();
+  }
+  const std::string& GetSrcObjectPath() const override {
+    return cloud_fs_options.src_bucket.GetObjectPath();
+  }
+  bool HasSrcBucket() const override {
+    return cloud_fs_options.src_bucket.IsValid();
+  }
+
+  const std::string& GetDestBucketName() const override {
+    return cloud_fs_options.dest_bucket.GetBucketName();
+  }
+  const std::string& GetDestObjectPath() const override {
+    return cloud_fs_options.dest_bucket.GetObjectPath();
+  }
+
+  bool HasDestBucket() const override {
+    return cloud_fs_options.dest_bucket.IsValid();
+  }
+  bool SrcMatchesDest() const override {
+    if (HasSrcBucket() && HasDestBucket()) {
+      return cloud_fs_options.src_bucket == cloud_fs_options.dest_bucket;
+    } else {
+      return false;
+    }
+  }
+
+  // returns the options used to create this object
+  const CloudFileSystemOptions& GetCloudFileSystemOptions() const override {
+    return cloud_fs_options;
+  }
 
   // Create a new AWS file system.
   // src_bucket_name: bucket name suffix where db data is read from

--- a/include/rocksdb/cloud/cloud_file_system_impl.h
+++ b/include/rocksdb/cloud/cloud_file_system_impl.h
@@ -4,8 +4,8 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <thread>
 #include <set>
+#include <thread>
 
 #include "rocksdb/cloud/cloud_file_system.h"
 #include "rocksdb/file_system.h"
@@ -22,8 +22,8 @@ class CloudFileDeletionScheduler;
 //
 // The Cloud file system
 //
-class CloudFileSystemImpl : public CloudFileSystem {
-  friend class CloudFileSystem;
+class CloudFileSystemImpl : public CloudFileSystemEnv {
+  friend class CloudFileSystemEnv;
 
  public:
   static int RegisterAwsObjects(ObjectLibrary& library, const std::string& arg);
@@ -367,6 +367,7 @@ class CloudFileSystemImpl : public CloudFileSystem {
   IOStatus DeleteLocalInvisibleFiles(
       const std::string& dbname,
       const std::vector<std::string>& active_cookies) override;
+
  private:
   // Files are invisibile if:
   // - It's CLOUDMANFIEST file and cookie is not active. NOTE: empty cookie is

--- a/include/rocksdb/cloud/cloud_file_system_impl.h
+++ b/include/rocksdb/cloud/cloud_file_system_impl.h
@@ -22,10 +22,12 @@ class CloudFileDeletionScheduler;
 //
 // The Cloud file system
 //
-class CloudFileSystemImpl : public CloudFileSystemEnv {
+class CloudFileSystemImpl : public CloudFileSystem {
   friend class CloudFileSystemEnv;
 
  public:
+  mutable std::shared_ptr<Logger> info_log_;  // informational messages
+
   static int RegisterAwsObjects(ObjectLibrary& library, const std::string& arg);
   // Constructor
   CloudFileSystemImpl(const CloudFileSystemOptions& options,
@@ -34,7 +36,12 @@ class CloudFileSystemImpl : public CloudFileSystemEnv {
 
   virtual ~CloudFileSystemImpl();
   static const char* kClassName() { return kCloud(); }
-  virtual const char* Name() const override { return kClassName(); }
+
+  const std::shared_ptr<FileSystem>& GetBaseFileSystem() const override {
+    return base_fs_;
+  }
+
+  const char* Name() const override { return kClassName(); }
 
   IOStatus NewSequentialFile(const std::string& fname,
                              const FileOptions& file_opts,
@@ -285,6 +292,9 @@ class CloudFileSystemImpl : public CloudFileSystemEnv {
 #endif
 
  protected:
+  CloudFileSystemOptions cloud_fs_options;
+  std::shared_ptr<FileSystem> base_fs_;  // The underlying file system
+
   Status CheckValidity() const;
   // Status TEST_Initialize(const std::string& name) override;
   // The pathname that contains a list of all db's inside a bucket.
@@ -367,6 +377,47 @@ class CloudFileSystemImpl : public CloudFileSystemEnv {
   IOStatus DeleteLocalInvisibleFiles(
       const std::string& dbname,
       const std::vector<std::string>& active_cookies) override;
+
+ public:
+  // returns the options used to create this object
+  const CloudFileSystemOptions& GetCloudFileSystemOptions() const override {
+    return cloud_fs_options;
+  }
+
+  const std::string& GetSrcBucketName() const override {
+    return cloud_fs_options.src_bucket.GetBucketName();
+  }
+  const std::string& GetSrcObjectPath() const override {
+    return cloud_fs_options.src_bucket.GetObjectPath();
+  }
+  bool HasSrcBucket() const override {
+    return cloud_fs_options.src_bucket.IsValid();
+  }
+
+  const std::string& GetDestBucketName() const override {
+    return cloud_fs_options.dest_bucket.GetBucketName();
+  }
+  const std::string& GetDestObjectPath() const override {
+    return cloud_fs_options.dest_bucket.GetObjectPath();
+  }
+
+  bool HasDestBucket() const override {
+    return cloud_fs_options.dest_bucket.IsValid();
+  }
+  bool SrcMatchesDest() const override {
+    if (HasSrcBucket() && HasDestBucket()) {
+      return cloud_fs_options.src_bucket == cloud_fs_options.dest_bucket;
+    } else {
+      return false;
+    }
+  }
+
+  const std::shared_ptr<CloudStorageProvider>& GetStorageProvider()
+      const override {
+    return cloud_fs_options.storage_provider;
+  }
+
+  Logger* GetLogger() const override { return info_log_.get(); }
 
  private:
   // Files are invisibile if:


### PR DESCRIPTION
Splitting the CloudFileSystem class into a pure interface class
and a separate class that contains static initialization and factory
methods (CloudFileSystemEnv).
This will make it possible to provide other implementations of CloudFileSystem
wihtout having to wrangle with static functions and options.
