### PR TITLE
[sys-7056] don't treat pruned (epoch,mus) as diverged

### DIFF
--- a/cloud/replication_test.cc
+++ b/cloud/replication_test.cc
@@ -1431,7 +1431,7 @@ TEST_F(ReplicationTest, ReplicationEpochs) {
       leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().empty());
 
   ASSERT_OK(leader->Put(wo(), leaderCF(cf(0)), "k2", "v2"));
-  ASSERT_OK(leader->Flush(FlushOptions()));
+  ASSERT_OK(leader->Flush(FlushOptions(), leaderCF(cf(0))));
 
   catchUpFollower();
 
@@ -1441,7 +1441,7 @@ TEST_F(ReplicationTest, ReplicationEpochs) {
 
   UpdateLeaderEpoch(3);
   ASSERT_OK(leader->Put(wo(), leaderCF(cf(0)), "k3", "v3"));
-  ASSERT_OK(leader->Flush(FlushOptions()));
+  ASSERT_OK(leader->Flush(FlushOptions(), leaderCF(cf(0))));
 
   catchUpFollower();
   ASSERT_EQ(leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().size(),
@@ -1453,6 +1453,62 @@ TEST_F(ReplicationTest, ReplicationEpochs) {
 
   ASSERT_EQ(leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().size(),
             1);
+}
+
+TEST_F(ReplicationTest, MaxNumReplicationEpochs) {
+  auto options = leaderOptions();
+  options.disable_auto_compactions = true;
+  options.disable_auto_flush = true;
+  // maintain at most two replication epochs in the set
+  options.max_num_replication_epochs = 2;
+  auto leader = openLeader(options);
+  openFollower(options);
+
+  auto cf = [](int i) { return "cf" + std::to_string(i); };
+
+  createColumnFamily(cf(0));
+
+  UpdateLeaderEpoch(2);
+
+  ASSERT_OK(leader->Put(wo(), leaderCF(cf(0)), "k1", "v1"));
+  ASSERT_OK(leader->Flush(FlushOptions(), leaderCF(cf(0))));
+
+  ASSERT_EQ(leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().size(),
+            1);
+
+  catchUpFollower();
+  verifyReplicationEpochsEqual();
+
+  UpdateLeaderEpoch(3);
+  // generate some manifest writes without changing persisted replication
+  // sequence
+  ASSERT_OK(leader->SetOptions(leaderCF(cf(0)), {{"max_write_buffer_number", "3"}}));
+
+  ASSERT_EQ(leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().size(),
+            2);
+  
+  UpdateLeaderEpoch(4);
+  // generate some manifest writes without changing persisted replication
+  // sequence
+  ASSERT_OK(leader->SetOptions(leaderCF(cf(0)), {{"max_write_buffer_number", "2"}}));
+
+  ASSERT_EQ(leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().size(),
+            2);
+  ASSERT_EQ(leaderFull()
+                ->GetVersionSet()
+                ->TEST_GetReplicationEpochSet()
+                .GetSmallestEpoch(),
+            3);
+
+  catchUpFollower();
+  verifyReplicationEpochsEqual();
+
+  closeLeader();
+  leader = openLeader(options);
+  ASSERT_EQ(leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().size(),
+            2);
+  ASSERT_EQ(leaderFull()->GetVersionSet()->TEST_GetReplicationEpochSet().GetSmallestEpoch(),
+            3);
 }
 
 }  //  namespace ROCKSDB_NAMESPACE

--- a/db/replication_epoch_edit.cc
+++ b/db/replication_epoch_edit.cc
@@ -51,7 +51,7 @@ Status ReplicationEpochSet::AddEpoch(const ReplicationEpochAddition& epoch,
     return Status::Corruption(ss.str());
   }
 
-  while (epochs_.size() + 1 >= max_num_replication_epochs) {
+  while (epochs_.size() >= max_num_replication_epochs) {
     epochs_.pop_front();
   }
   epochs_.push_back(epoch);

--- a/db/replication_epoch_edit.h
+++ b/db/replication_epoch_edit.h
@@ -101,9 +101,13 @@ class ReplicationEpochSet {
   std::optional<uint64_t> GetEpochForMUS(uint64_t mus) const;
 
   const auto& GetEpochs() const { return epochs_; }
+  uint64_t GetSmallestEpoch() const {
+    return epochs_.front().GetEpoch();
+  }
 
   bool empty() const { return epochs_.empty(); }
   auto size() const { return epochs_.size(); }
+
 
  private:
   Status AddEpoch(const ReplicationEpochAddition& epoch,


### PR DESCRIPTION
Usually `ReplicationEpochSet` covers all (epoch, first mus) after the persisted replication sequence. But it's possible that `ReplicationEpochSet` only covers the most recent `max_num_replication_epochs` if there are too many of them. This can happen for collections without active writes. Following corner case is possible:

* follower prunes replication epochs since there are too many of them
* follower is reopened, it will realize that there are (epoch, mus) < `ReplicationEpochSet` in local log, i.e, pruned (epoch,mus), so follower decides to cleanup local log and reopens db.
* follower reopens and starts to tail from leader, but leader's local log also contains these pruned (epoch, mus). There is no way that follower can recover from this without reopening leader.

The solution in this PR is to simply not treat the pruned (epoch, mus) as diverged record. This is fine since we can still rely on the most recent (epoch, mus) in the set for divergence detection
## TEST
- [x] Added a test to repro the corner case. 