### PR TITLE
[SYS-7306] Flush all column families when replication_log_listener exists

### DIFF
--- a/cloud/replication_test.cc
+++ b/cloud/replication_test.cc
@@ -705,6 +705,15 @@ TEST_F(ReplicationTest, MultiColumnFamily) {
   // Atomic flush, will flush all column families
   ASSERT_OK(leader->Flush(FlushOptions()));
 
+  {
+    // Make sure that CF5 was also flushed, even though it wasn't in the list of
+    // CFs in the call to Flush() above
+    ReadOptions ro;
+    ro.read_tier = kPersistedTier;
+    ASSERT_OK(leader->Get(ro, leaderCF(cf(5)), "key5", &val));
+    EXPECT_EQ(val, "val5");
+  }
+
   for (size_t i = 0; i < 1000; ++i) {
     ASSERT_OK(follower->Get(ReadOptions(), followerCF(cf(i % 10)),
                             "key" + std::to_string(i), &val));

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2465,7 +2465,13 @@ Status DBImpl::AtomicFlushMemTables(
     }
     WaitForPendingWrites();
 
-    SelectColumnFamiliesForAtomicFlush(&cfds, candidate_cfds);
+    // We are only allowed to flush all column families if
+    // replication_log_listener exists, i.e. we ignore candidate_cfds
+    if (immutable_db_options_.replication_log_listener) {
+      SelectColumnFamiliesForAtomicFlush(&cfds);
+    } else {
+      SelectColumnFamiliesForAtomicFlush(&cfds, candidate_cfds);
+    }
 
     MemTableSwitchRecord mem_switch_record;
     std::string replication_sequence;


### PR DESCRIPTION
Summary:
This was broken when resolving merge conflicts on RocksDB 8.9.1 upgrade.

Test Plan:
Added a unit test

Reviewers:
