### PR TITLE
[sys-7568] divergence detection for the case of no manifest write gen…

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -425,6 +425,7 @@ class DBImpl : public DB {
                                    std::string replication_sequence,
                                    CFOptionsFactory cf_options_factory,
                                    bool allow_new_manifest_writes,
+                                   uint64_t snapshot_replication_epoch,
                                    ApplyReplicationLogRecordInfo* info,
                                    unsigned flags) override;
 

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -3437,6 +3437,7 @@ class ModelDB : public DB {
                                    std::string /*replication_sequence*/,
                                    CFOptionsFactory /* cf_options_factory */,
                                    bool /* allow_new_manifest_writes */,
+                                   uint64_t /* snapshot_replication_epoch */,
                                    ApplyReplicationLogRecordInfo* /*info*/,
                                    unsigned /*flags*/) override {
     return Status::NotSupported("Not supported in Model DB");

--- a/db/replication_epoch_edit.h
+++ b/db/replication_epoch_edit.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <deque>
 #include <optional>
@@ -102,7 +103,12 @@ class ReplicationEpochSet {
 
   const auto& GetEpochs() const { return epochs_; }
   uint64_t GetSmallestEpoch() const {
+    assert(!epochs_.empty());
     return epochs_.front().GetEpoch();
+  }
+  uint64_t GetLargestEpoch() const {
+    assert(!epochs_.empty());
+    return epochs_.back().GetEpoch();
   }
 
   bool empty() const { return epochs_.empty(); }

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1511,6 +1511,7 @@ class DB {
                                            std::string replication_sequence,
                                            CFOptionsFactory cf_options_factory,
                                            bool allow_new_manifest_writes,
+                                           uint64_t snapshot_replication_epoch,
                                            ApplyReplicationLogRecordInfo* info,
                                            unsigned flags = 0) = 0;
   virtual Status GetReplicationRecordDebugString(

--- a/include/rocksdb/utilities/stackable_db.h
+++ b/include/rocksdb/utilities/stackable_db.h
@@ -560,11 +560,12 @@ class StackableDB : public DB {
                                    std::string replication_sequence,
                                    CFOptionsFactory cf_options_factory,
                                    bool allow_new_manifest_writes,
+                                   uint64_t snapshot_replication_epoch,
                                    ApplyReplicationLogRecordInfo* info,
                                    unsigned flags) override {
     return db_->ApplyReplicationLogRecord(
         record, replication_sequence, std::move(cf_options_factory),
-        allow_new_manifest_writes, info, flags);
+        allow_new_manifest_writes, snapshot_replication_epoch, info, flags);
   }
   Status GetReplicationRecordDebugString(const ReplicationLogRecord& record,
                                          std::string* out) const override {


### PR DESCRIPTION
…erated for snapshot epoch


This PR fixed a bug Igor found [here](https://rockset-io.slack.com/archives/C6NLH9D5G/p1712702703356129?thread_ts=1712695636.949789&cid=C6NLH9D5G). Basically the epoch based divergence detection misses one corner case: it's possible that follower pulls the snapshot manifest from s3 at epoch `e` before the leader flushes the first manifest writes for the snapshot epoch. As a result, the snapshot doesn't contain the `(e, first mus)` pair and can't detect divergence if local replication log contains more manifest writes at epoch: `e - 1`.  The reasoning behind the fix is:

For a given snapshot `S`, suppose snapshot epoch is `S(e)` and snapshot mus is `S(mus)`. Largest replication epoch and corresponding first mus in the replication epoch set is: `(e_r, mus_r)`. 

There are following cases:
If `e_r` == `S(e)`:
* case 1: for any `mus` <= `S(mus)`, since replication epoch set of the snapshot contains `(e, first mus)` pairs for all replication epochs after the persisted replication sequence, we can simply detect divergence by comparing the inferred epoch from the replication epoch set against the epoch of replication log.
* case 2: for any `mus` > `S(mus)`, these records are not diverged from the snapshot S. But they can still be diverged from the leader and we detect divergence when connecting to leader.

If `e_r` < `S(e)`: 
* case 3: for any `mus` <= `S(mus)`, we know for sure that epoch of `mus` <= `e_r`. So we can do the same thing as the case of `e_r == S(e)`, i.e, rely on the inferred epoch for divergence detection.

* case 4: for first `mus` > `S(mus)`, we know that this is expected to be the first `mus` of `S(e)`. So the epoch in the replication log should be equal to `S(e)`.  If this manifest write is  applied, the replication epoch set should be updated.
* case 5: for any `mus` > `S(mus)` + 1, since replication epoch set has been updated with `S(e)`, we go back to case 2.

## TEST
- [x] since this involves leader election, related changes are tested in rockset tests.
