### PR TITLE
remove --copy-dt-needed-entries when linking exes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,7 +621,6 @@ if(USE_FOLLY)
   add_compile_definitions(USE_FOLLY FOLLY_NO_CONFIG HAVE_CXX11_ATOMIC)
   list(APPEND THIRDPARTY_LIBS Folly::folly)
   set(FOLLY_LIBS Folly::folly)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--copy-dt-needed-entries")
 endif()
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
Summary:
This linker flag does not seem to be needed, and prevents use of gold or lld at link time.

Test Plan:
* build using llvm thinLTO