### PR TITLE
Remove extra slash for manifest file path

### DIFF
--- a/cloud/cloud_file_system_impl.cc
+++ b/cloud/cloud_file_system_impl.cc
@@ -2307,6 +2307,9 @@ IOStatus CloudFileSystemImpl::FindLiveFilesFromLocalManifest(
 }
 
 std::string CloudFileSystemImpl::CloudManifestFile(const std::string& dbname) {
+  if (dbname.empty()) {
+    return MakeCloudManifestFile(cloud_fs_options.cookie_on_open);
+  }
   return MakeCloudManifestFile(dbname, cloud_fs_options.cookie_on_open);
 }
 

--- a/cloud/db_cloud_impl.cc
+++ b/cloud/db_cloud_impl.cc
@@ -336,7 +336,7 @@ Status DBCloudImpl::DoCheckpointToCloud(
 
   // Create a temp MANIFEST file first as this captures all the files we need
   auto current_epoch = cfs->GetCloudManifest()->GetCurrentEpoch();
-  auto manifest_fname = ManifestFileWithEpoch("", current_epoch);
+  auto manifest_fname = ManifestFileWithEpoch(current_epoch);
   auto tmp_manifest_fname = manifest_fname + ".tmp";
   st = CopyFile(local_fs.get(), GetName() + "/" + manifest_fname,
                 Temperature::kUnknown, GetName() + "/" + tmp_manifest_fname,

--- a/cloud/filename.h
+++ b/cloud/filename.h
@@ -2,12 +2,11 @@
 
 #pragma once
 
+#include <rocksdb/slice.h>
+
 #include <algorithm>
 #include <functional>
 #include <string>
-#include <cstring>
-
-#include <rocksdb/slice.h>
 
 //
 // These are inlined methods to deal with pathnames and filenames.
@@ -81,17 +80,23 @@ inline bool ends_with(std::string const& value, std::string const& ending) {
   return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
-inline std::string MakeCloudManifestFile(const std::string& dbname, const std::string& cookie) {
-  return cookie.empty() ? (dbname + "/CLOUDMANIFEST")
-                        : (dbname + "/CLOUDMANIFEST-" + cookie);
+inline std::string MakeCloudManifestFile(const std::string& cookie) {
+  return cookie.empty() ? "CLOUDMANIFEST" : "CLOUDMANIFEST-" + cookie;
+}
+inline std::string MakeCloudManifestFile(const std::string& dbname,
+                                         const std::string& cookie) {
+  assert(!dbname.empty());
+  return dbname + "/" + MakeCloudManifestFile(cookie);
 }
 
+inline std::string ManifestFileWithEpoch(const std::string& epoch) {
+  return epoch.empty() ? "MANIFEST" : "MANIFEST-" + epoch;
+}
 inline std::string ManifestFileWithEpoch(const std::string& dbname,
                                          const std::string& epoch) {
-  return epoch.empty() ? (dbname + "/MANIFEST")
-                       : (dbname + "/MANIFEST-" + epoch);
+  assert(!dbname.empty());
+  return dbname + "/" + ManifestFileWithEpoch(epoch);
 }
-
 
 inline std::string RemoveEpoch(const std::string& path) {
   auto lastDash = path.rfind('-');
@@ -114,7 +119,7 @@ inline std::string GetCookie(const std::string& cloud_manifest_file_path) {
     return "";
   }
 
-  return cloud_manifest_fname.substr(firstDash+1);
+  return cloud_manifest_fname.substr(firstDash + 1);
 }
 
 // pathaname seperator


### PR DESCRIPTION
For azure blob store, "/a/b" is different from "/a//b", so we can't have any extra slashes.