### PR TITLE
fix(purger): Fix the purger loop

### DIFF
--- a/cloud/purge.cc
+++ b/cloud/purge.cc
@@ -34,7 +34,7 @@ void CloudFileSystemImpl::Purger() {
 
   while (true) {
     std::unique_lock<std::mutex> lk(purger_lock_);
-    purger_cv_.wait_for(lk, period, [&]() { return purger_is_running_; });
+    purger_cv_.wait_for(lk, period, [&]() { return !purger_is_running_; });
     if (!purger_is_running_) {
       break;
     }


### PR DESCRIPTION
Right now the purger loops forever without waiting for `purger_periodicity_millis` between two runs. That's a bug. Additionally, when the purger is stopped, it waits the configured periodicity (10 minutes by default) before stopping. This is a real problem when one wants to gracefully shut down a DB. 

This PR fixes it.

By toggling the precondition of `wait_for`, the purger now waits the right duration between two runs and shutdown on demand without waiting which is the intended behavior.