### PR TITLE
doc: Fix run_purger doc

### DIFF
--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -272,9 +272,8 @@ class CloudFileSystemOptions {
   // means the default timeout assigned by the underlying cloud storage.
   uint64_t request_timeout_ms;
 
-  // Use this to turn off the purger. You can do this if you don't use the clone
-  // feature of RocksDB cloud
-  // Default: true
+  // Use this to turn on the purger (this is currently not recommended).
+  // Default: false
   bool run_purger;
 
   // If true, we will sync local snapshot(i.e, CLOUDMANIFEST and MANIFEST files)


### PR DESCRIPTION
It won't close [the issue](https://github.com/rockset/rocksdb-cloud/issues/338) with the purger. But at least the doc won't be as misleading as it was.