### PR TITLE
feat: Expose AWS `endpointOverride` option

### DIFF
--- a/cloud/aws/aws_retry.cc
+++ b/cloud/aws/aws_retry.cc
@@ -127,6 +127,7 @@ Status AwsCloudOptions::GetClientConfiguration(
   if (cloud_fs_options.request_timeout_ms != 0) {
     config->requestTimeoutMs = cloud_fs_options.request_timeout_ms;
   }
+  config->endpointOverride = cloud_env_options.aws_options.endpoint_override;
 
   config->region = ToAwsString(region);
   return Status::OK();

--- a/include/rocksdb/cloud/cloud_file_system.h
+++ b/include/rocksdb/cloud/cloud_file_system.h
@@ -98,6 +98,13 @@ using S3ClientFactory = std::function<std::shared_ptr<Aws::S3::S3Client>(
     const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>&,
     const Aws::Client::ClientConfiguration&)>;
 
+// Additional AWS options
+class AwsOptions {
+ public:
+  // Override the http endpoint used to talk to a service.
+  std::string endpoint_override;
+};
+
 // Defines parameters required to connect to Kafka
 class KafkaLogOptions {
  public:
@@ -208,6 +215,9 @@ class CloudFileSystemOptions {
   // the cloud fs be used.
   // Default:  null
   std::shared_ptr<CloudStorageProvider> storage_provider;
+
+  // AWS additional options
+  AwsOptions aws_options;
 
   // Access credentials
   AwsCloudAccessCredentials credentials;


### PR DESCRIPTION
This allows you to connect to a local `minio` server. This is based on [this idea](https://github.com/rockset/rocksdb-cloud/issues/45).

It adds a new option `endpoint_override` which is given to the S3 client. I wrapped it up in a new struct `AwsOptions` like in the original idea as it opens the door to additional useful settings such as proxy, scheme, etc... Let me know if you want me to add some of them as part of this PR.

As for me, this is good enough to connect to a local `minio` server:
- I set the bucket prefix to "" (It currently defaults to `"rockset."` and AWS will try to resolve the bucket name as a domain in this case)
- I set `endpoint_override` to `"http://127.0.0.1:9000"`