### PR TITLE
Avoid `error: invalid application of 'sizeof' to an incomplete type 'rocksdb:xxx'` when compiling with C++-23

### DIFF
--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -17,15 +17,6 @@
 #include "table/internal_iterator.h"
 
 namespace ROCKSDB_NAMESPACE {
-struct FragmentedRangeTombstoneList;
-
-struct FragmentedRangeTombstoneListCache {
-  // ensure only the first reader needs to initialize l
-  std::mutex reader_mutex;
-  std::unique_ptr<FragmentedRangeTombstoneList> tombstones = nullptr;
-  // readers will first check this bool to avoid
-  std::atomic<bool> initialized = false;
-};
 
 struct FragmentedRangeTombstoneList {
  public:
@@ -123,6 +114,14 @@ struct FragmentedRangeTombstoneList {
   uint64_t num_unfragmented_tombstones_;
   uint64_t total_tombstone_payload_bytes_;
 };
+struct FragmentedRangeTombstoneListCache {
+  // ensure only the first reader needs to initialize l
+  std::mutex reader_mutex;
+  std::unique_ptr<FragmentedRangeTombstoneList> tombstones = nullptr;
+  // readers will first check this bool to avoid
+  std::atomic<bool> initialized = false;
+};
+
 
 // FragmentedRangeTombstoneIterator converts an InternalIterator of a range-del
 // meta block into an iterator over non-overlapping tombstone fragments. The

--- a/util/xxhash.h
+++ b/util/xxhash.h
@@ -2058,6 +2058,9 @@ static int XXH_isLittleEndian(void)
 #endif
 
 
+#if defined (__cplusplus)
+}
+#endif
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ > 201710L)
 /* C23 and future versions have standard "unreachable()" */
 #  include <stddef.h>
@@ -2078,6 +2081,9 @@ static int XXH_isLittleEndian(void)
 #  define XXH_UNREACHABLE()
 #endif
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
 #define XXH_ASSUME(c) if (!(c)) { XXH_UNREACHABLE(); }
 
 /*!

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
@@ -35,6 +35,7 @@ BaseDeltaIterator::BaseDeltaIterator(ColumnFamilyHandle* column_family,
   assert(delta_iterator_);
   assert(comparator_);
 }
+inline BaseDeltaIterator::~BaseDeltaIterator() {};
 
 bool BaseDeltaIterator::Valid() const {
   return status_.ok() ? (current_at_base_ ? BaseValid() : DeltaValid()) : false;

--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
+++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
@@ -38,7 +38,7 @@ class BaseDeltaIterator : public Iterator {
                     WBWIIteratorImpl* delta_iterator,
                     const Comparator* comparator);
 
-  ~BaseDeltaIterator() override {}
+  ~BaseDeltaIterator() override;
 
   bool Valid() const override;
   void SeekToFirst() override;


### PR DESCRIPTION
When trying to compile with c++-23 I'm getting errors like:

```
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/unique_ptr.h:91:16: error: invalid application of 'sizeof' to an incomplete type 'rocksdb::FragmentedRangeTombstoneList'
   91 |         static_assert(sizeof(_Tp)>0,
      |                       ^~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/unique_ptr.h:398:4: note: in instantiation of member function 'std::default_delete<rocksdb::FragmentedRangeTombstoneList>::operator()' requested here
  398 |           get_deleter()(std::move(__ptr));
      |           ^
cpp/third-party/rocksdb-cloud/db/range_tombstone_fragmenter.h:25:62: note: in instantiation of member function 'std::unique_ptr<rocksdb::FragmentedRangeTombstoneList>::~unique_ptr' requested here
   25 |   std::unique_ptr<FragmentedRangeTombstoneList> tombstones = nullptr;
      |                                                              ^
cpp/third-party/rocksdb-cloud/db/range_tombstone_fragmenter.h:20:8: note: forward declaration of 'rocksdb::FragmentedRangeTombstoneList'
   20 | struct FragmentedRangeTombstoneList;
      |        ^
```

With this fix declaration are reargenged to avoid this and when not possible we give explicit constructor/destructors and move them to a different place (ie. not in the headers).
