### PR TITLE
Add the option of skipping manifest writes on first sync error

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -7829,6 +7829,48 @@ TEST_F(DBTest2, TableCacheMissDuringReadFromBlockCacheTier) {
   ASSERT_EQ(orig_num_file_opens, TestGetTickerCount(options, NO_FILE_OPENS));
 }
 
+// RocksdbCloud contribution start
+TEST_F(DBTest2, SkipManifestWriteOnError) {
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  options.disable_auto_compactions = true;
+  options.skip_manifest_write_on_first_manifest_write_error = true;
+  Reopen(options);
+
+  WriteOptions wo;
+  wo.disableWAL = true;
+  ASSERT_OK(Put("k1", "v1", wo));
+  ASSERT_OK(Flush());
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::ProcessManifestWrites:AfterSyncManifest", [&](void* arg) {
+        ASSERT_NE(nullptr, arg);
+        auto* s = static_cast<Status*>(arg);
+        ASSERT_OK(*s);
+        *s = Status::IOError("simulated io error");
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  ASSERT_OK(Put("k2", "v2", wo));
+  ASSERT_NOK(Flush());
+  
+  ASSERT_NOK(Put("k3", "v3", wo));
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->ClearAllCallBacks();
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  Reopen(options);
+  ASSERT_EQ("v1", Get("k1"));
+  // The version edits are appended to the manifest file, just not synced
+  ASSERT_EQ("v2", Get("k2"));
+  ASSERT_EQ("NOT_FOUND", Get("k3"));
+  ASSERT_OK(Put("k3", "v3", wo));
+  ASSERT_EQ("v3", Get("k3"));
+  ASSERT_OK(Flush());
+  ASSERT_EQ("v3", Get("k3"));
+}
+// RocksdbCloud contribution end
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -7830,11 +7830,11 @@ TEST_F(DBTest2, TableCacheMissDuringReadFromBlockCacheTier) {
 }
 
 // RocksdbCloud contribution start
-TEST_F(DBTest2, SkipManifestWriteOnError) {
+TEST_F(DBTest2, DisableRecoveryOnManifestWriteError) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
   options.disable_auto_compactions = true;
-  options.skip_manifest_write_on_first_manifest_write_error = true;
+  options.attempt_recovery_after_manifest_write_error = false;
   Reopen(options);
 
   WriteOptions wo;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5322,11 +5322,13 @@ Status VersionSet::ProcessManifestWrites(
     const ColumnFamilyOptions* new_cf_options, const ReadOptions& read_options,
     const WriteOptions& write_options) {
   mu->AssertHeld();
+  // RocksdbCloud contribution start
   if (!db_options_->attempt_recovery_after_manifest_write_error && !io_status_.ok()) {
     // If recovery from manifest write failure is disabled, all following manifest writes
     // get the same errors
     return io_status_;
   }
+  // RocksdbCloud contribution end
   assert(!writers.empty());
   ManifestWriter& first_writer = writers.front();
   ManifestWriter* last_writer = &first_writer;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -5632,6 +5632,15 @@ Status VersionSet::ProcessManifestWrites(
   Status s;
   IOStatus io_s;
   IOStatus manifest_io_status;
+  // RocksDB-Cloud contribution begin
+  if (db_options_->skip_manifest_write_on_first_manifest_write_error &&
+    !io_status_.ok()) {
+    // recovering previous io errors so that manifest writes are skipped
+    s = io_status_;
+    io_s = io_status_;
+  }
+  if (s.ok())
+  // RocksDB-Cloud contribution end
   {
     FileOptions opt_file_opts = fs_->OptimizeForManifestWrite(file_options_);
     mu->Unlock();

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1601,9 +1601,8 @@ struct DBOptions {
   // large
   uint32_t max_num_replication_epochs = 100;
 
-  // If true, further manifest writes will be skipped on the first manifest
-  // write error. Db has to be reopened to clear the error status
-  bool skip_manifest_write_on_first_manifest_write_error = false;
+  // If false, all manifest writes are failed until db is reopened
+  bool attempt_recovery_after_manifest_write_error = true;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1600,6 +1600,10 @@ struct DBOptions {
   // persisted replication sequence, so the max limit here shouldn't be quite
   // large
   uint32_t max_num_replication_epochs = 100;
+
+  // If true, further manifest writes will be skipped on the first manifest
+  // write error. Db has to be reopened to clear the error status
+  bool skip_manifest_write_on_first_manifest_write_error = false;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -775,8 +775,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       enforce_single_del_contracts(options.enforce_single_del_contracts),
       disable_delete_obsolete_files_on_open(options.disable_delete_obsolete_files_on_open),
       max_num_replication_epochs(options.max_num_replication_epochs),
-      skip_manifest_write_on_first_manifest_write_error(
-          options.skip_manifest_write_on_first_manifest_write_error) {
+      attempt_recovery_after_manifest_write_error(
+          options.attempt_recovery_after_manifest_write_error) {
   fs = env->GetFileSystem();
   clock = env->GetSystemClock().get();
   logger = info_log.get();

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -774,7 +774,9 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       compaction_service(options.compaction_service),
       enforce_single_del_contracts(options.enforce_single_del_contracts),
       disable_delete_obsolete_files_on_open(options.disable_delete_obsolete_files_on_open),
-      max_num_replication_epochs(options.max_num_replication_epochs) {
+      max_num_replication_epochs(options.max_num_replication_epochs),
+      skip_manifest_write_on_first_manifest_write_error(
+          options.skip_manifest_write_on_first_manifest_write_error) {
   fs = env->GetFileSystem();
   clock = env->GetSystemClock().get();
   logger = info_log.get();

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -110,7 +110,7 @@ struct ImmutableDBOptions {
   bool enforce_single_del_contracts;
   bool disable_delete_obsolete_files_on_open;
   uint32_t max_num_replication_epochs;
-  bool skip_manifest_write_on_first_manifest_write_error;
+  bool attempt_recovery_after_manifest_write_error;
 
   bool IsWalDirSameAsDBPath() const;
   bool IsWalDirSameAsDBPath(const std::string& path) const;

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -110,6 +110,7 @@ struct ImmutableDBOptions {
   bool enforce_single_del_contracts;
   bool disable_delete_obsolete_files_on_open;
   uint32_t max_num_replication_epochs;
+  bool skip_manifest_write_on_first_manifest_write_error;
 
   bool IsWalDirSameAsDBPath() const;
   bool IsWalDirSameAsDBPath(const std::string& path) const;


### PR DESCRIPTION
With the leader follower replication + RocksDB Cloud, once there is io_error for manifest write, we shouldn't allow writing `kManifestWrite` record to local replication log and syncing manifest file anymore. Reason is, it's possible that replication log is closed after this, which causes following manifest writes to be synced but not showing up in replication log. What's more, they might use previous manifest write's manifest update sequence since manifest update sequence is not bumped on io error.

