### PR TITLE
[MISC]Fix FileCopy  and add other options to skip versions_->LogAndApply

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1603,6 +1603,7 @@ Status ColumnFamilyData::SetOptions(
     // Disabling flush on running db is not supported due to bunch of checks we
     // added to catch unexpected flush. But it's easy to support it later if we
     // want to
+    // TODO: make it supported
     if (!mutable_cf_options_.disable_auto_flush && cf_opts.disable_auto_flush) {
       s = Status::NotSupported(
           "Disabling flush on running db is not supported");

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1795,12 +1795,14 @@ Status DBImpl::SetOptions(
     return Status::InvalidArgument("empty input");
   }
 
-  bool only_set_disable_write_stall = false;
-  if (options_map.size() == 1 &&
-      options_map.find("disable_write_stall") != options_map.end()) {
-    only_set_disable_write_stall = true;
+  bool skip_log_and_apply = true;
+  std::unordered_set<std::string> skip_log_and_apply_keys = {"disable_write_stall", "disable_auto_compactions", "disable_auto_flush"};
+  for (auto it = options_map.begin(); it != options_map.end(); it++) {
+    if (skip_log_and_apply_keys.count(it->first) == 0) {
+      skip_log_and_apply = false;
+      break;
+    }
   }
-
   InstrumentedMutexLock ol(&options_mutex_);
   MutableCFOptions new_options;
   Status s;
@@ -1812,9 +1814,9 @@ Status DBImpl::SetOptions(
     s = cfd->SetOptions(db_options, options_map);
     if (s.ok()) {
       new_options = *cfd->GetLatestMutableCFOptions();
-      // If the only thing we change is `disable_write_stall`, there is no need
+      // If the only thing we change is all in `skip_log_and_apply_keys`, there is no need
       // to append the dummy version
-      if (!only_set_disable_write_stall) {
+      if (!skip_log_and_apply) {
         // Append new version to recompute compaction score.
         VersionEdit dummy_edit;
         s = versions_->LogAndApply(cfd, new_options, read_options,

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1800,13 +1800,10 @@ Status DBImpl::SetOptions(
   std::unordered_map<std::string, std::optional<bool>> skip_log_and_apply_keys = {
       {"disable_write_stall",            std::nullopt}, // either "true" or "false" is ok
       {"disable_auto_compactions",       true},         // must be "true"
-      {"disable_auto_flush",             true},          // must be "true"
+      {"disable_auto_flush",             true},         // must be "true"
   };
 
-  for (const auto& kv : options_map) {
-      const std::string& opt_name  = kv.first;
-      const std::string& opt_value = kv.second;
-
+  for (const auto& [opt_name, opt_value] : options_map) {
       auto it = skip_log_and_apply_keys.find(opt_name);
       if (it == skip_log_and_apply_keys.end()) {
           // option not recognized

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7551,8 +7551,8 @@ TEST_F(DBTest, SetOptionsVersionInstallBehavior) {
   ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disable_write_stall";
 
   // SetOptions with disable_auto_compactions
-  ASSERT_OK(dbfull()->SetOptions({{"disable_auto_compactions", "false"}}));
-  ASSERT_EQ(dbfull()->GetOptions().disable_auto_compactions, false);
+  ASSERT_OK(dbfull()->SetOptions({{"disable_auto_compactions", "true"}}));
+  ASSERT_EQ(dbfull()->GetOptions().disable_auto_compactions, true);
   ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disable_auto_compactions";
 
   // SetOptions with disable_auto_flush
@@ -7578,6 +7578,12 @@ TEST_F(DBTest, SetOptionsVersionInstallBehavior) {
   // SetOptions with write_buffer_size (should install new SuperVersion)
   ASSERT_OK(dbfull()->SetOptions({{"write_buffer_size", "2097152"}}));
   ASSERT_EQ(log_and_apply_calls.load(), 1) << "LogAndApply should be called for write_buffer_size change";
+
+  ASSERT_OK(dbfull()->SetOptions({{"disable_write_stall", "false"}}));
+  ASSERT_EQ(log_and_apply_calls.load(), 1) << "LogAndApply should not be called for disable_write_stall change";
+
+  ASSERT_OK(dbfull()->SetOptions({{"disable_auto_compactions", "false"}}));
+  ASSERT_EQ(log_and_apply_calls.load(), 2) << "LogAndApply should be called for disable_auto_compactions change";
 
   // Clean up SyncPoint
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7531,6 +7531,59 @@ TEST_F(DBTest, ShuttingDownNotBlockStalledWrites) {
   thd.join();
 }
 
+TEST_F(DBTest, SetOptionsVersionInstallBehavior) {
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  options.env = env_;
+  options.write_buffer_size = 1024 * 1024; // 1MB
+  DestroyAndReopen(options);
+
+  // Set up SyncPoint to count LogAndApply calls
+  std::atomic<int> log_and_apply_calls(0);
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "VersionSet::LogAndApply:WriteManifestStart",
+      [&](void*) { log_and_apply_calls.fetch_add(1); });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  // SetOptions with disable_write_stall
+  ASSERT_OK(dbfull()->SetOptions({{"disable_write_stall", "true"}}));
+  ASSERT_EQ(dbfull()->GetOptions().disable_write_stall, true);
+  ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disable_write_stall";
+
+  // SetOptions with disable_auto_compactions
+  ASSERT_OK(dbfull()->SetOptions({{"disable_auto_compactions", "false"}}));
+  ASSERT_EQ(dbfull()->GetOptions().disable_auto_compactions, false);
+  ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disable_auto_compactions";
+
+  // SetOptions with disable_auto_flush
+  // Note: disabling auto flush on a running DB may not be supported, so we check for NotSupported
+  Status s = dbfull()->SetOptions({{"disable_auto_flush", "true"}});
+  if (s.IsNotSupported()) {
+    // Acceptable, skip this check
+  } else {
+    ASSERT_OK(s);
+    ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disable_auto_flush";
+  }
+
+  // SetOptions with two all together
+  // TODO: add disable_auto_flush once it's supported
+  std::unordered_map<std::string, std::string> opts = {
+      {"disable_write_stall", "true"},
+      {"disable_auto_compactions", "true"},
+  };
+  s = dbfull()->SetOptions(opts);
+  ASSERT_OK(s);
+  ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disables only";
+
+  // SetOptions with write_buffer_size (should install new SuperVersion)
+  ASSERT_OK(dbfull()->SetOptions({{"write_buffer_size", "2097152"}}));
+  ASSERT_EQ(log_and_apply_calls.load(), 1) << "LogAndApply should be called for write_buffer_size change";
+
+  // Clean up SyncPoint
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char** argv) {

--- a/file/file_util.cc
+++ b/file/file_util.cc
@@ -79,6 +79,10 @@ IOStatus CopyFile(FileSystem* fs, const std::string& source,
   IOStatus io_s;
   std::unique_ptr<WritableFileWriter> dest_writer;
 
+  if (source == destination) {
+    return IOStatus::OK();
+  }
+
   {
     options.temperature = dst_temp;
     std::unique_ptr<FSWritableFile> destfile;


### PR DESCRIPTION
Changes:
1) Current FileCopy will truncate the source file to zero bytes if source and target is same. The new behavior is it will do nothing when source and target is same. 
2) Skip the versions_->LogAndApply for extra two options: disable_auto_compactions, disable_auto_flush. These two options do not change the LSM state, so it's safe to do that. 