### PR TITLE
SetOptions: support enable/disable disable_auto_flush on running db

### DIFF
--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -3446,7 +3446,11 @@ TEST_F(DBFlushTest, DisableAutoFlushMultiCF) {
 }
 
 TEST_F(DBFlushTest, DisableAutoFlushOnRunningDB) {
-  EXPECT_NOK(db_->SetOptions({{"disable_auto_flush", "true"}}));
+  EXPECT_OK(db_->SetOptions({{"disable_auto_flush", "true"}}));
+  EXPECT_TRUE(db_->GetOptions().disable_auto_flush);
+
+  EXPECT_OK(db_->SetOptions({{"disable_auto_flush", "false"}}));
+  EXPECT_FALSE(db_->GetOptions().disable_auto_flush);
 }
 
 // Test the case that non-trival compaction job is triggered before
@@ -3516,11 +3520,8 @@ TEST_F(DBFlushTest, AutoCompactionBeforeEnablingFlush) {
   // old super version of compaction job installed, which has
   // `disable_auto_flush = true!`
   EXPECT_TRUE(cfd->GetSuperVersion()->mutable_cf_options.disable_auto_flush);
-  // But auto flush of memtable won't be disabled. So we have a short period
-  // of time that current superversion's `mutable_cf_option` to be not consistent
-  // with memtable's auto_flush setting, which is fine since next time we call
-  // `InstallSuperVersion` will fix this
-  EXPECT_TRUE(cfd->GetSuperVersion()->mem->TEST_IsAutoFlushEnabled());
+  // Auto flush of memtable is disabled
+  EXPECT_FALSE(cfd->GetSuperVersion()->mem->TEST_IsAutoFlushEnabled());
 
   // trigger a manual flush to install a new super version
   // the new superversion will use the latest `mutable_cf_options` of the

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -537,6 +537,12 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
 
     all_mutable_cf_options.emplace_back(*cfd->GetLatestMutableCFOptions());
     const MutableCFOptions& mutable_cf_options = all_mutable_cf_options.back();
+    if (mutable_cf_options.disable_auto_flush) {
+      ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "Skipping flush for column family [%s] because auto flush is disabled.",
+                     cfd->GetName().c_str());
+      continue;
+    }
     uint64_t max_memtable_id = bg_flush_args[i].max_memtable_id_;
     FlushReason flush_reason = bg_flush_args[i].flush_reason_;
     jobs.emplace_back(new FlushJob(

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -7558,18 +7558,14 @@ TEST_F(DBTest, SetOptionsVersionInstallBehavior) {
   // SetOptions with disable_auto_flush
   // Note: disabling auto flush on a running DB may not be supported, so we check for NotSupported
   Status s = dbfull()->SetOptions({{"disable_auto_flush", "true"}});
-  if (s.IsNotSupported()) {
-    // Acceptable, skip this check
-  } else {
-    ASSERT_OK(s);
-    ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disable_auto_flush";
-  }
+  ASSERT_OK(s);
+  ASSERT_EQ(log_and_apply_calls.load(), 0) << "LogAndApply should not be called for disable_auto_flush";
 
   // SetOptions with two all together
-  // TODO: add disable_auto_flush once it's supported
   std::unordered_map<std::string, std::string> opts = {
       {"disable_write_stall", "true"},
       {"disable_auto_compactions", "true"},
+      {"disable_auto_flush", "true"},
   };
   s = dbfull()->SetOptions(opts);
   ASSERT_OK(s);
@@ -7584,6 +7580,9 @@ TEST_F(DBTest, SetOptionsVersionInstallBehavior) {
 
   ASSERT_OK(dbfull()->SetOptions({{"disable_auto_compactions", "false"}}));
   ASSERT_EQ(log_and_apply_calls.load(), 2) << "LogAndApply should be called for disable_auto_compactions change";
+
+  ASSERT_OK(dbfull()->SetOptions({{"disable_auto_flush", "false"}}));
+  ASSERT_EQ(log_and_apply_calls.load(), 3) << "LogAndApply should be called for disable_auto_flush change";
 
   // Clean up SyncPoint
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -256,6 +256,15 @@ void MemTable::EnableAutoFlush() {
   }
 }
 
+void MemTable::DisableAutoFlush() {
+  bool flush_previously_enabled =
+      !disable_auto_flush_.exchange(true, std::memory_order_relaxed);
+  if (!flush_previously_enabled) {
+    ROCKS_LOG_WARN(moptions_.info_log,
+                   "DisableFlush called when flush is already disabled");
+  }
+}
+
 bool MemTable::TEST_IsAutoFlushEnabled() const {
   return !disable_auto_flush_.load(std::memory_order_relaxed);
 }

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -543,6 +543,8 @@ class MemTable {
 
   // Enable auto flush if it's previously disabled
   void EnableAutoFlush();
+  // Disable auto flush if it's previously enabled
+  void DisableAutoFlush();
   bool TEST_IsAutoFlushEnabled() const;
   void ConstructFragmentedRangeTombstones();
 


### PR DESCRIPTION
Once enable disable_auto_flush, all existing flush job will not be impacted---caller needs to cancel running flush job. But no new flush job will be created. Active memory table's disable_auto_flush_ is also updated as part of SetOptions