### PR TITLE
Fix option attempt_recovery_after_manifest_write_error

### DIFF
--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -571,6 +571,16 @@ static std::unordered_map<std::string, OptionTypeInfo>
                    disable_delete_obsolete_files_on_open),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"max_num_replication_epochs",
+         {offsetof(struct ImmutableDBOptions,
+                   attempt_recovery_after_manifest_write_error),
+          OptionType::kInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
+        {"attempt_recovery_after_manifest_write_error",
+         {offsetof(struct ImmutableDBOptions,
+                   attempt_recovery_after_manifest_write_error),
+          OptionType::kBoolean, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
 };
 
 const std::string OptionsHelper::kDBOptionsName = "DBOptions";
@@ -957,6 +967,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    disable_delete_obsolete_files_on_open ? "true" : "false");
   ROCKS_LOG_HEADER(log, "              Options.max_num_replication_epochs: %d",
                    max_num_replication_epochs);
+  ROCKS_LOG_HEADER(log, "              Options.attempt_recovery_after_manifest_write_error: %d",
+                   attempt_recovery_after_manifest_write_error);
 }
 
 bool ImmutableDBOptions::IsWalDirSameAsDBPath() const {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -184,6 +184,8 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.disable_delete_obsolete_files_on_open =
       immutable_db_options.disable_delete_obsolete_files_on_open;
   options.daily_offpeak_time_utc = mutable_db_options.daily_offpeak_time_utc;
+  options.max_num_replication_epochs = immutable_db_options.max_num_replication_epochs;
+  options.attempt_recovery_after_manifest_write_error = immutable_db_options.attempt_recovery_after_manifest_write_error;
   return options;
 }
 


### PR DESCRIPTION
Main fix here is to be able to build DBOptions from immutable db options for `attempt_recovery_after_manifest_write_error` and `max_num_replication_epochs`. We call function: `rocksdb::GetOptionsFromString` in rockset. So if the option is set before we call that function, the option could be reverted to default if we don't support building DBOptions from immutable db options here.

## TEST
- [x] Tested and verified in rockset codebase.