### PR TITLE
Only prefetch footer on db open

### DIFF
--- a/table/block_based/block_based_table_reader.h
+++ b/table/block_based/block_based_table_reader.h
@@ -502,6 +502,16 @@ class BlockBasedTable : public TableReader {
       const int level, size_t file_size, size_t max_file_size_for_l0_meta_pin,
       BlockCacheLookupContext* lookup_context);
 
+  struct IndexFilterPinningInfo {
+    bool pin_top_level_index; // top-level index block
+    bool pin_top_level_filter; // top-level filter block
+    bool pin_partition; // applies to both index and filter partitions
+    bool pin_unpartitioned; // applies to both index and filter blocks
+  };
+  static IndexFilterPinningInfo ShouldPinIndexFilterBlocks(
+      const BlockBasedTableOptions& table_options, const Rep* rep,
+      const int level, size_t file_size, size_t max_file_size_for_l0_meta_pin);
+
   static BlockType GetBlockTypeForMetaBlockByName(const Slice& meta_block_name);
 
   Status VerifyChecksumInMetaBlocks(const ReadOptions& read_options,


### PR DESCRIPTION
## Summary

Rocksdb fetches full tail of the SST file on `BlockBasedTable::Open()` regardless of whether or not it actually needs to read the index and filter blocks. Normally this is fine, as these blocks are expected to be < 5MB [[link]](https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters#how-large-are-the-indexfilter-blocks) -- but we have workloads where the filter blocks are very large. In this case it doesn't make sense to prefetch the full tail if we don't need to read the index/filter blocks at all.

This PR refactors some code to extract pinning info in a separate struct. We only read the index/filter blocks if `prefetch_all || preload_all || pining_enabled`; so this PR now does prefetch in two phases:
1. Only prefetch ~4KB (footer + properties)
2. Use the above to decide if pinning is enabled. If yes, do a full prefetch of the tail.

This does mean that if pinning is enabled we pay the price of prefetching twice. This can be optimized if needed, but the first prefetch is tiny and fixing would need a somewhat larger refactor, so I've not done that in this PR.

## Test Plan

Rocksdb tests.