### PR TITLE
[rocskdb-cloud] EncryptedFS should use correct base FS 

### DIFF
--- a/env/env_encryption.cc
+++ b/env/env_encryption.cc
@@ -799,7 +799,12 @@ std::shared_ptr<FileSystem> NewEncryptedFS(
   std::unique_ptr<FileSystem> efs;
   Status s = NewEncryptedFileSystemImpl(base, provider, &efs);
   if (s.ok()) {
-    s = efs->PrepareOptions(ConfigOptions());
+    // We must call PrepareOptions() with the Env pointing to
+    // the correct base FileSystem.
+    auto env = CompositeEnvWrapper(Env::Default(), base);
+    ConfigOptions opt;
+    opt.env = &env;
+    s = efs->PrepareOptions(opt);
   }
   if (s.ok()) {
     std::shared_ptr<FileSystem> result(efs.release());


### PR DESCRIPTION
## Summary

Rocksdb uses `FileSystemWrapper` class to create an `EncryptedFileSystem` -- this basically creates a shim over the base file-system with the de/encryption logic being executed in the shim layer.

This PR fixes (what I think is) a bug in the implementation where RocksDb uses uses a default env when calling `efs->PrepareOptions()`. This is all fine when the base FS is a Default PosixFS -- but fails catastrophically when the base FS is something else.

## Test

Added new unit test; fails before my change; passes after.