### PR TITLE
Change tail prefetch size log to DEBUG

### DIFF
--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -903,7 +903,7 @@ Status BlockBasedTable::PrefetchTail(
                      "Tail prefetch size %zu is calculated based on heuristics",
                      tail_prefetch_size);
     } else {
-      ROCKS_LOG_WARN(
+      ROCKS_LOG_DEBUG(
           logger,
           "Tail prefetch size %zu is calculated based on TailPrefetchStats",
           tail_prefetch_size);


### PR DESCRIPTION
This is reasonable behavior for RocksDb eg. when you have large footers. Let's change log level to DEBUG to avoid log spam.

