### PR TITLE
[diagnostics] add log for dropping memtable at follower

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1608,7 +1608,8 @@ Status DBImpl::ApplyReplicationLogRecord(ReplicationLogRecord record,
             continue;
           }
           cfd->imm()->RemoveOldMemTables(cfd->GetLogNumber(),
-                                         &job_context.memtables_to_free);
+                                         &job_context.memtables_to_free,
+                                         immutable_db_options_.info_log.get());
           auto& sv_context = job_context.superversion_contexts.back();
           if (!sv_context.new_superversion) {
             sv_context.NewSuperVersion();

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -711,7 +711,8 @@ Status DBImplSecondary::TryCatchUpWithPrimary() {
     if (s.ok()) {
       for (auto cfd : cfds_changed) {
         cfd->imm()->RemoveOldMemTables(cfd->GetLogNumber(),
-                                       &job_context.memtables_to_free);
+                                       &job_context.memtables_to_free,
+                                       immutable_db_options_.info_log.get());
         auto& sv_context = job_context.superversion_contexts.back();
         cfd->InstallSuperVersion(&sv_context, &mutex_);
         sv_context.NewSuperVersion();

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -445,7 +445,8 @@ class MemTableList {
   // was created, i.e. mem->GetNextLogNumber() <= log_number. The memtables are
   // not freed, but put into a vector for future deref and reclamation.
   void RemoveOldMemTables(uint64_t log_number,
-                          autovector<MemTable*>* to_delete);
+                          autovector<MemTable*>* to_delete,
+                          Logger* info_log);
 
   // @return vector of <memtable id, next_log_num, replication_sequence> in
   // unflushed memtables


### PR DESCRIPTION
Summary:
Add memtable dropping logs in RemoveOldMemTables. This is to provide evidence that memtable is released in follower properly. 